### PR TITLE
completed re-factor of holon_reference constructors

### DIFF
--- a/crates/coordinator/holons/src/helpers.rs
+++ b/crates/coordinator/holons/src/helpers.rs
@@ -26,22 +26,10 @@ pub fn get_holon_node_from_record(
 /// It assumes the holon is Local
 pub fn define_local_target(holon:&Holon) -> RelationshipTarget {
     // Define a RelationshipTarget for the provided Holon
-    let mut local_reference = LocalHolonReference::new();
-    local_reference.with_holon(holon.clone());
+    let local_reference = LocalHolonReference::from_holon(holon.clone());
     let reference : HolonReference = Local(local_reference);
-
     let target = RelationshipTarget::One(reference);
     target
 }
-// pub fn get_holon_from_target(target: &RelationshipTarget)-> Option<Holon> {
-//     match target {
-//         ZeroOrOne(option_holon_reference)=> {
-//             if let Some(holon_reference) = option_holon_reference {
-//
-//             }
-//         },
-//         One(holon_reference),
-//     }
-//
-// }
+
 

--- a/crates/coordinator/holons/src/holon.rs
+++ b/crates/coordinator/holons/src/holon.rs
@@ -9,6 +9,7 @@ use hdi::prelude::ActionHash;
 use hdk::entry::get;
 use hdk::prelude::*;
 use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
+use shared_types_holon::HolonId;
 use shared_types_holon::value_types::BaseValue;
 
 impl Holon {
@@ -146,8 +147,8 @@ impl Holon {
     /// it then "inflates" the HolonNode into a Holon and returns it
     /// Not currently extern... because fetches will be mediated by the cache
 
-    pub fn fetch_holon(id: ActionHash) -> Result<Holon, HolonError> {
-        let holon_node_record = get(id.clone(), GetOptions::default())?;
+    pub fn fetch_holon(id: HolonId) -> Result<Holon, HolonError> {
+        let holon_node_record = get(id.0.clone(), GetOptions::default())?;
         return if let Some(node) = holon_node_record {
             let mut holon = Holon::try_from_node(node)?;
             holon.state = HolonState::Fetched;
@@ -155,12 +156,12 @@ impl Holon {
             Ok(holon)
         } else {
             // no holon_node fetched for specified holon_id
-            Err(HolonError::HolonNotFound(id.to_string()))
+            Err(HolonError::HolonNotFound(id.0.to_string()))
         };
     }
 
-    pub fn delete_holon(id: ActionHash) -> Result<ActionHash, HolonError> {
-        let result = delete_holon_node(id);
+    pub fn delete_holon(id: HolonId) -> Result<ActionHash, HolonError> {
+        let result = delete_holon_node(id.0);
         match result {
             Ok(result) => Ok(result),
             Err(error) => Err(HolonError::WasmError(error.to_string())),

--- a/crates/coordinator/holons/src/holon_api.rs
+++ b/crates/coordinator/holons/src/holon_api.rs
@@ -40,7 +40,7 @@ pub fn commit(input: Holon) -> ExternResult<Holon> {
 pub fn get_holon(
     target_holon_id: ActionHash,
 ) -> ExternResult<Option<Holon>> {
-    match Holon::fetch_holon(target_holon_id) {
+    match Holon::fetch_holon(target_holon_id.into()) {
         Ok(result)=> Ok(Option::from(result)),
         Err(holon_error) => {
             Err(holon_error.into())

--- a/crates/coordinator/holons/src/holon_reference.rs
+++ b/crates/coordinator/holons/src/holon_reference.rs
@@ -1,6 +1,7 @@
 use crate::holon_errors::HolonError;
 use crate::holon_types::Holon;
 use hdk::prelude::*;
+use shared_types_holon::HolonId;
 
 pub trait HolonReferenceFns {
     fn get_holon(&self) -> Result<Holon, HolonError>;
@@ -22,7 +23,7 @@ impl HolonReferenceFns for HolonReference {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct LocalHolonReference {
-    holon_id: Option<ActionHash>,
+    holon_id: Option<HolonId>,
     holon: Option<Holon>,
 }
 
@@ -45,13 +46,27 @@ impl HolonReferenceFns for LocalHolonReference {
 }
 
 impl LocalHolonReference {
-    pub fn new() -> LocalHolonReference {
-        LocalHolonReference {
-            holon_id: None,
+
+    // Constructor function for creating from HolonId
+    pub fn from_holon_id(holon_id: HolonId) -> Self {
+        Self {
+            holon_id: Some(holon_id),
             holon: None,
         }
     }
-    pub fn with_holon(&mut self, holon: Holon) -> &mut Self {
+
+    // Constructor function for creating from Holon
+    pub fn from_holon(holon: Holon) -> Self {
+        Self {
+            holon_id: None,
+            holon: Some(holon),
+        }
+    }
+    pub fn add_holon_id(&mut self, holon_id: HolonId)-> &mut Self {
+        self.holon_id = Some(holon_id);
+        self
+    }
+    pub fn add_holon(&mut self, holon: Holon) -> &mut Self {
         self.holon = Some(holon);
         self
     }

--- a/crates/coordinator/holons/src/holon_types.rs
+++ b/crates/coordinator/holons/src/holon_types.rs
@@ -2,7 +2,7 @@ use crate::relationship::RelationshipMap;
 use derive_new::new;
 use hdk::prelude::*;
 use shared_types_holon::value_types::BaseValue;
-use shared_types_holon::{PropertyMap, PropertyName};
+use shared_types_holon::{HolonId, PropertyMap, PropertyName};
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -44,17 +44,3 @@ impl fmt::Display for HolonState {
     }
 }
 
-// #[hdk_entry_helper]
-// #[derive(Clone, PartialEq, Eq)]
-// pub struct LocalHolonReference {
-//     pub holon_id: HolonId,
-//     pub holon: Option<Holon>,
-// }
-//
-// #[hdk_entry_helper]
-// #[derive(Clone, PartialEq, Eq)]
-// pub enum HolonReference {
-//     Local(LocalHolonReference),
-//     //External(ExternalHolonReference),
-// }
-//

--- a/crates/coordinator/holons/tests/shared_test/descriptors/schema_helpers.rs
+++ b/crates/coordinator/holons/tests/shared_test/descriptors/schema_helpers.rs
@@ -4,10 +4,9 @@ use holons::holon_types::Holon;
 use holons::relationship::RelationshipTarget;
 /// This helper function returns a RelationshipTarget for the specified holon
 /// It assumes the holon is Local
-fn get_local_target(holon:&Holon) ->RelationshipTarget {
+fn get_local_target(holon:Holon) ->RelationshipTarget {
     // Define a RelationshipTarget for the provided Holon
-    let mut local_reference = LocalHolonReference::new();
-    local_reference.with_holon(holon.clone());
+    let mut local_reference = LocalHolonReference::from_holon(holon);
     let reference : HolonReference = Local(local_reference);
 
     let target = RelationshipTarget::One(reference);

--- a/crates/shared_types/holon/src/holon_node.rs
+++ b/crates/shared_types/holon/src/holon_node.rs
@@ -10,9 +10,14 @@ pub struct HolonNode {
 }
 
 pub type PropertyMap = BTreeMap<PropertyName, BaseValue>;
-
+#[hdk_entry_helper]
 #[derive(Clone, PartialEq, Eq)]
 pub struct HolonId(pub ActionHash);
+impl From<ActionHash> for HolonId {
+    fn from(action_hash: ActionHash) -> Self {
+        HolonId(action_hash)
+    }
+}
 
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd)]

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,7 +36,7 @@
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^4.5.5",
-    "vite": "^4.0.0",
+    "vite": "^5.0.11",
     "vite-plugin-checker": "^0.1.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
added usage of HolonId in place of ActionHash. I discovered that although we had defined HolonId using the newtype pattern to wrap ActionHash, there were places where we were explicitly using ActionHash where we should have been using HolonId. So I fixed those as well.