### PR TITLE
76 add match db content dance test step

### DIFF
--- a/crates/coordinator/dances/src/dance_request.rs
+++ b/crates/coordinator/dances/src/dance_request.rs
@@ -1,9 +1,8 @@
+use crate::staging_area::StagingArea;
 use hdk::prelude::*;
 use holons::commit_manager::StagedIndex;
 use holons::holon::Holon;
 use shared_types_holon::{HolonId, MapString, PropertyMap};
-use crate::staging_area::StagingArea;
-
 
 #[hdk_entry_helper]
 #[derive(Clone, Eq, PartialEq)]
@@ -13,13 +12,12 @@ pub struct DanceRequest {
     pub body: RequestBody,
     pub staging_area: StagingArea,
     //pub descriptor: Option<HolonReference>, // space_id+holon_id of DanceDescriptor
-
 }
 
 #[hdk_entry_helper]
 #[derive(Clone, Eq, PartialEq)]
 pub enum DanceType {
-    Standalone, // i.e., a dance not associated with a specific holon
+    Standalone,           // i.e., a dance not associated with a specific holon
     QueryMethod(HolonId), // a read-only dance originated from a specific, already persisted, holon
     Command(StagedIndex), // a mutating method operating on a specific staged_holon identified by its index into the staged_holons vector
 }
@@ -28,6 +26,7 @@ pub enum DanceType {
 pub enum RequestBody {
     None,
     Holon(Holon),
+    HolonId(HolonId),
     ParameterValues(PropertyMap),
     Index(StagedIndex),
 }
@@ -51,7 +50,12 @@ impl RequestBody {
 }
 
 impl DanceRequest {
-    pub fn new(dance_name:MapString, dance_type:DanceType, body:RequestBody, staging_area: StagingArea)->Self {
+    pub fn new(
+        dance_name: MapString,
+        dance_type: DanceType,
+        body: RequestBody,
+        staging_area: StagingArea,
+    ) -> Self {
         Self {
             dance_name,
             dance_type,
@@ -60,9 +64,3 @@ impl DanceRequest {
         }
     }
 }
-
-
-
-
-
-

--- a/crates/coordinator/dances/src/dance_response.rs
+++ b/crates/coordinator/dances/src/dance_response.rs
@@ -1,13 +1,13 @@
-use std::fmt;
 use derive_new::new;
+use std::fmt;
 
 use crate::staging_area::StagingArea;
 use hdk::prelude::*;
 use holons::commit_manager::StagedIndex;
-use holons::holon::{Holon};
+use holons::holon::Holon;
 use holons::holon_error::HolonError;
 use holons::holon_reference::HolonReference;
-use shared_types_holon::{MapString};
+use shared_types_holon::MapString;
 
 #[hdk_entry_helper]
 #[derive(Clone, Eq, PartialEq)]
@@ -42,7 +42,7 @@ pub enum ResponseStatusCode {
 #[derive(Clone, Eq, PartialEq)]
 pub enum ResponseBody {
     None,
-    //Holon(Holon),
+    Holon(Holon),
     Holons(Vec<Holon>), // will be replaced by SmartCollection once supported
     // SmartCollection(SmartCollection),
     Index(StagedIndex),
@@ -73,21 +73,16 @@ impl fmt::Display for ResponseStatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ResponseStatusCode::OK => write!(f, "200 -- OK"),
-            ResponseStatusCode::Accepted => write!(f, "202 -- Accepted"),           // 202
-            ResponseStatusCode::BadRequest => write!(f, "400 -- Bad Request"),         // 400,
-            ResponseStatusCode::Unauthorized => write!(f, "401 -- Unauthorized"),       // 401
-            ResponseStatusCode::NotFound => write!(f, "404 -- Not Found"),           // 404
-            ResponseStatusCode::ServerError => write!(f, "500 -- ServerError"),        // 500
-            ResponseStatusCode::NotImplemented => write!(f, "501 -- Not Implemented"),     // 501
+            ResponseStatusCode::Accepted => write!(f, "202 -- Accepted"), // 202
+            ResponseStatusCode::BadRequest => write!(f, "400 -- Bad Request"), // 400,
+            ResponseStatusCode::Unauthorized => write!(f, "401 -- Unauthorized"), // 401
+            ResponseStatusCode::NotFound => write!(f, "404 -- Not Found"), // 404
+            ResponseStatusCode::ServerError => write!(f, "500 -- ServerError"), // 500
+            ResponseStatusCode::NotImplemented => write!(f, "501 -- Not Implemented"), // 501
             ResponseStatusCode::ServiceUnavailable => write!(f, "503 -- Service Unavailable"), // 503
-
         }
     }
 }
-
-
-
-
 
 impl DanceResponse {
     pub fn new(

--- a/crates/coordinator/dances/src/dancer.rs
+++ b/crates/coordinator/dances/src/dancer.rs
@@ -10,7 +10,10 @@ use holons::holon_error::HolonError;
 use shared_types_holon::MapString;
 
 use crate::dance_response::{DanceResponse, ResponseBody, ResponseStatusCode};
-use crate::holon_dance_adapter::{commit_dance, get_all_holons_dance, stage_new_holon_dance, with_properties_dance};
+use crate::holon_dance_adapter::{
+    commit_dance, get_all_holons_dance, get_holon_by_id_dance, stage_new_holon_dance,
+    with_properties_dance,
+};
 use crate::staging_area::StagingArea;
 
 /// The Dancer handles dance() requests on the uniform API and dispatches the Rust function
@@ -39,7 +42,7 @@ pub fn dance(request: DanceRequest) -> ExternResult<DanceResponse> {
 
     // Initialize the context, mapping the StagingArea (if there is one) into a CommitManager
 
-   // let mut commit_manager = CommitManager::new();
+    // let mut commit_manager = CommitManager::new();
 
     let commit_manager = request.clone().staging_area.to_commit_manager();
     // assert_eq!(request.staging_area.staged_holons.len(),commit_manager.staged_holons.len());
@@ -51,9 +54,12 @@ pub fn dance(request: DanceRequest) -> ExternResult<DanceResponse> {
     // TODO: If the request is a Command, add the request to the undo_list
 
     // Dispatch the dance and map result to DanceResponse
-    if !dancer.dance_name_is_dispatchable(request.clone()) {
-        return Err(HolonError::NotImplemented("No function to dispatch in dispatch table".to_string()).into())
-    }
+    // if !dancer.dance_name_is_dispatchable(request.clone()) {
+    //     return Err(HolonError::NotImplemented(
+    //         "No function to dispatch in dispatch table".to_string(),
+    //     )
+    //     .into());
+    // }
     let dispatch_result = dancer.dispatch(&context, request);
 
     let mut result = process_dispatch_result(dispatch_result);
@@ -88,6 +94,7 @@ impl Dancer {
 
         // Register functions into the dispatch table
         dispatch_table.insert("get_all_holons", get_all_holons_dance as DanceFunction);
+        dispatch_table.insert("get_holon_by_id", get_holon_by_id_dance as DanceFunction);
         dispatch_table.insert("stage_new_holon", stage_new_holon_dance as DanceFunction);
         dispatch_table.insert("commit", commit_dance as DanceFunction);
         dispatch_table.insert("with_properties", with_properties_dance as DanceFunction);
@@ -103,11 +110,9 @@ impl Dancer {
     //     self.dispatch_table.insert(name.clone().as_str(), func);
     // }
 
-    fn dance_name_is_dispatchable(
-        &self,
-        request: DanceRequest,
-    ) -> bool {
-        self.dispatch_table.contains_key(request.dance_name.0.as_str())
+    fn dance_name_is_dispatchable(&self, request: DanceRequest) -> bool {
+        self.dispatch_table
+            .contains_key(request.dance_name.0.as_str())
     }
     // Function to dispatch a request based on the function name
     fn dispatch(
@@ -145,7 +150,7 @@ fn process_dispatch_result(dispatch_result: Result<ResponseBody, HolonError>) ->
                 status_code: ResponseStatusCode::OK,
                 description: MapString("Success".to_string()),
                 body: body,
-                descriptor: None,   // Provide appropriate value if needed
+                descriptor: None, // Provide appropriate value if needed
                 staging_area: StagingArea::new(), // Provide appropriate value if needed
             }
         }
@@ -173,8 +178,8 @@ fn process_dispatch_result(dispatch_result: Result<ResponseBody, HolonError>) ->
             DanceResponse {
                 status_code: ResponseStatusCode::from(error), // Convert HolonError to ResponseStatusCode
                 description: MapString(error_message),
-                body: ResponseBody::None,         // No body since it's an error
-                descriptor: None,   // Provide appropriate value if needed
+                body: ResponseBody::None, // No body since it's an error
+                descriptor: None,         // Provide appropriate value if needed
                 staging_area: StagingArea::new(), // Provide appropriate value if needed
             }
         }

--- a/crates/coordinator/dances/src/holon_dance_adapter.rs
+++ b/crates/coordinator/dances/src/holon_dance_adapter.rs
@@ -13,7 +13,6 @@
 /// 2.  Invoking the native function
 /// 3.  Creating a DanceResponse based on the results returned by the native function. This includes,
 /// mapping any errors into an appropriate ResponseStatus and returning results in the body.
-
 use hdk::prelude::*;
 
 use holons::commit_manager::CommitRequestStatus::*;
@@ -21,6 +20,7 @@ use holons::commit_manager::StagedIndex;
 use holons::context::HolonsContext;
 use holons::holon::Holon;
 use holons::holon_error::HolonError;
+use shared_types_holon::HolonId;
 use shared_types_holon::{MapInteger, MapString, PropertyMap};
 
 use crate::dance_request::{DanceRequest, DanceType, RequestBody};
@@ -38,8 +38,10 @@ use crate::staging_area::StagingArea;
 /// *ResponseBody:*
 /// - an Index into staged_holons that references the newly staged holon.
 ///
-pub fn stage_new_holon_dance(context: &HolonsContext, request: DanceRequest)
-    -> Result<ResponseBody, HolonError> {
+pub fn stage_new_holon_dance(
+    context: &HolonsContext,
+    request: DanceRequest,
+) -> Result<ResponseBody, HolonError> {
     // Create and stage new Holon
     let mut new_holon = Holon::new();
 
@@ -58,23 +60,38 @@ pub fn stage_new_holon_dance(context: &HolonsContext, request: DanceRequest)
     }
 
     // Stage the new holon
-    let staged_reference = context.commit_manager.borrow_mut().stage_new_holon(new_holon);
+    let staged_reference = context
+        .commit_manager
+        .borrow_mut()
+        .stage_new_holon(new_holon);
     // This operation will have added the staged_holon to the CommitManager's vector and returned a
     // StagedReference to it.
 
     // Convert the holon_index in the StagedReference into a MapInteger
     // and then return it in the response body
-    let index = MapInteger(staged_reference.holon_index.try_into().expect("Conversion failed"));
+    let index = MapInteger(
+        staged_reference
+            .holon_index
+            .try_into()
+            .expect("Conversion failed"),
+    );
     Ok(ResponseBody::Index(index))
 }
 
-///
 /// Builds a DanceRequest for staging a new holon. Properties, if supplied, they will be included
 /// in the body of the request.
-pub fn build_stage_new_holon_dance_request(staging_area: StagingArea, properties:PropertyMap)->Result<DanceRequest, HolonError> {
+pub fn build_stage_new_holon_dance_request(
+    staging_area: StagingArea,
+    properties: PropertyMap,
+) -> Result<DanceRequest, HolonError> {
     let body = RequestBody::new_parameter_values(properties);
-    Ok(DanceRequest::new(MapString("stage_new_holon".to_string()), DanceType::Standalone,body, staging_area))
-    }
+    Ok(DanceRequest::new(
+        MapString("stage_new_holon".to_string()),
+        DanceType::Standalone,
+        body,
+        staging_area,
+    ))
+}
 
 /// Add property values to an already staged holon
 ///
@@ -87,7 +104,10 @@ pub fn build_stage_new_holon_dance_request(staging_area: StagingArea, properties
 /// *ResponseBody:*
 /// - an Index into staged_holons that references the updated holon.
 ///
-pub fn with_properties_dance(context: &HolonsContext, request: DanceRequest) -> Result<ResponseBody, HolonError> {
+pub fn with_properties_dance(
+    context: &HolonsContext,
+    request: DanceRequest,
+) -> Result<ResponseBody, HolonError> {
     // Get the staged holon
     match request.dance_type {
         DanceType::Command(staged_index) => {
@@ -102,32 +122,44 @@ pub fn with_properties_dance(context: &HolonsContext, request: DanceRequest) -> 
                         RequestBody::None => {
                             // No parameters to populate, continue
                             Ok(ResponseBody::Index(staged_index))
-                        },
+                        }
                         RequestBody::ParameterValues(parameters) => {
                             // Populate parameters into the new Holon
                             for (property_name, base_value) in parameters {
-                                holon_mut.with_property_value(property_name.clone(), base_value.clone());
+                                holon_mut
+                                    .with_property_value(property_name.clone(), base_value.clone());
                             }
                             Ok(ResponseBody::Index(staged_index))
-                        },
+                        }
                         _ => Err(HolonError::InvalidParameter("request.body".to_string())),
                     }
-                },
-                Err(_) => Err(HolonError::IndexOutOfRange("Unable to borrow a mutable reference to holon at supplied staged_index".to_string()))
+                }
+                Err(_) => Err(HolonError::IndexOutOfRange(
+                    "Unable to borrow a mutable reference to holon at supplied staged_index"
+                        .to_string(),
+                )),
             }
-        },
-        _ => Err(HolonError::InvalidParameter("Expected Command(StagedIndex) DanceType, didn't get one".to_string()))
+        }
+        _ => Err(HolonError::InvalidParameter(
+            "Expected Command(StagedIndex) DanceType, didn't get one".to_string(),
+        )),
     }
 }
 
-
-///
 /// Builds a DanceRequest for adding a new property value(s) to an already staged holon.
-pub fn build_with_properties_dance_request(staging_area: StagingArea, index: StagedIndex, properties: PropertyMap) ->Result<DanceRequest, HolonError> {
+pub fn build_with_properties_dance_request(
+    staging_area: StagingArea,
+    index: StagedIndex,
+    properties: PropertyMap,
+) -> Result<DanceRequest, HolonError> {
     let body = RequestBody::new_parameter_values(properties);
-    Ok(DanceRequest::new(MapString("with_properties".to_string()), DanceType::Command(index), body, staging_area))
+    Ok(DanceRequest::new(
+        MapString("with_properties".to_string()),
+        DanceType::Command(index),
+        body,
+        staging_area,
+    ))
 }
-
 
 /// Get all holons from the persistent store
 ///
@@ -139,26 +171,77 @@ pub fn build_with_properties_dance_request(staging_area: StagingArea, index: Sta
 /// *ResponseBody:*
 /// - Holons -- will be replaced by SmartCollection once supported
 ///
-pub fn get_all_holons_dance(_context: &HolonsContext, _request: DanceRequest) -> Result<ResponseBody, HolonError> {
+pub fn get_all_holons_dance(
+    _context: &HolonsContext,
+    _request: DanceRequest,
+) -> Result<ResponseBody, HolonError> {
     // TODO: add support for descriptor parameter
     //
     //
-    let query_result =  Holon::get_all_holons();
+    let query_result = Holon::get_all_holons();
     match query_result {
-        Ok(holons) => Ok(
-            ResponseBody::Holons(holons)
-        ),
-        Err(holon_error) => {
-            Err(holon_error.into())
-        }
+        Ok(holons) => Ok(ResponseBody::Holons(holons)),
+        Err(holon_error) => Err(holon_error.into()),
     }
-
-
 }
-// Builds a DanceRequest for retrieving all holons from the persistent store
-pub fn build_get_all_holons_dance_request(staging_area: StagingArea)->Result<DanceRequest, HolonError> {
+
+/// Builds a DanceRequest for retrieving all holons from the persistent store
+pub fn build_get_all_holons_dance_request(
+    staging_area: StagingArea,
+) -> Result<DanceRequest, HolonError> {
     let body = RequestBody::new();
-    Ok(DanceRequest::new(MapString("get_all_holons".to_string()), DanceType::Standalone, body, staging_area))
+    Ok(DanceRequest::new(
+        MapString("get_all_holons".to_string()),
+        DanceType::Standalone,
+        body,
+        staging_area,
+    ))
+}
+
+/// Gets Holon from persistent store, located by HolonId (ActionHash)
+///
+/// *DanceRequest:*
+/// - dance_name: "get_holon_by_id"
+/// - dance_type: Standalone
+/// - request_body:
+///     - HolonId(HolonId)
+///
+/// *ResponseBody:*
+///     - Holon(Holon)
+///
+pub fn get_holon_by_id_dance(
+    _context: &HolonsContext,
+    request: DanceRequest,
+) -> Result<ResponseBody, HolonError> {
+    let holon_id = match request.body {
+        RequestBody::HolonId(id) => id,
+        _ => {
+            return Err(HolonError::InvalidParameter(
+                "RequestBody variant must be HolonId".to_string(),
+            ))
+        }
+    };
+    let query = Holon::get_holon(holon_id)?;
+    if let Some(holon) = query {
+        Ok(ResponseBody::Holon(holon))
+    } else {
+        Err(HolonError::HolonNotFound(
+            "get_holon returned None for given HolonId".to_string(),
+        ))
+    }
+}
+
+/// Builds a DanceRequest for retrieving holon by HolonId from the persistent store
+pub fn build_get_holon_by_id_dance_request(
+    staging_area: StagingArea,
+) -> Result<DanceRequest, HolonError> {
+    let body = RequestBody::new();
+    Ok(DanceRequest::new(
+        MapString("get_holon_by_id".to_string()),
+        DanceType::Standalone,
+        body,
+        staging_area,
+    ))
 }
 
 /// Commit all staged holons to the persistent store
@@ -171,22 +254,19 @@ pub fn build_get_all_holons_dance_request(staging_area: StagingArea)->Result<Dan
 /// *ResponseBody:*
 /// - Holons -- a vector of clones of all successfully committed holons
 ///
-pub fn commit_dance(context: &HolonsContext, _request: DanceRequest) -> Result<ResponseBody, HolonError> {
-
-    let commit_response = context
-        .commit_manager
-        .borrow_mut()
-        .commit(context);
-
+pub fn commit_dance(
+    context: &HolonsContext,
+    _request: DanceRequest,
+) -> Result<ResponseBody, HolonError> {
+    let commit_response = context.commit_manager.borrow_mut().commit(context);
 
     match commit_response.status {
-        Complete => Ok(
-            ResponseBody::Holons(commit_response.saved_holons)
-        ),
+        Complete => Ok(ResponseBody::Holons(commit_response.saved_holons)),
         Incomplete => {
-            let completion_message = format!("{} of {:?} were successfully committed",
-                                             commit_response.saved_holons.len(),
-                                             commit_response.commits_attempted,
+            let completion_message = format!(
+                "{} of {:?} were successfully committed",
+                commit_response.saved_holons.len(),
+                commit_response.commits_attempted,
             );
             Err(HolonError::CommitFailure(completion_message.to_string()))
         }
@@ -196,12 +276,15 @@ pub fn commit_dance(context: &HolonsContext, _request: DanceRequest) -> Result<R
 ///
 /// Builds a DanceRequest for staging a new holon. Properties, if supplied, they will be included
 /// in the body of the request.
-pub fn build_commit_dance_request(staging_area: StagingArea)->Result<DanceRequest, HolonError> {
+pub fn build_commit_dance_request(staging_area: StagingArea) -> Result<DanceRequest, HolonError> {
     let body = RequestBody::None;
-    Ok(DanceRequest::new(MapString("commit".to_string()), DanceType::Standalone, body, staging_area))
+    Ok(DanceRequest::new(
+        MapString("commit".to_string()),
+        DanceType::Standalone,
+        body,
+        staging_area,
+    ))
 }
-
-
 
 //
 // #[hdk_extern]
@@ -261,10 +344,6 @@ pub fn build_commit_dance_request(staging_area: StagingArea)->Result<DanceReques
 //         }
 //     }
 // }
-
-
-
-
 
 /*
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/coordinator/dances/tests/dance_tests.rs
+++ b/crates/coordinator/dances/tests/dance_tests.rs
@@ -15,6 +15,7 @@ use rstest::*;
 use crate::shared_test::test_commit::execute_commit;
 use crate::shared_test::test_data_types::{DanceTestState, DanceTestStep};
 use crate::shared_test::test_ensure_database_count::execute_ensure_database_count;
+use crate::shared_test::test_match_db_content::execute_match_db_content;
 use crate::shared_test::test_stage_new_holon::execute_stage_new_holon;
 use crate::shared_test::test_with_properties_command::execute_with_properties;
 use dances::staging_area::StagingArea;
@@ -73,12 +74,14 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
         match step {
             DanceTestStep::EnsureDatabaseCount(expected_count) => {
                 execute_ensure_database_count(&conductor, &cell, &mut test_state, expected_count)
-                    .await
+                    .await;
             }
             DanceTestStep::StageHolon(holon) => {
-                execute_stage_new_holon(&conductor, &cell, &mut test_state, holon).await
+                execute_stage_new_holon(&conductor, &cell, &mut test_state, holon).await;
             }
-            DanceTestStep::Commit => execute_commit(&conductor, &cell, &mut test_state).await,
+            DanceTestStep::Commit => {
+                execute_commit(&conductor, &cell, &mut test_state).await;
+            }
             DanceTestStep::WithProperties(staged_index, properties) => {
                 execute_with_properties(
                     &conductor,
@@ -87,9 +90,13 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
                     staged_index,
                     properties,
                 )
-                .await
-            } // DanceTestStep::Update(holon) => execute_update_step(&conductor, &cell, holon),
-              // DanceTestStep::Delete(holon_id) => execute_delete_step(&conductor, &cell, holon_id),
+                .await;
+            }
+            // DanceTestStep::Update(holon) => execute_update_step(&conductor, &cell, holon),
+            // DanceTestStep::Delete(holon_id) => execute_delete_step(&conductor, &cell, holon_id),
+            DanceTestStep::MatchSavedContent => {
+                execute_match_db_content(&conductor, &cell, &mut test_state).await;
+            }
         }
     }
     println!("-------------- END OF {name} TEST CASE  ------------------");

--- a/crates/coordinator/dances/tests/dance_tests.rs
+++ b/crates/coordinator/dances/tests/dance_tests.rs
@@ -20,7 +20,7 @@ use crate::shared_test::test_stage_new_holon::execute_stage_new_holon;
 use crate::shared_test::test_with_properties_command::execute_with_properties;
 use dances::staging_area::StagingArea;
 use holons::helpers::*;
-use holons::holon::Holon;
+use holons::holon::{Holon, HolonState};
 use holons::holon_api::*;
 use holons::holon_error::HolonError;
 use shared_test::dance_fixtures::*;
@@ -59,6 +59,10 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
     let steps = test_case.clone().steps;
     let name = test_case.clone().name.clone();
     let description = test_case.clone().description;
+    // let fixture_holons = test_case.holons;
+    // assert!(fixture_holons.iter().all(|h| h.state == HolonState::New));
+    // assert!(fixture_holons.iter().all(|h| h.saved_node == None));
+    // println!("fixture_holons: {:#?}", fixture_holons);
 
     let steps_count = steps.len();
 
@@ -99,5 +103,6 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
             }
         }
     }
+
     println!("-------------- END OF {name} TEST CASE  ------------------");
 }

--- a/crates/coordinator/dances/tests/dance_tests.rs
+++ b/crates/coordinator/dances/tests/dance_tests.rs
@@ -12,22 +12,22 @@ use holochain::sweettest::*;
 use holochain::sweettest::{SweetCell, SweetConductor};
 use rstest::*;
 
-use holons::helpers::*;
-use holons::holon::Holon;
-use holons::holon_api::*;
-use holons::holon_error::HolonError;
-use dances::staging_area::StagingArea;
-use shared_test::dance_fixtures::*;
-use shared_test::test_data_types::{DancesTestCase};
-use shared_test::*;
-use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
-use shared_types_holon::value_types::BaseValue;
-use shared_types_holon::HolonId;
 use crate::shared_test::test_commit::execute_commit;
 use crate::shared_test::test_data_types::{DanceTestState, DanceTestStep};
 use crate::shared_test::test_ensure_database_count::execute_ensure_database_count;
 use crate::shared_test::test_stage_new_holon::execute_stage_new_holon;
 use crate::shared_test::test_with_properties_command::execute_with_properties;
+use dances::staging_area::StagingArea;
+use holons::helpers::*;
+use holons::holon::Holon;
+use holons::holon_api::*;
+use holons::holon_error::HolonError;
+use shared_test::dance_fixtures::*;
+use shared_test::test_data_types::DancesTestCase;
+use shared_test::*;
+use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
+use shared_types_holon::value_types::BaseValue;
+use shared_types_holon::HolonId;
 //use crate::shared_test::ensure_database_count::*;
 
 /// This function accepts a DanceTestCase created by the test fixture for that case.
@@ -62,22 +62,35 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
     let steps_count = steps.len();
 
     // Initialize the DanceTestState
-    let mut test_state =DanceTestState::new();
+    let mut test_state = DanceTestState::new();
 
-    println!("******* STARTING {name} TEST CASE WITH {steps_count} TEST STEPS ***************************");
-    println!("******* {description}  ***************************");
+    println!("\n******* STARTING {name} TEST CASE WITH {steps_count} TEST STEPS ***************************");
+    println!("\n******* {description}  ***************************");
 
+    println!("Steps: {:#?}", test_case.steps.clone());
     for step in test_case.steps {
         //println!("\n\n============= STARTING NEXT STEP: {}", step);
         match step {
-            DanceTestStep::EnsureDatabaseCount(expected_count) => execute_ensure_database_count(&conductor, &cell, &mut test_state, expected_count).await,
-            DanceTestStep::StageHolon(holon) => execute_stage_new_holon(&conductor, &cell, &mut test_state, holon).await,
-            DanceTestStep::Commit() => execute_commit(&conductor, &cell, &mut test_state,).await,
-            DanceTestStep::WithProperties(staged_index, properties) => execute_with_properties(&conductor, &cell, &mut test_state, staged_index, properties).await,
-            // DanceTestStep::Update(holon) => execute_update_step(&conductor, &cell, holon),
-            // DanceTestStep::Delete(holon_id) => execute_delete_step(&conductor, &cell, holon_id),
+            DanceTestStep::EnsureDatabaseCount(expected_count) => {
+                execute_ensure_database_count(&conductor, &cell, &mut test_state, expected_count)
+                    .await
+            }
+            DanceTestStep::StageHolon(holon) => {
+                execute_stage_new_holon(&conductor, &cell, &mut test_state, holon).await
+            }
+            DanceTestStep::Commit => execute_commit(&conductor, &cell, &mut test_state).await,
+            DanceTestStep::WithProperties(staged_index, properties) => {
+                execute_with_properties(
+                    &conductor,
+                    &cell,
+                    &mut test_state,
+                    staged_index,
+                    properties,
+                )
+                .await
+            } // DanceTestStep::Update(holon) => execute_update_step(&conductor, &cell, holon),
+              // DanceTestStep::Delete(holon_id) => execute_delete_step(&conductor, &cell, holon_id),
         }
     }
     println!("-------------- END OF {name} TEST CASE  ------------------");
 }
-

--- a/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
+++ b/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
@@ -47,7 +47,7 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
 
     );
 
-    // let mut expected_holons = Vec::new();
+    let mut expected_holons = Vec::new();
 
     test_case.add_ensure_database_count_step(MapInteger(0))?;
 
@@ -59,7 +59,7 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
         )),
     );
     test_case.add_stage_holon_step(book_holon.clone())?;
-    // expected_holons.push(book_holon.clone());
+    expected_holons.push(book_holon.clone());
 
     let mut properties = PropertyMap::new();
     properties.insert(
@@ -72,7 +72,7 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     let mut person_holon = Holon::new();
 
     test_case.add_stage_holon_step(person_holon.clone())?;
-    // expected_holons.push(person_holon.clone());
+    expected_holons.push(person_holon.clone());
 
     let mut properties = PropertyMap::new();
     properties.insert(
@@ -89,6 +89,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_match_db_content_test_step()?;
 
     test_case.add_ensure_database_count_step(MapInteger(2))?;
+
+    // test_case.holons = expected_holons;
 
     // let mut book_holon = Holon::new();
     // book_holon

--- a/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
+++ b/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
@@ -1,7 +1,7 @@
 // Simple Create Test Fixture
 //
 // This file is used to creates a TestCase that exercises the following steps:
-// - Ensure database is empty 
+// - Ensure database is empty
 // - stage a new holon
 // - update the staged holon's properties
 // - commit the holon
@@ -11,18 +11,17 @@
 //
 //
 
-
 #![allow(dead_code)]
 
 use core::panic;
+use holons::commit_manager::{CommitManager, StagedIndex};
+use holons::context::HolonsContext;
 use holons::helpers::*;
-use holons::holon_api::*;
 use holons::holon::Holon;
+use holons::holon_api::*;
 use rstest::*;
 use shared_types_holon::value_types::BaseValue;
 use std::collections::btree_map::BTreeMap;
-use holons::commit_manager::{CommitManager, StagedIndex};
-use holons::context::HolonsContext;
 
 use crate::shared_test::test_data_types::DancesTestCase;
 
@@ -34,13 +33,14 @@ use crate::shared_test::test_data_types::DancesTestCase;
 // };
 
 use holons::holon_error::HolonError;
-use shared_types_holon::{MapBoolean, MapInteger, MapString, PropertyMap, PropertyName, PropertyValue};
+use shared_types_holon::{
+    MapBoolean, MapInteger, MapString, PropertyMap, PropertyName, PropertyValue,
+};
 
 /// This function creates a set of simple (undescribed) holons
 ///
 #[fixture]
 pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
-
     let mut test_case = DancesTestCase::new(
         "Simple Create/Get Holon Testcase".to_string(),
         "Ensure DB starts empty, stage Book and Person Holons, add properties, commit, ensure db count is 2".to_string(),
@@ -50,11 +50,12 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_ensure_database_count_step(MapInteger(0))?;
 
     let mut book_holon = Holon::new();
-    book_holon
-        .with_property_value(
-            PropertyName(MapString("title".to_string())),
-            BaseValue::StringValue(MapString("Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string())))
-        ;
+    book_holon.with_property_value(
+        PropertyName(MapString("title".to_string())),
+        BaseValue::StringValue(MapString(
+            "Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string(),
+        )),
+    );
     test_case.add_stage_holon_step(book_holon)?;
 
     let mut properties = PropertyMap::new();
@@ -72,20 +73,16 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     let mut properties = PropertyMap::new();
     properties.insert(
         PropertyName(MapString("first name".to_string())),
-        BaseValue::StringValue(MapString("Roger".to_string()))
+        BaseValue::StringValue(MapString("Roger".to_string())),
     );
     properties.insert(
         PropertyName(MapString("last name".to_string())),
-        BaseValue::StringValue(MapString("Briggs".to_string()))
+        BaseValue::StringValue(MapString("Briggs".to_string())),
     );
     test_case.add_with_properties_step(MapInteger(1), properties)?;
 
-
-
-
     test_case.add_commit_step()?;
     test_case.add_ensure_database_count_step(MapInteger(2))?;
-
 
     // let mut book_holon = Holon::new();
     // book_holon
@@ -99,7 +96,6 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     // test_case.add_create_step(book_holon)?;
 
     Ok(test_case.clone())
-
 }
 
 // #[cfg(test)]

--- a/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
+++ b/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
@@ -47,6 +47,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
 
     );
 
+    // let mut expected_holons = Vec::new();
+
     test_case.add_ensure_database_count_step(MapInteger(0))?;
 
     let mut book_holon = Holon::new();
@@ -56,7 +58,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
             "Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string(),
         )),
     );
-    test_case.add_stage_holon_step(book_holon)?;
+    test_case.add_stage_holon_step(book_holon.clone())?;
+    // expected_holons.push(book_holon.clone());
 
     let mut properties = PropertyMap::new();
     properties.insert(
@@ -68,7 +71,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
 
     let mut person_holon = Holon::new();
 
-    test_case.add_stage_holon_step(person_holon)?;
+    test_case.add_stage_holon_step(person_holon.clone())?;
+    // expected_holons.push(person_holon.clone());
 
     let mut properties = PropertyMap::new();
     properties.insert(
@@ -82,6 +86,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_with_properties_step(MapInteger(1), properties)?;
 
     test_case.add_commit_step()?;
+    test_case.add_match_db_content_test_step()?;
+
     test_case.add_ensure_database_count_step(MapInteger(2))?;
 
     // let mut book_holon = Holon::new();
@@ -94,6 +100,8 @@ pub fn simple_create_test_fixture() -> Result<DancesTestCase, HolonError> {
     //         BaseValue::StringValue(MapString("Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_string())))
     //     ;
     // test_case.add_create_step(book_holon)?;
+
+    // debug!("expected holons: {:?}", expected_holons);
 
     Ok(test_case.clone())
 }

--- a/crates/coordinator/dances/tests/shared_test/mod.rs
+++ b/crates/coordinator/dances/tests/shared_test/mod.rs
@@ -1,13 +1,13 @@
 // #![allow(warnings)]
 
-pub mod test_data_types;
 pub mod dance_fixtures;
+pub mod test_data_types;
 
-pub mod test_ensure_database_count;
-pub mod test_stage_new_holon;
 pub mod test_commit;
+pub mod test_ensure_database_count;
+pub mod test_match_db_content;
+pub mod test_stage_new_holon;
 pub mod test_with_properties_command;
-
 
 use hdk::prelude::*;
 use holochain::sweettest::{SweetAgents, SweetCell, SweetConductor, SweetDnaFile};

--- a/crates/coordinator/dances/tests/shared_test/test_commit.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_commit.rs
@@ -2,37 +2,41 @@
 
 #![allow(unused_imports)]
 
-
-
 use std::collections::BTreeMap;
 
 use async_std::task;
+use dances::dance_response::ResponseBody::{self, Holons, Index};
+use dances::dance_response::{DanceResponse, ResponseStatusCode};
+use dances::holon_dance_adapter::{
+    build_commit_dance_request, build_get_all_holons_dance_request,
+    build_stage_new_holon_dance_request,
+};
 use hdk::prelude::*;
 use holochain::sweettest::*;
 use holochain::sweettest::{SweetCell, SweetConductor};
 use rstest::*;
-use dances::holon_dance_adapter::{build_commit_dance_request, build_get_all_holons_dance_request, build_stage_new_holon_dance_request};
-use dances::dance_response::{DanceResponse, ResponseStatusCode};
-use dances::dance_response::ResponseBody::{Holons, Index};
 
+use crate::shared_test::dance_fixtures::*;
+use crate::shared_test::test_data_types::DanceTestStep;
+use crate::shared_test::test_data_types::{DanceTestState, DancesTestCase};
+use crate::shared_test::*;
 use holons::helpers::*;
 use holons::holon::Holon;
 use holons::holon_api::*;
 use holons::holon_error::HolonError;
-use crate::shared_test::dance_fixtures::*;
-use crate::shared_test::test_data_types::{DancesTestCase, DanceTestState};
-use crate::shared_test::*;
 use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
 use shared_types_holon::value_types::BaseValue;
 use shared_types_holon::{HolonId, MapInteger, MapString};
-use crate::shared_test::test_data_types::DanceTestStep;
 
 /// This function builds and dances a `stage_new_holon` DanceRequest for the supplied Holon
 /// and confirms a Success response
 ///
 
-pub async fn execute_commit(conductor: &SweetConductor, cell: &SweetCell, test_state: &mut DanceTestState) ->() {
-
+pub async fn execute_commit(
+    conductor: &SweetConductor,
+    cell: &SweetCell,
+    test_state: &mut DanceTestState,
+) -> () {
     println!("\n\n--- TEST STEP: Committing Staged Holons ---- :");
 
     // Build a commit DanceRequest
@@ -40,7 +44,7 @@ pub async fn execute_commit(conductor: &SweetConductor, cell: &SweetCell, test_s
     println!("Dance Request: {:#?}", request);
 
     match request {
-        Ok(valid_request)=> {
+        Ok(valid_request) => {
             let response: DanceResponse = conductor
                 .call(&cell.zome("dances"), "dance", valid_request)
                 .await;
@@ -53,15 +57,24 @@ pub async fn execute_commit(conductor: &SweetConductor, cell: &SweetCell, test_s
                 // Check that staging area is empty
                 assert!(response.staging_area.staged_holons.is_empty());
                 println!("Success! Commit succeeded");
+                // get saved holons out of response body and add them to the test_state created holons
+                match response.body {
+                    ResponseBody::Holon(holon) => {
+                        test_state.created_holons.push(holon);
+                    }
+                    ResponseBody::Holons(holons) => {
+                        for holon in holons {
+                            test_state.created_holons.push(holon);
+                        }
+                    }
+                    _ => panic!("Invalid ResponseBody: {:?}", response.body),
+                }
             } else {
                 panic!("DanceRequest returned {code} for {description}");
             }
         }
-        Err(error)=> {
+        Err(error) => {
             panic!("{:?} Unable to build a stage_holon request ", error);
         }
     }
-
-
-
 }

--- a/crates/coordinator/dances/tests/shared_test/test_data_types.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_data_types.rs
@@ -13,53 +13,6 @@ pub struct DancesTestCase {
     pub steps: VecDeque<DanceTestStep>,
 }
 
-#[derive(Clone, Debug)]
-pub enum DanceTestStep {
-    EnsureDatabaseCount(MapInteger), // Ensures the expected number of holons exist in the DB
-    StageHolon(Holon), // Associated data is expected Holon, it could be an empty Holon (i.e., with no internal state)
-    Commit,
-    WithProperties(StagedIndex, PropertyMap), // Update properties for Holon at StagedIndex with PropertyMap
-                                              // Update(Holon), // Associated data is expected Holon after update
-                                              // Delete(HolonId), // Associated data is id of Holon to delete
-}
-
-impl fmt::Display for DanceTestStep {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DanceTestStep::EnsureDatabaseCount(count) => {
-                write!(f, "EnsureDatabaseCount = {}", count.0)
-            }
-            DanceTestStep::StageHolon(holon) => {
-                write!(f, "StageHolon({:#?})", holon)
-            }
-            DanceTestStep::Commit => {
-                write!(f, "Commit")
-            }
-            DanceTestStep::WithProperties(index, properties) => {
-                write!(
-                    f,
-                    "WithProperties for Holon at ({:#?}) with properties: {:#?} ",
-                    index, properties
-                )
-            }
-        }
-    }
-}
-
-pub struct DanceTestState {
-    pub staging_area: StagingArea,
-    pub created_holons: Vec<Holon>,
-}
-
-impl DanceTestState {
-    pub fn new() -> DanceTestState {
-        DanceTestState {
-            staging_area: StagingArea::new(),
-            created_holons: Vec::new(),
-        }
-    }
-}
-
 impl DancesTestCase {
     pub fn new(name: String, description: String) -> Self {
         Self {
@@ -103,6 +56,62 @@ impl DancesTestCase {
     //     self.steps.push_back(DanceTestStep::Delete(holon_id));
     //     Ok(())
     // }
+
+    pub fn add_match_db_content_test_step(&mut self) -> Result<(), HolonError> {
+        self.steps.push_back(DanceTestStep::MatchSavedContent);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum DanceTestStep {
+    EnsureDatabaseCount(MapInteger), // Ensures the expected number of holons exist in the DB
+    StageHolon(Holon), // Associated data is expected Holon, it could be an empty Holon (i.e., with no internal state)
+    Commit,
+    WithProperties(StagedIndex, PropertyMap), // Update properties for Holon at StagedIndex with PropertyMap
+    // Update(Holon), // Associated data is expected Holon after update
+    // Delete(HolonId), // Associated data is id of Holon to delete
+    MatchSavedContent,
+}
+
+impl fmt::Display for DanceTestStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DanceTestStep::EnsureDatabaseCount(count) => {
+                write!(f, "EnsureDatabaseCount = {}", count.0)
+            }
+            DanceTestStep::StageHolon(holon) => {
+                write!(f, "StageHolon({:#?})", holon)
+            }
+            DanceTestStep::Commit => {
+                write!(f, "Commit")
+            }
+            DanceTestStep::WithProperties(index, properties) => {
+                write!(
+                    f,
+                    "WithProperties for Holon at ({:#?}) with properties: {:#?} ",
+                    index, properties
+                )
+            }
+            DanceTestStep::MatchSavedContent => {
+                write!(f, "MatchSavedContent")
+            }
+        }
+    }
+}
+
+pub struct DanceTestState {
+    pub staging_area: StagingArea,
+    pub created_holons: Vec<Holon>,
+}
+
+impl DanceTestState {
+    pub fn new() -> DanceTestState {
+        DanceTestState {
+            staging_area: StagingArea::new(),
+            created_holons: Vec::new(),
+        }
+    }
 }
 
 // #[derive(Clone, Debug)]

--- a/crates/coordinator/dances/tests/shared_test/test_data_types.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_data_types.rs
@@ -11,6 +11,7 @@ pub struct DancesTestCase {
     pub name: String,
     pub description: String,
     pub steps: VecDeque<DanceTestStep>,
+    // pub holons: Vec<Holon>,
 }
 
 impl DancesTestCase {
@@ -19,6 +20,7 @@ impl DancesTestCase {
             name,
             description,
             steps: VecDeque::new(),
+            // holons: Vec::new(),
         }
     }
 

--- a/crates/coordinator/dances/tests/shared_test/test_data_types.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_data_types.rs
@@ -1,26 +1,26 @@
-use std::collections::VecDeque;
-use std::fmt;
+use dances::staging_area::StagingArea;
+use holons::commit_manager::StagedIndex;
 use holons::holon::{Holon, HolonState};
 use holons::holon_error::HolonError;
 use shared_types_holon::{HolonId, MapInteger, MapString, PropertyMap, PropertyValue};
-use dances::staging_area::StagingArea;
-use holons::commit_manager::StagedIndex;
+use std::collections::VecDeque;
+use std::fmt;
 
 #[derive(Clone, Debug)]
 pub struct DancesTestCase {
-    pub name : String,
+    pub name: String,
     pub description: String,
-    pub steps : VecDeque<DanceTestStep>,
+    pub steps: VecDeque<DanceTestStep>,
 }
 
 #[derive(Clone, Debug)]
 pub enum DanceTestStep {
     EnsureDatabaseCount(MapInteger), // Ensures the expected number of holons exist in the DB
     StageHolon(Holon), // Associated data is expected Holon, it could be an empty Holon (i.e., with no internal state)
-    Commit(),
-    WithProperties(StagedIndex,PropertyMap) // Update properties for Holon at StagedIndex with PropertyMap
-    // Update(Holon), // Associated data is expected Holon after update
-    // Delete(HolonId), // Associated data is id of Holon to delete
+    Commit,
+    WithProperties(StagedIndex, PropertyMap), // Update properties for Holon at StagedIndex with PropertyMap
+                                              // Update(Holon), // Associated data is expected Holon after update
+                                              // Delete(HolonId), // Associated data is id of Holon to delete
 }
 
 impl fmt::Display for DanceTestStep {
@@ -32,11 +32,15 @@ impl fmt::Display for DanceTestStep {
             DanceTestStep::StageHolon(holon) => {
                 write!(f, "StageHolon({:#?})", holon)
             }
-            DanceTestStep::Commit() => {
+            DanceTestStep::Commit => {
                 write!(f, "Commit")
             }
-            DanceTestStep::WithProperties(index,properties) => {
-                write!(f, "WithProperties for Holon at ({:#?}) with properties: {:#?} ", index, properties)
+            DanceTestStep::WithProperties(index, properties) => {
+                write!(
+                    f,
+                    "WithProperties for Holon at ({:#?}) with properties: {:#?} ",
+                    index, properties
+                )
             }
         }
     }
@@ -56,17 +60,18 @@ impl DanceTestState {
     }
 }
 
-
 impl DancesTestCase {
-    pub fn new(name: String, description: String)->Self {
+    pub fn new(name: String, description: String) -> Self {
         Self {
             name,
             description,
-            steps: VecDeque::new(), }
+            steps: VecDeque::new(),
+        }
     }
 
     pub fn add_ensure_database_count_step(&mut self, count: MapInteger) -> Result<(), HolonError> {
-        self.steps.push_back(DanceTestStep::EnsureDatabaseCount(count));
+        self.steps
+            .push_back(DanceTestStep::EnsureDatabaseCount(count));
         Ok(())
     }
 
@@ -75,12 +80,17 @@ impl DancesTestCase {
         Ok(())
     }
     pub fn add_commit_step(&mut self) -> Result<(), HolonError> {
-        self.steps.push_back(DanceTestStep::Commit());
+        self.steps.push_back(DanceTestStep::Commit);
         Ok(())
     }
 
-    pub fn add_with_properties_step(&mut self, index:StagedIndex, properties:PropertyMap) -> Result<(), HolonError> {
-        self.steps.push_back(DanceTestStep::WithProperties(index, properties));
+    pub fn add_with_properties_step(
+        &mut self,
+        index: StagedIndex,
+        properties: PropertyMap,
+    ) -> Result<(), HolonError> {
+        self.steps
+            .push_back(DanceTestStep::WithProperties(index, properties));
         Ok(())
     }
     //

--- a/crates/coordinator/dances/tests/shared_test/test_ensure_database_count.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_ensure_database_count.rs
@@ -2,30 +2,30 @@
 
 #![allow(unused_imports)]
 
-
-
 use std::collections::BTreeMap;
 
 use async_std::task;
+use dances::dance_response::ResponseBody::Holons;
+use dances::dance_response::{DanceResponse, ResponseStatusCode};
+use dances::holon_dance_adapter::{
+    build_get_all_holons_dance_request, build_stage_new_holon_dance_request,
+};
 use hdk::prelude::*;
 use holochain::sweettest::*;
 use holochain::sweettest::{SweetCell, SweetConductor};
 use rstest::*;
-use dances::holon_dance_adapter::{build_get_all_holons_dance_request, build_stage_new_holon_dance_request};
-use dances::dance_response::{DanceResponse, ResponseStatusCode};
-use dances::dance_response::ResponseBody::Holons;
 
+use crate::shared_test::dance_fixtures::*;
+use crate::shared_test::test_data_types::DanceTestStep;
+use crate::shared_test::test_data_types::{DanceTestState, DancesTestCase};
+use crate::shared_test::*;
 use holons::helpers::*;
 use holons::holon::Holon;
 use holons::holon_api::*;
 use holons::holon_error::HolonError;
-use crate::shared_test::dance_fixtures::*;
-use crate::shared_test::test_data_types::{DancesTestCase, DanceTestState};
-use crate::shared_test::*;
 use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
 use shared_types_holon::value_types::BaseValue;
 use shared_types_holon::{HolonId, MapInteger, MapString};
-use crate::shared_test::test_data_types::DanceTestStep;
 
 /// This function builds and dances a `get_all_holons` DanceRequest and confirms that the number
 /// of holons returned matches the expected_count of holons provided.
@@ -35,8 +35,8 @@ pub async fn execute_ensure_database_count(
     conductor: &SweetConductor,
     cell: &SweetCell,
     test_state: &mut DanceTestState,
-    expected_count: MapInteger
-){
+    expected_count: MapInteger,
+) {
     let expected_count_string = expected_count.0.to_string();
     println!("\n\n--- TEST STEP: Ensuring database holds {expected_count_string} holons ---");
     // Build a get_all_holons DanceRequest
@@ -44,28 +44,25 @@ pub async fn execute_ensure_database_count(
     println!("Dance Request: {:#?}", request);
 
     match request {
-        Ok(valid_request)=> {
+        Ok(valid_request) => {
             let response: DanceResponse = conductor
                 .call(&cell.zome("dances"), "dance", valid_request)
                 .await;
             test_state.staging_area = response.staging_area.clone();
 
-            if let Holons(holons) = response.body {
+            if let Holons(holons) = response.body.clone() {
                 assert_eq!(expected_count, MapInteger(holons.len() as i64));
                 let actual_count = holons.len().to_string();
                 println!("Success! DB has {actual_count} holons, as expected");
-
             } else {
-                panic!("Expected get_all_holons to return Holons response, but it didn't!");
+                panic!(
+                    "Expected get_all_holons to return Holons response, but it returned {:?}",
+                    response.body
+                );
             }
-
-
         }
-        Err(error)=> {
+        Err(error) => {
             panic!("{:?} Unable to build a get_all_holons request ", error);
         }
     }
-
-
-
 }

--- a/crates/coordinator/dances/tests/shared_test/test_match_db_content.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_match_db_content.rs
@@ -1,0 +1,66 @@
+// #![allow(unused_imports)]
+
+use std::collections::BTreeMap;
+
+use async_std::task;
+use dances::dance_response::ResponseBody::Holons;
+use dances::dance_response::{DanceResponse, ResponseStatusCode};
+use dances::holon_dance_adapter::{
+    build_get_all_holons_dance_request, build_stage_new_holon_dance_request,
+};
+use hdk::prelude::*;
+use holochain::sweettest::*;
+use holochain::sweettest::{SweetCell, SweetConductor};
+use rstest::*;
+
+use crate::shared_test::dance_fixtures::*;
+use crate::shared_test::test_data_types::DanceTestStep;
+use crate::shared_test::test_data_types::{DanceTestState, DancesTestCase};
+use crate::shared_test::*;
+use holons::helpers::*;
+use holons::holon::Holon;
+use holons::holon_api::*;
+use holons::holon_error::HolonError;
+use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
+use shared_types_holon::value_types::BaseValue;
+use shared_types_holon::{HolonId, MapInteger, MapString};
+
+/// This function iterates through the expected_holons vector supplied as a parameter
+/// and for each holon: builds and dances a `get_holon_by_id` DanceRequest,
+/// then confirms that the Holon returned matches the expected
+
+pub async fn execute_match_db_content(
+    conductor: &SweetConductor,
+    cell: &SweetCell,
+    test_state: &mut DanceTestState,
+    expected_holons: Vec<Holon>,
+) {
+    println!("\n\n--- TEST STEP: Ensuring database matches expected holons ---");
+    for expected_holon in expected_holons {
+        // Build a get_holon_by_id DanceRequest
+        let request = build_get_holon_by_id_dance_request(test_state.staging_area.clone());
+        // println!("Dance Request: {:#?}", request);
+
+        match request {
+            Ok(valid_request) => {
+                let response: DanceResponse = conductor
+                    .call(&cell.zome("dances"), "dance", valid_request)
+                    .await;
+                test_state.staging_area = response.staging_area.clone();
+
+                if let Holon(fetched_holon) = response.body.clone() {
+                    assert_eq!(expected_holon, fetched_holon);
+                    println!("Success! DB fetched holon matched expected");
+                } else {
+                    panic!(
+                        "Expected get_holon_by_id to return a Holon response, but it returned {}",
+                        response.body.clone()
+                    );
+                }
+            }
+            Err(error) => {
+                panic!("{:?} Unable to build a get_all_holons request ", error);
+            }
+        }
+    }
+}

--- a/crates/coordinator/dances/tests/shared_test/test_match_db_content.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_match_db_content.rs
@@ -51,8 +51,11 @@ pub async fn execute_match_db_content(
                     .await;
                 test_state.staging_area = response.staging_area.clone();
 
-                if let ResponseBody::Holon(fetched_holon) = response.body.clone() {
-                    assert_eq!(expected_holon, fetched_holon);
+                if let ResponseBody::Holon(actual_holon) = response.body.clone() {
+                    assert_eq!(
+                        expected_holon.essential_content(),
+                        actual_holon.essential_content()
+                    );
                     println!("Success! DB fetched holon matched expected");
                 } else {
                     panic!(

--- a/crates/coordinator/holons/src/cache_manager.rs
+++ b/crates/coordinator/holons/src/cache_manager.rs
@@ -1,4 +1,3 @@
-use crate::context::HolonsContext;
 use crate::holon::Holon;
 use crate::holon_error::HolonError;
 use hdk::prelude::*;

--- a/crates/coordinator/holons/src/cache_manager.rs
+++ b/crates/coordinator/holons/src/cache_manager.rs
@@ -59,7 +59,7 @@ impl HolonCacheManager {
 
     /// fetch_holon gets a specific HolonNode from the persistent store based on its ActionHash, it then
     /// "inflates" the HolonNode into a Holon and returns it
-    fn fetch_holon(_context: &HolonsContext, id: &HolonId) -> Result<Holon, HolonError> {
+    fn fetch_holon(id: &HolonId) -> Result<Holon, HolonError> {
         let holon_node_record = get(id.0.clone(), GetOptions::default())?;
         if let Some(node) = holon_node_record {
             let holon = Holon::try_from_node(node)?;
@@ -80,7 +80,6 @@ impl HolonCacheManager {
 
     pub fn get_rc_holon(
         &mut self,
-        context: &HolonsContext,
         holon_space_id: Option<&HolonId>,
         holon_id: &HolonId,
     ) -> Result<Rc<Holon>, HolonError> {
@@ -94,7 +93,7 @@ impl HolonCacheManager {
         }
 
         // If not found in the cache, fetch the holon
-        let fetched_holon = Self::fetch_holon(context, holon_id)?;
+        let fetched_holon = Self::fetch_holon(holon_id)?;
 
         // Obtain a mutable reference to local_cache
         let cache_mut = self.get_cache_mut(holon_space_id)?;

--- a/crates/coordinator/holons/src/commit_manager.rs
+++ b/crates/coordinator/holons/src/commit_manager.rs
@@ -1,7 +1,7 @@
+use hdk::prelude::*;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::BTreeMap;
 use std::rc::Rc;
-use hdk::prelude::*;
 
 // use crate::cache_manager::HolonCacheManager;
 use crate::context::HolonsContext;
@@ -12,7 +12,6 @@ use crate::relationship::RelationshipTarget;
 use crate::smart_reference::SmartReference;
 use crate::staged_reference::StagedReference;
 use shared_types_holon::{MapInteger, MapString};
-
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CommitManager {
@@ -26,7 +25,7 @@ pub type StagedIndex = MapInteger;
 pub struct CommitResponse {
     pub status: CommitRequestStatus,
     pub commits_attempted: MapInteger,
-    pub saved_holons:Vec<Holon>,
+    pub saved_holons: Vec<Holon>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -64,16 +63,16 @@ impl CommitManager {
             commits_attempted: MapInteger(self.staged_holons.len() as i64),
             saved_holons: Vec::new(),
         };
-                // Invoke commit on each of the staged_holons
+        // Invoke commit on each of the staged_holons
         // If successful, add an "unloaded" SmartReference to it to saved_holons
         // Otherwise, set request_status to Incomplete
         for rc_holon in self.staged_holons.clone() {
             let outcome = rc_holon.borrow_mut().clone().commit(context);
             match outcome {
-                Ok(holon)=> {
+                Ok(holon) => {
                     response.saved_holons.push(holon);
                 }
-                Err(_error)=> {
+                Err(_error) => {
                     response.status = CommitRequestStatus::Incomplete;
                 }
             }
@@ -83,11 +82,8 @@ impl CommitManager {
             CommitRequestStatus::Complete => {
                 self.clear_staged_objects();
                 response
-
             }
-            CommitRequestStatus::Incomplete => {
-                response
-            }
+            CommitRequestStatus::Incomplete => response,
         }
     }
 
@@ -112,7 +108,6 @@ impl CommitManager {
         StagedReference { key, holon_index }
     }
 
-
     // Constructor function for creating StagedReference from an index into CommitManagers StagedHolons
     // pub fn get_reference_from_index(&self, index: MapInteger) -> Result<StagedReference, HolonError> {
     //
@@ -121,7 +116,7 @@ impl CommitManager {
     //     if holon_index < 0 || holon_index > self.staged_holons.len() {
     //         Err(HolonError::IndexOutOfRange(index.0.to_string()))
     //     }
-        // let key = rc_holon.borrow().get_key()?;
+    // let key = rc_holon.borrow().get_key()?;
 
     //     Ok(StagedReference { key, holon_index })
     // }
@@ -244,7 +239,6 @@ impl CommitManager {
         self.index.clear();
     }
 
-
     /// Stages a new version of an existing holon for update, retaining the linkage to the holon version it is derived from by populating its (new) predecessor field existing_holon value provided.
     pub fn edit_holon(
         &mut self,
@@ -296,5 +290,3 @@ impl CommitManager {
         Ok(staged_reference)
     }
 }
-
-

--- a/crates/coordinator/holons/src/holon.rs
+++ b/crates/coordinator/holons/src/holon.rs
@@ -9,6 +9,7 @@ use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
 use shared_types_holon::value_types::BaseValue;
 use shared_types_holon::{HolonId, MapString, PropertyValue};
 
+use crate::all_holon_nodes::*;
 use crate::context::HolonsContext;
 use crate::helpers::get_holon_node_from_record;
 use crate::holon_error::HolonError;
@@ -16,7 +17,6 @@ use crate::holon_node::UpdateHolonNodeInput;
 use crate::holon_node::*;
 use crate::relationship::RelationshipMap;
 use crate::smart_reference::SmartReference;
-use crate::{all_holon_nodes::*};
 
 #[hdk_entry_helper]
 #[derive(Clone, Eq, PartialEq)]
@@ -121,17 +121,18 @@ impl Holon {
     }
 
     /// This function bypasses the cache (it should be retired in favor of fetch_holon once cache is implemented
-    /// TODO: replace with cache aware function
+    // TODO: replace with cache aware function
+    // TODO: Throw None case or remove option
     pub fn get_holon(id: HolonId) -> Result<Option<Holon>, HolonError> {
         let holon_node_record = get_holon_node(id.0.clone())?;
-        return if let Some(node) = holon_node_record {
+        if let Some(node) = holon_node_record {
             let mut holon = Holon::try_from_node(node)?;
             holon.state = HolonState::Fetched;
             Ok(Some(holon))
         } else {
             // no holon_node fetched for specified holon_id
             Err(HolonError::HolonNotFound(id.0.to_string()))
-        };
+        }
     }
 
     pub fn get_property_value(
@@ -255,7 +256,11 @@ impl Holon {
                         let holon_id = record.action_address().clone();
                         // Iterate through the holon's relationship map, invoking commit on each
                         for (name, target) in self.relationship_map.0.clone() {
-                            target.commit(context, HolonId::from(holon_id.clone()), name.clone())?;
+                            target.commit(
+                                context,
+                                HolonId::from(holon_id.clone()),
+                                name.clone(),
+                            )?;
                         }
 
                         self.state = HolonState::Saved;

--- a/crates/coordinator/holons/src/holon.rs
+++ b/crates/coordinator/holons/src/holon.rs
@@ -34,6 +34,16 @@ pub struct Holon {
     pub errors: Vec<HolonError>,
 }
 
+/// Type used for testing in order to match the essential content of a Holon
+#[hdk_entry_helper]
+#[derive(Clone, Eq, PartialEq)]
+pub struct EssentialHolonContent {
+    pub property_map: PropertyMap,
+    pub relationship_map: RelationshipMap,
+    key: Option<MapString>,
+    pub errors: Vec<HolonError>,
+}
+
 // Move to id staged holons via index should mean that derived implementations of PartialEq and Eq
 // /// The PartialEq and Eq traits need to be implemented for Holon to support Vec operations of the CommitManager.
 // /// NOTE: Holons types are NOT required to have a Key, so we can't rely on key for identity.
@@ -335,6 +345,17 @@ impl Holon {
             Err(error) => Err(HolonError::WasmError(error.to_string())),
         }
     }
+
+    pub fn essential_content(&self) -> EssentialHolonContent {
+        EssentialHolonContent {
+            property_map: self.property_map.clone(),
+            relationship_map: self.relationship_map.clone(),
+            key: self.key.clone(),
+            errors: self.errors.clone(),
+        }
+    }
+
+    // ====
     // pub fn commit(mut self, context: &HolonsContext) -> Result<Self, HolonError> {
     //     //let mut holon = self.clone(); // avoid doing this?
     //     match self.state {

--- a/crates/coordinator/holons/src/smart_reference.rs
+++ b/crates/coordinator/holons/src/smart_reference.rs
@@ -36,7 +36,7 @@ impl SmartReference {
         let mut cache_manager_ref_mut = context.cache_manager.borrow_mut();
 
         // Attempt to populate rc_holon by invoking get_rc_holon on the cache_manager
-        let rc_holon = cache_manager_ref_mut.get_rc_holon(context, None, &self.holon_id)?;
+        let rc_holon = cache_manager_ref_mut.get_rc_holon(None, &self.holon_id)?;
 
         // Update rc_holon in self
         self.rc_holon = Some(rc_holon);


### PR DESCRIPTION
`cargo test -p dances --test dance_tests  -- --show-output`
1 test passing. 

fixture changes so far not needed... EssentialHolonContent fixed the issue of passing 'expected_holons' from test_case.created_holons into execute_match_db_content DanceTestStep, since it takes a mutable reference.

This PR might benefit from further assertions and tests. There may be value in returning the fixture_holons from the fixture anyways, and we could run some match checks on the `created` and `fetched` holons.. although there may be a more simplified check, and perhaps not necessary for the current stage.