### PR TITLE
75 implement DeleteHolon dance undescribed

### DIFF
--- a/crates/coordinator/dances/src/dance_request.rs
+++ b/crates/coordinator/dances/src/dance_request.rs
@@ -1,12 +1,12 @@
-use crate::{staging_area::StagingArea};
+use crate::staging_area::StagingArea;
 use hdk::prelude::*;
 use holons::commit_manager::StagedIndex;
 use holons::holon::Holon;
 use holons::holon_reference::HolonReference;
-use holons::relationship::RelationshipName;
 use holons::query::{NodeCollection, QueryExpression};
+use holons::relationship::RelationshipName;
 
-use shared_types_holon::{HolonId, MapString, PropertyMap};
+use shared_types_holon::{HolonId, LocalId, MapString, PropertyMap};
 
 #[hdk_entry_helper]
 #[derive(Clone, Eq, PartialEq)]
@@ -24,6 +24,7 @@ pub enum DanceType {
     Standalone,                  // i.e., a dance not associated with a specific holon
     QueryMethod(NodeCollection), // a read-only dance originated from a specific, already persisted, holon
     CommandMethod(StagedIndex), // a mutating method operating on a specific staged_holon identified by its index into the staged_holons vector
+    DeleteMethod(LocalId),
 }
 
 #[hdk_entry_helper]

--- a/crates/coordinator/dances/src/dance_response.rs
+++ b/crates/coordinator/dances/src/dance_response.rs
@@ -76,6 +76,7 @@ impl From<HolonError> for ResponseStatusCode {
             HolonError::Utf8Conversion(_, _) => ResponseStatusCode::ServerError,
             HolonError::HashConversion(_, _) => ResponseStatusCode::ServerError,
             HolonError::UnexpectedValueType(_, _) => ResponseStatusCode::ServerError,
+            HolonError::DeletionNotAllowed(_) => ResponseStatusCode::BadRequest,
         }
     }
 }

--- a/crates/coordinator/dances/src/dancer.rs
+++ b/crates/coordinator/dances/src/dancer.rs
@@ -13,7 +13,9 @@ use crate::dance_response::{DanceResponse, ResponseBody, ResponseStatusCode};
 use crate::descriptors_dance_adapter::load_core_schema_dance;
 
 use crate::holon_dance_adapter::{
-    abandon_staged_changes_dance, add_related_holons_dance, commit_dance, get_all_holons_dance, get_holon_by_id_dance, query_relationships_dance, remove_related_holons_dance, stage_new_holon_dance, with_properties_dance
+    abandon_staged_changes_dance, add_related_holons_dance, commit_dance, delete_holon_dance,
+    get_all_holons_dance, get_holon_by_id_dance, query_relationships_dance,
+    remove_related_holons_dance, stage_new_holon_dance, with_properties_dance,
 };
 
 use crate::staging_area::StagingArea;
@@ -105,6 +107,7 @@ impl Dancer {
         dispatch_table.insert("get_holon_by_id", get_holon_by_id_dance as DanceFunction);
         dispatch_table.insert("stage_new_holon", stage_new_holon_dance as DanceFunction);
         dispatch_table.insert("commit", commit_dance as DanceFunction);
+        dispatch_table.insert("delete_holon", delete_holon_dance as DanceFunction);
         dispatch_table.insert("with_properties", with_properties_dance as DanceFunction);
 
         dispatch_table.insert(
@@ -189,6 +192,7 @@ fn process_dispatch_result(dispatch_result: Result<ResponseBody, HolonError>) ->
             // If the dispatch_result is an error, extract the associated string value
             let error_message = match error.clone() {
                 HolonError::EmptyField(_)
+                | HolonError::DeletionNotAllowed(_)
                 | HolonError::InvalidParameter(_)
                 | HolonError::HolonNotFound(_)
                 | HolonError::CommitFailure(_)

--- a/crates/coordinator/dances/tests/dance_tests.rs
+++ b/crates/coordinator/dances/tests/dance_tests.rs
@@ -76,15 +76,16 @@ use shared_types_holon::HolonId;
 ///      set WASM_LOG to enable guest-side (i.e., zome code) tracing
 ///
 #[rstest]
-
 #[case::simple_undescribed_create_holon_test(simple_create_test_fixture())]
 #[case::simple_add_related_holon_test(simple_add_remove_related_holons_fixture())]
 #[case::simple_abandon_staged_changes_test(simple_abandon_staged_changes_fixture())]
 #[case::load_core_schema(load_core_schema_test_fixture())]
-
+#[case::delete_holon(delete_holon_fixture())]
 #[tokio::test(flavor = "multi_thread")]
 async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
     // Setup
+
+    use test_delete_holon::execute_delete_holon;
     let _ = holochain_trace::test_run();
 
     let (conductor, _agent, cell): (SweetConductor, AgentPubKey, SweetCell) =
@@ -146,7 +147,12 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
                 )
                 .await
             }
-            DanceTestStep::DatabasePrint => execute_commit(&conductor, &cell, &mut test_state).await,
+            DanceTestStep::DatabasePrint => {
+                execute_commit(&conductor, &cell, &mut test_state).await
+            }
+            DanceTestStep::DeleteHolon(expected_response) => {
+                execute_delete_holon(&conductor, &cell, &mut test_state, expected_response).await
+            }
             DanceTestStep::EnsureDatabaseCount(expected_count) => {
                 execute_ensure_database_count(&conductor, &cell, &mut test_state, expected_count)
                     .await

--- a/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
+++ b/crates/coordinator/dances/tests/shared_test/dance_fixtures.rs
@@ -3,19 +3,19 @@
 use crate::get_holon_by_key_from_test_state;
 use crate::tracing::{error, info, warn};
 use core::panic;
-use holons::query::{QueryExpression};
+use holochain::core::author_key_is_valid;
 use holons::helpers::*;
 use holons::holon::Holon;
 use holons::holon_api::*;
 use holons::holon_collection::{CollectionState, HolonCollection};
 use holons::holon_reference::HolonReference;
+use holons::query::QueryExpression;
 use holons::smart_reference::SmartReference;
 use holons::staged_reference::StagedReference;
 use pretty_assertions::assert_eq;
 use rstest::*;
 use shared_types_holon::value_types::BaseValue;
 use std::collections::btree_map::BTreeMap;
-use holochain::core::author_key_is_valid;
 
 use dances::dance_response::ResponseStatusCode;
 use holons::commit_manager::{CommitManager, StagedIndex};
@@ -34,10 +34,10 @@ use holons::holon_error::HolonError;
 use holons::holon_reference::HolonReference::Staged;
 use holons::relationship::RelationshipName;
 
+use crate::shared_test::book_authors_setup_fixture::setup_book_author_steps;
 use shared_types_holon::{
     HolonId, MapBoolean, MapInteger, MapString, PropertyMap, PropertyName, PropertyValue,
 };
-use crate::shared_test::book_authors_setup_fixture::setup_book_author_steps;
 
 /// This function creates a set of simple (undescribed) holons
 ///
@@ -191,30 +191,23 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
 
     // ADD STEP:  RELATIONSHIP:  Book H1-> Author H2 & H3  //
 
-
     let authored_by_relationship_name = RelationshipName(MapString("AUTHORED_BY".to_string()));
 
     // Create the expected_holon
     let mut authored_by_collection = HolonCollection::new_staged();
-    authored_by_collection.add_reference_with_key(
-        Some(&person_1_key),
-        &person_1_reference.clone())?;
+    authored_by_collection
+        .add_reference_with_key(Some(&person_1_key), &person_1_reference.clone())?;
 
-    authored_by_collection.add_reference_with_key(
-        Some(&person_2_key),
-        &person_2_reference)?;
-
+    authored_by_collection.add_reference_with_key(Some(&person_2_key), &person_2_reference)?;
 
     book_holon.relationship_map.0.insert(
         authored_by_relationship_name.clone(),
         authored_by_collection.clone(),
     );
 
-
     let mut related_holons: Vec<HolonReference> = Vec::new();
     related_holons.push(person_1_reference.clone());
     related_holons.push(person_2_reference);
-
 
     test_case.add_related_holons_step(
         book_index, // source holon
@@ -224,22 +217,24 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
         book_holon.clone(),
     )?;
 
-
     let empty_collection = HolonCollection::new_staged();
 
-    let mut book_holon_with_no_related= book_holon.clone();
+    let mut book_holon_with_no_related = book_holon.clone();
     book_holon_with_no_related.relationship_map.0.clear();
-    book_holon_with_no_related.relationship_map.0.insert(authored_by_relationship_name.clone(),empty_collection);
+    book_holon_with_no_related
+        .relationship_map
+        .0
+        .insert(authored_by_relationship_name.clone(), empty_collection);
 
     let mut one_in_collection = HolonCollection::new_staged();
-    one_in_collection.add_reference_with_key(
-        Some(&person_1_key),
-        &person_1_reference)?;
+    one_in_collection.add_reference_with_key(Some(&person_1_key), &person_1_reference)?;
 
-    let mut book_holon_with_one_related= book_holon.clone();
+    let mut book_holon_with_one_related = book_holon.clone();
     book_holon_with_one_related.relationship_map.0.clear();
-    book_holon_with_one_related.relationship_map.0.insert(authored_by_relationship_name.clone(),one_in_collection);
-
+    book_holon_with_one_related
+        .relationship_map
+        .0
+        .insert(authored_by_relationship_name.clone(), one_in_collection);
 
     // // test invalid source holon
     // let wrong_book_index: usize = 8;
@@ -251,7 +246,6 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     //     ResponseStatusCode::ServerError,
     //     book_holon.clone(), //expected
     // )?;
-
 
     // test invalid relationship name
     let wrong_relationship_name: RelationshipName = RelationshipName(MapString("WRONG".into()));
@@ -267,11 +261,10 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     test_case.remove_related_holons_step(
         book_index, // source holon
         authored_by_relationship_name.clone(),
-        related_holons.clone().split_off(1),  //takes the second person holon
+        related_holons.clone().split_off(1), //takes the second person holon
         ResponseStatusCode::OK,
         book_holon_with_one_related.clone(), //expected
     )?;
-
 
     //test remove all related holons including ignoring a previous one that was already removed
     test_case.remove_related_holons_step(
@@ -282,7 +275,7 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
         book_holon_with_no_related.clone(), //expected none
     )?;
 
-     test_case.add_related_holons_step(
+    test_case.add_related_holons_step(
         book_index, // source holon
         authored_by_relationship_name.clone(),
         related_holons.to_vec(),
@@ -324,12 +317,13 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     let test_data = setup_book_author_steps(
         &mut test_case,
         &mut holons_to_add,
-        &desired_test_relationship
+        &desired_test_relationship,
     )?;
 
-    let person_1_index= test_data[1].staged_index;
+    let person_1_index = test_data[1].staged_index;
     let book_holon_key = test_data[0].key.clone();
-    let book_holon = test_data[0].expected_holon
+    let book_holon = test_data[0]
+        .expected_holon
         .clone()
         .expect("Expected setup method to return Some book holon at index 0, got none.");
 
@@ -395,6 +389,46 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
         query_expression,
         ResponseStatusCode::OK,
     )?;
+
+    Ok(test_case.clone())
+}
+
+/// Fixture for creating a DeleteHolon Testcase
+#[fixture]
+pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
+    let mut test_case = DancesTestCase::new(
+        "DeleteHolon Testcase".to_string(),
+        "Tests delete_holon dance, matches expected response, in the OK case confirms get_holon_by_id returns NotFound error response for the given holon_to_delete ID.".to_string(),
+    );
+
+    //  ADD STEP:  STAGE:  Book Holon  //
+    let mut book_holon = Holon::new();
+    let book_holon_key = MapString(
+        "Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string(),
+    );
+    book_holon.with_property_value(
+        PropertyName(MapString("key".to_string())),
+        BaseValue::StringValue(book_holon_key.clone()),
+    )?;
+    book_holon.with_property_value(
+        PropertyName(MapString("title".to_string())),
+        BaseValue::StringValue(MapString(
+            "Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string(),
+        )),
+    )?.with_property_value(
+        PropertyName(MapString("description".to_string())),
+        BaseValue::StringValue(MapString("Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_string()))
+    )?;
+    test_case.add_stage_holon_step(book_holon)?;
+
+    // ADD STEP:  COMMIT  // all Holons in staging_area
+    test_case.add_commit_step()?;
+
+    // ADD STEP: DELETE HOLON - Valid //
+    test_case.add_delete_holon_step(ResponseStatusCode::OK)?;
+
+    // ADD STEP: DELETE HOLON - Invalid //
+    test_case.add_delete_holon_step(ResponseStatusCode::NotFound)?;
 
     Ok(test_case.clone())
 }

--- a/crates/coordinator/dances/tests/shared_test/mod.rs
+++ b/crates/coordinator/dances/tests/shared_test/mod.rs
@@ -3,31 +3,28 @@
 pub mod dance_fixtures;
 pub mod test_data_types;
 
+pub mod book_authors_setup_fixture;
 pub mod descriptor_dance_fixtures;
 pub mod test_abandon_staged_changes;
 pub mod test_add_related_holon;
-pub mod test_remove_related_holon;
 pub mod test_commit;
+pub mod test_delete_holon;
 pub mod test_ensure_database_count;
 pub mod test_load_core_schema;
 pub mod test_match_db_content;
+pub mod test_print_database;
 pub mod test_query_relationships;
+pub mod test_remove_related_holon;
 pub mod test_stage_new_holon;
 pub mod test_with_properties_command;
-pub mod book_authors_setup_fixture;
-pub mod test_print_database;
 
 use hdk::prelude::*;
 use holochain::sweettest::{SweetAgents, SweetCell, SweetConductor, SweetDnaFile};
+use holons::holon_reference::HolonGettable;
 use holons::{
-    context::HolonsContext,
-    holon::Holon
-    ,
-    holon_error::HolonError,
-    holon_reference::HolonReference,
+    context::HolonsContext, holon::Holon, holon_error::HolonError, holon_reference::HolonReference,
     relationship::RelationshipName,
 };
-use holons::holon_reference::HolonGettable;
 use shared_types_holon::{HolonId, MapString};
 use test_data_types::DanceTestState;
 

--- a/crates/coordinator/dances/tests/shared_test/test_data_types.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_data_types.rs
@@ -1,12 +1,12 @@
 use dances::dance_response::ResponseStatusCode;
-use holons::query::{QueryExpression};
+use holons::query::QueryExpression;
 use dances::staging_area::StagingArea;
 use holons::commit_manager::StagedIndex;
 use holons::holon::{Holon, HolonState};
 use holons::holon_error::HolonError;
 use holons::holon_reference::HolonReference;
 use holons::relationship::RelationshipName;
-use shared_types_holon::{HolonId, MapInteger, MapString, PropertyMap, PropertyValue};
+use shared_types_holon::{HolonId, LocalId, MapInteger, MapString, PropertyMap, PropertyValue};
 use std::collections::VecDeque;
 use std::fmt;
 
@@ -34,6 +34,7 @@ pub enum DanceTestStep {
          Holon
     ), 
     DatabasePrint, // Writes log messages for each holon in the persistent store
+    DeleteHolon(ResponseStatusCode),
     EnsureDatabaseCount(MapInteger), // Ensures the expected number of holons exist in the DB
     StageHolon(Holon), // Associated data is expected Holon, it could be an empty Holon (i.e., with no internal state)
     Commit,            // Attempts to commit
@@ -67,6 +68,9 @@ impl fmt::Display for DanceTestStep {
             }
             DanceTestStep::DatabasePrint => {
                 write!(f, "DatabasePrint")
+            }
+            DanceTestStep::DeleteHolon(local_id) => {
+                write!(f, "DeleteHolon({:?})", local_id)
             }
             DanceTestStep::EnsureDatabaseCount(count) => {
                 write!(f, "EnsureDatabaseCount = {}", count.0)
@@ -169,6 +173,11 @@ impl DancesTestCase {
     }
     pub fn add_database_print_step(&mut self) -> Result<(), HolonError> {
         self.steps.push_back(DanceTestStep::DatabasePrint);
+        Ok(())
+    }
+    pub fn add_delete_holon_step(&mut self, expected_response: ResponseStatusCode) -> Result<(), HolonError> {
+        self.steps
+            .push_back(DanceTestStep::DeleteHolon(expected_response));
         Ok(())
     }
     pub fn add_ensure_database_count_step(&mut self, count: MapInteger) -> Result<(), HolonError> {

--- a/crates/coordinator/dances/tests/shared_test/test_delete_holon.rs
+++ b/crates/coordinator/dances/tests/shared_test/test_delete_holon.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use async_std::task;
+use dances::dance_response::ResponseBody::{Holons, Index};
+use dances::dance_response::{DanceResponse, ResponseStatusCode};
+use dances::holon_dance_adapter::{
+    build_delete_holon_dance_request, build_get_all_holons_dance_request,
+    build_get_holon_by_id_dance_request, build_stage_new_holon_dance_request,
+};
+use hdk::prelude::*;
+use holochain::sweettest::*;
+use holochain::sweettest::{SweetCell, SweetConductor};
+use rstest::*;
+
+use crate::shared_test::dance_fixtures::*;
+use crate::shared_test::test_data_types::DanceTestStep;
+use crate::shared_test::test_data_types::{DanceTestState, DancesTestCase};
+use crate::shared_test::*;
+use holons::helpers::*;
+use holons::holon::Holon;
+use holons::holon_api::*;
+use holons::holon_error::HolonError;
+use shared_types_holon::holon_node::{HolonNode, PropertyMap, PropertyName};
+use shared_types_holon::value_types::BaseValue;
+use shared_types_holon::{HolonId, LocalId, MapInteger, MapString};
+
+/// This function builds and dances a `delete_holon` DanceRequest for the supplied Holon
+/// and matches the expected response
+///
+
+pub async fn execute_delete_holon(
+    conductor: &SweetConductor,
+    cell: &SweetCell,
+    test_state: &mut DanceTestState,
+    expected_response: ResponseStatusCode,
+) -> () {
+    info!("\n\n--- TEST STEP: Staging a new Holon:");
+    // for now, there is always only 1 Holon in created_holons when testing a Delete,
+    // until support for retrieval by key is implemented in Issue 118
+    let holon_to_delete = &test_state.created_holons[0];
+    let local_id = holon_to_delete.get_local_id().unwrap();
+    // Build a stage_holon DanceRequest
+    let delete_holon_request =
+        build_delete_holon_dance_request(test_state.staging_area.clone(), local_id.clone());
+    debug!("delete_holon Dance Request: {:#?}", delete_holon_request);
+
+    match delete_holon_request {
+        Ok(valid_request) => {
+            let delete_holon_response: DanceResponse = conductor
+                .call(&cell.zome("dances"), "dance", valid_request)
+                .await;
+            debug!(
+                "delete_holon Dance Response: {:#?}",
+                delete_holon_response.clone()
+            );
+            let code = delete_holon_response.status_code;
+            assert_eq!(
+                code, expected_response,
+                "Returned {:?} did not match expected {:?}",
+                code, expected_response
+            );
+            let result = match expected_response {
+                ResponseStatusCode::OK => Ok(()),
+                _ => Err(code),
+            };
+
+            match result {
+                Ok(_) => {
+                    info!("Success! delete_holon returned OK response, confirming deletion...");
+                    let get_holon_by_id_request = build_get_holon_by_id_dance_request(
+                        test_state.staging_area.clone(),
+                        HolonId::Local(local_id.clone()),
+                    );
+                    match get_holon_by_id_request {
+                        Ok(valid_request) => {
+                            let get_holon_by_id_response: DanceResponse = conductor
+                                .call(&cell.zome("dances"), "dance", valid_request)
+                                .await;
+
+                            let code = get_holon_by_id_response.status_code;
+                            assert_eq!(code, ResponseStatusCode::NotFound);
+                        }
+                        Err(holon_error) => {
+                            panic!("{:?} Unable to build a stage_holon request ", holon_error);
+                        }
+                    }
+                }
+                Err(response) => {
+                    info!(
+                        "Success! delete_holon matched expected_response Error variant: {:?}",
+                        response
+                    );
+                }
+            }
+        }
+        Err(holon_error) => {
+            panic!("{:?} Unable to build a stage_holon request ", holon_error);
+        }
+    }
+}

--- a/crates/coordinator/holons/src/holon.rs
+++ b/crates/coordinator/holons/src/holon.rs
@@ -299,11 +299,12 @@ impl Holon {
     }
 
     pub fn delete_holon(id: LocalId) -> Result<ActionHash, HolonError> {
-        let result = delete_holon_node(id.0);
-        match result {
-            Ok(result) => Ok(result),
-            Err(error) => Err(HolonError::WasmError(error.to_string())),
-        }
+        let record = get(id.0.clone(), GetOptions::default())
+            .map_err(|e| HolonError::from(e))?
+            .ok_or_else(|| HolonError::HolonNotFound(format!("at id: {:?}", id.0)))?;
+        let mut holon = Holon::try_from_node(record)?;
+        holon.is_deletable()?;
+        delete_holon_node(id.0).map_err(|e| HolonError::from(e))
     }
 
     pub fn essential_content(&self) -> Result<EssentialHolonContent, HolonError> {
@@ -526,6 +527,22 @@ impl Holon {
     //         errors: self.errors.clone(),
     //     }
     // }
+
+    pub fn is_deletable(&mut self) -> Result<(), HolonError> {
+        let related_holons = self.get_all_related_holons()?;
+        if !related_holons.0.is_empty() {
+            let relationships = related_holons
+                .0
+                .keys()
+                .map(|name| name.0 .0.clone())
+                .collect::<Vec<String>>()
+                .join(", ");
+
+            Err(HolonError::DeletionNotAllowed(relationships))
+        } else {
+            Ok(())
+        }
+    }
 
     /// Ensures that the holon's `relationship_map` includes an entry for the specified relationship
     /// and returns a count of the number of holons in the holon collection for the specified

--- a/crates/coordinator/holons/src/holon.rs
+++ b/crates/coordinator/holons/src/holon.rs
@@ -529,19 +529,20 @@ impl Holon {
     // }
 
     pub fn is_deletable(&mut self) -> Result<(), HolonError> {
-        let related_holons = self.get_all_related_holons()?;
-        if !related_holons.0.is_empty() {
-            let relationships = related_holons
-                .0
-                .keys()
-                .map(|name| name.0 .0.clone())
-                .collect::<Vec<String>>()
-                .join(", ");
+        // let related_holons = self.get_all_related_holons()?;
+        // if !related_holons.0.is_empty() {
+        //     let relationships = related_holons
+        //         .0
+        //         .keys()
+        //         .map(|name| name.0 .0.clone())
+        //         .collect::<Vec<String>>()
+        //         .join(", ");
 
-            Err(HolonError::DeletionNotAllowed(relationships))
-        } else {
-            Ok(())
-        }
+        //     Err(HolonError::DeletionNotAllowed(relationships))
+        // } else {
+        //     Ok(())
+        // }
+        Ok(()) // always return Ok until support for get_all_related_holons
     }
 
     /// Ensures that the holon's `relationship_map` includes an entry for the specified relationship

--- a/crates/coordinator/holons/src/holon_error.rs
+++ b/crates/coordinator/holons/src/holon_error.rs
@@ -5,46 +5,50 @@ use thiserror::Error;
 #[hdk_entry_helper]
 #[derive(Error, Eq, PartialEq, Clone)]
 pub enum HolonError {
-    #[error("{0} field is missing")]
-    EmptyField(String),
-    #[error("{0} parameter is not valid")]
-    InvalidParameter(String),
     #[error("Holon not found: {0}")]
     HolonNotFound(String),
+    #[error("Cache Error: {0}")]
+    CacheError(String),
     #[error("Commit Failure {0}")]
     CommitFailure(String),
-    #[error("WasmError {0}")]
-    WasmError(String),
-    #[error("Couldn't convert Record to {0}")]
-    RecordConversion(String),
+    #[error(
+        "You must remove related holons from {0} relationship before you can delete this holon."
+    )]
+    DeletionNotAllowed(String),
+    #[error("{0} field is missing")]
+    EmptyField(String),
+    #[error("Failed to Borrow {0}")]
+    FailedToBorrow(String),
     #[error("Couldn't convert {0} into {1} ")]
     HashConversion(String, String),
-    #[error("Invalid HolonReference, {0}")]
-    InvalidHolonReference(String),
     #[error("Index {0} into Holons Vector is Out of Range")]
     IndexOutOfRange(String),
-    #[error("{0} Not Implemented")]
-    NotImplemented(String),
+    #[error("Invalid HolonReference, {0}")]
+    InvalidHolonReference(String),
+    #[error("{0} parameter is not valid")]
+    InvalidParameter(String),
+    #[error("{0} is not a valid relationship for this source holon type {1}")]
+    InvalidRelationship(String, String), // TODO: move this error to ValidationError
     #[error("Miscellaneous error: {0}")]
     Misc(String),
     #[error("{0} relationship is missing StagedCollection")]
     MissingStagedCollection(String),
-    #[error("Failed to Borrow {0}")]
-    FailedToBorrow(String),
-    #[error("to {0}")]
-    UnableToAddHolons(String),
-    #[error("{0} is not a valid relationship for this source holon type {1}")]
-    InvalidRelationship(String, String), // TODO: move this error to ValidationError
-    #[error("Cache Error: {0}")]
-    CacheError(String),
-    #[error("Validation error: {0}")]
-    ValidationError(ValidationError),
     #[error("{0} access not allowed while holon is in {1} state")]
     NotAccessible(String, String),
+    #[error("{0} Not Implemented")]
+    NotImplemented(String),
+    #[error("Couldn't convert Record to {0}")]
+    RecordConversion(String),
+    #[error("to {0}")]
+    UnableToAddHolons(String),
     #[error("Unable to cast {0} into expected ValueType: {1}")]
     UnexpectedValueType(String, String),
     #[error("Invalid UTF8: Couldn't convert {0} into {1}")]
     Utf8Conversion(String, String),
+    #[error("Validation error: {0}")]
+    ValidationError(ValidationError),
+    #[error("WasmError {0}")]
+    WasmError(String),
 }
 
 impl From<WasmError> for HolonError {


### PR DESCRIPTION
Notes:
- Holon::is_deletable() always returning Ok until support for get_all_related_holons
- executor designed to be flexible to pass any ResponseStatusCode error (although NotFound is the most logical/obvious and the only one being used in this issue)
- only 1 Holon is being created in the fixture until support for get by key for created_holons is available in the new BTreeMap design (see #118)