### PR TITLE
163 allow optional property values main

### DIFF
--- a/crates/holons_client/tests/shared_test/fixtures/abandon_staged_changes_fixture.rs
+++ b/crates/holons_client/tests/shared_test/fixtures/abandon_staged_changes_fixture.rs
@@ -77,11 +77,11 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     let mut abandoned_holon_1 = Holon::new();
     abandoned_holon_1.with_property_value(
         PropertyName(MapString("key".to_string())),
-        BaseValue::StringValue(MapString("Abandon1".to_string())),
+        Some(BaseValue::StringValue(MapString("Abandon1".to_string()))),
     )?;
     abandoned_holon_1.with_property_value(
         PropertyName(MapString("example abandon".to_string())),
-        BaseValue::StringValue(MapString("test1".to_string())),
+        Some(BaseValue::StringValue(MapString("test1".to_string()))),
     )?;
     test_case.add_stage_holon_step(abandoned_holon_1.clone())?;
     expected_count += 1;
@@ -90,11 +90,11 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     let mut abandoned_holon_2 = Holon::new();
     abandoned_holon_2.with_property_value(
         PropertyName(MapString("key".to_string())),
-        BaseValue::StringValue(MapString("Abandon2".to_string())),
+        Some(BaseValue::StringValue(MapString("Abandon2".to_string()))),
     )?;
     abandoned_holon_2.with_property_value(
         PropertyName(MapString("example abandon".to_string())),
-        BaseValue::StringValue(MapString("test2".to_string())),
+        Some(BaseValue::StringValue(MapString("test2".to_string()))),
     )?;
     test_case.add_stage_holon_step(abandoned_holon_2.clone())?;
     expected_count += 1;

--- a/crates/holons_client/tests/shared_test/fixtures/book_authors_setup_fixture_with_context.rs
+++ b/crates/holons_client/tests/shared_test/fixtures/book_authors_setup_fixture_with_context.rs
@@ -42,17 +42,17 @@ pub fn setup_book_author_steps_with_context(
     book_holon
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(book_holon_key.clone()),
+            Some(BaseValue::StringValue(book_holon_key.clone())),
         )?
         .with_property_value(
             PropertyName(MapString("title".to_string())),
-            BaseValue::StringValue(book_holon_key.clone()),
+            Some(BaseValue::StringValue(book_holon_key.clone())),
         )?
         .with_property_value(
             PropertyName(MapString("description".to_string())),
-            BaseValue::StringValue(MapString(
+            Some(BaseValue::StringValue(MapString(
                 "Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_string(),
-            )),
+            ))),
         )?;
     test_case.add_stage_holon_step(book_holon.clone())?;
     let book_ref = stage_new_holon_api(context, book_holon)?;
@@ -64,15 +64,15 @@ pub fn setup_book_author_steps_with_context(
     person_1_holon
         .with_property_value(
             PropertyName(MapString("first name".to_string())),
-            BaseValue::StringValue(MapString("Roger".to_string())),
+            Some(BaseValue::StringValue(MapString("Roger".to_string()))),
         )?
         .with_property_value(
             PropertyName(MapString("last name".to_string())),
-            BaseValue::StringValue(MapString("Briggs".to_string())),
+            Some(BaseValue::StringValue(MapString("Briggs".to_string()))),
         )?
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(person_1_key.clone()),
+            Some(BaseValue::StringValue(person_1_key.clone())),
         )?;
     test_case.add_stage_holon_step(person_1_holon.clone())?;
     let person_1_reference = stage_new_holon_api(context, person_1_holon.clone())?;
@@ -84,15 +84,15 @@ pub fn setup_book_author_steps_with_context(
     person_2_holon
         .with_property_value(
             PropertyName(MapString("first name".to_string())),
-            BaseValue::StringValue(MapString("George".to_string())),
+            Some(BaseValue::StringValue(MapString("George".to_string()))),
         )?
         .with_property_value(
             PropertyName(MapString("last name".to_string())),
-            BaseValue::StringValue(MapString("Smith".to_string())),
+            Some(BaseValue::StringValue(MapString("Smith".to_string()))),
         )?
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(person_2_key.clone()),
+            Some(BaseValue::StringValue(person_2_key.clone())),
         )?;
     test_case.add_stage_holon_step(person_2_holon.clone())?;
     let person_2_reference = stage_new_holon_api(context, person_2_holon.clone())?;
@@ -104,15 +104,15 @@ pub fn setup_book_author_steps_with_context(
     publisher_holon
         .with_property_value(
             PropertyName(MapString("name".to_string())),
-            BaseValue::StringValue(publisher_key.clone()),
+            Some(BaseValue::StringValue(publisher_key.clone())),
         )?
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(publisher_key.clone()),
+            Some(BaseValue::StringValue(publisher_key.clone())),
         )?
         .with_property_value(
             PropertyName(MapString("description".to_string())),
-            BaseValue::StringValue(MapString("We publish Holons for testing purposes".to_string())),
+            Some(BaseValue::StringValue(MapString("We publish Holons for testing purposes".to_string()))),
         )?;
     test_case.add_stage_holon_step(publisher_holon.clone())?;
     stage_new_holon_api(context, publisher_holon.clone())?;

--- a/crates/holons_client/tests/shared_test/fixtures/delete_holon_fixture.rs
+++ b/crates/holons_client/tests/shared_test/fixtures/delete_holon_fixture.rs
@@ -35,17 +35,17 @@ pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
     );
     book_holon.with_property_value(
         PropertyName(MapString("key".to_string())),
-        BaseValue::StringValue(book_holon_key.clone()),
-    )?;
+        Some(BaseValue::StringValue(book_holon_key.clone()),
+    ))?;
     book_holon.with_property_value(
         PropertyName(MapString("title".to_string())),
-        BaseValue::StringValue(MapString(
+        Some(BaseValue::StringValue(MapString(
             "Emerging World: The Evolution of Consciousness and the Future of Humanity".to_string(),
         )),
-    )?.with_property_value(
+    ))?.with_property_value(
         PropertyName(MapString("description".to_string())),
-        BaseValue::StringValue(MapString("Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_string())),
-    )?;
+        Some(BaseValue::StringValue(MapString("Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_string())),
+    ))?;
     test_case.add_stage_holon_step(book_holon)?;
 
     // ADD STEP:  COMMIT  // all Holons in staging_area

--- a/crates/holons_client/tests/shared_test/fixtures/stage_new_from_clone_fixture.rs
+++ b/crates/holons_client/tests/shared_test/fixtures/stage_new_from_clone_fixture.rs
@@ -129,15 +129,15 @@ pub fn simple_stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonErro
     let cloned_holon_key = MapString("A clone of original publisher".to_string());
     changed_properties.insert(
         PropertyName(MapString("title".to_string())),
-        BaseValue::StringValue(cloned_holon_key.clone()),
+        Some(BaseValue::StringValue(cloned_holon_key.clone())),
     );
     changed_properties.insert(
         PropertyName(MapString("key".to_string())),
-        BaseValue::StringValue(cloned_holon_key.clone()),
+        Some(BaseValue::StringValue(cloned_holon_key.clone())),
     );
     changed_properties.insert(
         PropertyName(MapString("description".to_string())),
-        BaseValue::StringValue(MapString("this is testing a clone from a saved Holon, changing it, modifying relationships, then committing".to_string())),
+        Some(BaseValue::StringValue(MapString("this is testing a clone from a saved Holon, changing it, modifying relationships, then committing".to_string()))),
     );
 
     test_case.add_with_properties_step(

--- a/crates/holons_client/tests/shared_test/test_abandon_staged_changes.rs
+++ b/crates/holons_client/tests/shared_test/test_abandon_staged_changes.rs
@@ -58,7 +58,7 @@ pub async fn execute_abandon_staged_changes(
                 abandoned_holon.with_property_value(
                     context, // ✅ Pass context for proper behavior
                     PropertyName(MapString("some_name".to_string())),
-                    BaseValue::BooleanValue(MapBoolean(true))
+                    Some(BaseValue::BooleanValue(MapBoolean(true)))
                 ),
                 Err(HolonError::NotAccessible(_, _))
             ));

--- a/crates/holons_core/src/reference_layer/holon_operations_api.rs
+++ b/crates/holons_core/src/reference_layer/holon_operations_api.rs
@@ -137,12 +137,18 @@ fn get_holon_service(context: &dyn HolonsContextBehavior) -> Arc<dyn HolonServic
     Arc::clone(&holon_service)
 }
 
-pub fn get_key_from_property_map(map: &PropertyMap) -> Option<MapString> {
+pub fn get_key_from_property_map(map: &PropertyMap) -> Result<Option<MapString>, HolonError> {
     let key_option = map.get(&PropertyName(MapString("key".to_string())));
-    if let Some(key) = key_option {
-        Some(MapString(key.into()))
+    if let Some(Some(inner_value)) = key_option {
+        let string_value: String = inner_value.try_into().map_err(|_| {
+            HolonError::UnexpectedValueType(
+                format!("{:?}", inner_value),
+                "MapString".to_string(),
+            )
+        })?;
+        Ok(Some(MapString(string_value)))
     } else {
-        None
+        Ok(None)
     }
 }
 

--- a/crates/holons_core/src/reference_layer/holon_readable.rs
+++ b/crates/holons_core/src/reference_layer/holon_readable.rs
@@ -14,7 +14,7 @@ pub trait HolonReadable {
         &self,
         context: &dyn HolonsContextBehavior,
         property_name: &PropertyName,
-    ) -> Result<PropertyValue, HolonError>;
+    ) -> Result<Option<PropertyValue>, HolonError>;
 
     /// This function returns the primary key value for the holon or None if there is no key value
     /// for this holon (NOTE: Not all holon types have defined keys.)

--- a/crates/holons_core/src/reference_layer/holon_reference.rs
+++ b/crates/holons_core/src/reference_layer/holon_reference.rs
@@ -33,7 +33,7 @@ impl HolonReadable for HolonReference {
         &self,
         context: &dyn HolonsContextBehavior,
         property_name: &PropertyName,
-    ) -> Result<PropertyValue, HolonError> {
+    ) -> Result<Option<PropertyValue>, HolonError> {
         match self {
             HolonReference::Smart(smart_reference) => {
                 smart_reference.get_property_value(context, property_name)

--- a/crates/holons_core/src/reference_layer/holon_writable.rs
+++ b/crates/holons_core/src/reference_layer/holon_writable.rs
@@ -54,6 +54,6 @@ pub trait HolonWritable {
         &self,
         context: &dyn HolonsContextBehavior,
         property: PropertyName,
-        value: BaseValue,
+        value: Option<BaseValue>,
     ) -> Result<&Self, HolonError>;
 }

--- a/crates/holons_core/src/reference_layer/smart_reference.rs
+++ b/crates/holons_core/src/reference_layer/smart_reference.rs
@@ -201,8 +201,11 @@ impl fmt::Display for SmartReference {
         match &self.smart_property_values {
             Some(props) if !props.is_empty() => {
                 // Display the first 2 properties as a preview, followed by a count if there are more
-                let preview: Vec<String> =
-                    props.iter().take(2).map(|(key, value)| format!("{}:{}", key, value)).collect();
+                let preview: Vec<String> = props
+                    .iter()
+                    .take(2)
+                    .map(|(key, value)| format!("{}:{:?}", key, value))
+                    .collect();
 
                 let additional_count = props.len().saturating_sub(preview.len());
 
@@ -242,7 +245,7 @@ impl HolonReadable for SmartReference {
         &self,
         context: &dyn HolonsContextBehavior,
         property_name: &PropertyName,
-    ) -> Result<PropertyValue, HolonError> {
+    ) -> Result<Option<PropertyValue>, HolonError> {
         // Check if the property value is available in smart_property_values
         if let Some(smart_map) = &self.smart_property_values {
             if let Some(value) = smart_map.get(property_name) {
@@ -256,26 +259,40 @@ impl HolonReadable for SmartReference {
         Ok(prop_val)
     }
 
-    /// This function extracts the key from the smart_property_values or, failing that, from
-    /// its referenced holon
+    /// This function extracts the key from the smart_property_values or, if not found there, from
+    /// its referenced holon. Returns an Option -- as even though an entry for 'key' may be present in the BTreeMap, the value could be None.
     ///
     fn get_key(
         &self,
         context: &dyn HolonsContextBehavior,
     ) -> Result<Option<MapString>, HolonError> {
-        if let Some(smart_prop_vals) = self.smart_property_values.clone() {
-            let key_option = smart_prop_vals.get(&PropertyName(MapString("key".to_string())));
-            if let Some(key) = key_option {
-                Ok(Some(MapString(key.into())))
-            } else {
-                let holon = self.get_rc_holon(context)?;
-                let key = holon.borrow().get_key()?;
-                Ok(key)
+        // Since smart_property_values is an optional PropertyMap, first check to see if one exists..
+        if let Some(smart_property_values) = self.smart_property_values.clone() {
+            // If found, do a get on the PropertyMap to see if it contains a value.
+            if let Some(Some(inner_value)) = smart_property_values.get(&PropertyName(MapString("key".to_string()))) {
+                // Try to convert a Some value to String, throws an error on failure because all values for the Key 'key' should be MapString.
+                let string_value: String = inner_value.try_into().map_err(|_| {
+                    HolonError::UnexpectedValueType(
+                        format!("{:?}", inner_value),
+                        "MapString".to_string(),
+                    )
+                })?;
+                Ok(Some(MapString(string_value)))
+            } 
+            else {
+                Ok(None)
             }
-        } else {
+        }
+        // Then if not, check the reference..
+         else {
             let holon = self.get_rc_holon(context)?;
-            let key = holon.borrow().get_key()?;
-            Ok(key)
+            let key_option = holon.borrow().get_key()?;
+            if let Some(key) = key_option {
+                Ok(Some(key))
+            }
+            else {
+                Ok(None)
+            }
         }
     }
 

--- a/crates/holons_core/src/reference_layer/staged_reference.rs
+++ b/crates/holons_core/src/reference_layer/staged_reference.rs
@@ -88,7 +88,7 @@ impl HolonReadable for StagedReference {
         &self,
         context: &dyn HolonsContextBehavior,
         property_name: &PropertyName,
-    ) -> Result<PropertyValue, HolonError> {
+    ) -> Result<Option<PropertyValue>, HolonError> {
         let rc_holon = self.get_rc_holon(context)?;
         let borrowed_holon = rc_holon.borrow();
         borrowed_holon.get_property_value(property_name)
@@ -324,7 +324,7 @@ impl HolonWritable for StagedReference {
         &self,
         context: &dyn HolonsContextBehavior,
         property: PropertyName,
-        value: BaseValue,
+        value: Option<BaseValue>,
     ) -> Result<&Self, HolonError> {
         let rc_holon = self.get_rc_holon(context)?;
         let mut holon_refcell = rc_holon.borrow_mut();

--- a/crates/holons_core/src/utils/json_adapter.rs
+++ b/crates/holons_core/src/utils/json_adapter.rs
@@ -133,10 +133,22 @@ impl<'a> Serialize for PropertyMapWrapper<'a> {
         let mut map = serializer.serialize_map(Some(self.0.len()))?;
         for (k, v) in self.0 {
             match v {
-                BaseValue::StringValue(s) => map.serialize_entry(&k.0, &s.0)?,
-                BaseValue::BooleanValue(b) => map.serialize_entry(&k.0, &b.0)?,
-                BaseValue::IntegerValue(i) => map.serialize_entry(&k.0, &i.0)?,
-                BaseValue::EnumValue(e) => map.serialize_entry(&k.0, &e.0)?,
+                Some(BaseValue::StringValue(s)) => map.serialize_entry(&k.0, &s.0)?,
+                Some(BaseValue::BooleanValue(b)) => map.serialize_entry(&k.0, &b.0)?,
+                Some(BaseValue::IntegerValue(i)) => map.serialize_entry(&k.0, &i.0)?,
+                Some(BaseValue::EnumValue(e)) => map.serialize_entry(&k.0, &e.0)?,
+                None => {
+                    // Handle None entries:
+                    // Option 1: Skip the entry entirely
+                    // Option 2: Serialize as null
+                    // Option 3: Custom logic (e.g., default value)
+
+                    // Option 1 (Skipping the entry):
+                    // Simply omit None values by doing nothing here.
+
+                    // Option 2 (Serialize None as null):
+                    // map.serialize_entry(&k.0, &serde_json::Value::Null)?;
+                }
             }
         }
         map.end()

--- a/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -300,7 +300,7 @@ fn save_smartlinks_for_collection(
                 let mut prop_vals: PropertyMap = BTreeMap::new();
                 prop_vals.insert(
                     PropertyName(MapString("key".to_string())),
-                    BaseValue::StringValue(key),
+                    Some(BaseValue::StringValue(key)),
                 );
                 SmartLink {
                     from_address: source_id.clone(),

--- a/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
+++ b/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
@@ -117,15 +117,15 @@ impl GuestHolonService {
         space_holon
             .with_property_value(
                 PropertyName(MapString("name".to_string())),
-                name.clone().into_base_value(),
+                Some(name.clone().into_base_value()),
             )?
             .with_property_value(
                 PropertyName(MapString("key".to_string())),
-                name.clone().into_base_value(),
+                Some(name.clone().into_base_value()),
             )?
             .with_property_value(
                 PropertyName(MapString("description".to_string())),
-                description.into_base_value(),
+                Some(description.into_base_value()),
             )?;
 
         // Try to create the holon node in the DHT
@@ -288,7 +288,7 @@ impl HolonServiceApi for GuestHolonService {
 
         for smartlink in smartlinks {
             let holon_reference = smartlink.to_holon_reference();
-            collection.add_reference_with_key(smartlink.get_key().as_ref(), &holon_reference)?;
+            collection.add_reference_with_key(smartlink.get_key()?.as_ref(), &holon_reference)?;
         }
         Ok(collection)
     }

--- a/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
+++ b/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
@@ -340,7 +340,9 @@ fn encode_link_tag(
             bytes.extend_from_slice(property.0 .0.as_bytes());
             bytes.extend_from_slice(&UNICODE_NUL_STR.as_bytes());
             bytes.extend_from_slice(&PROPERTY_VALUE_SEPARATOR);
-            bytes.extend_from_slice(&value.into_bytes().0);
+            if let Some(value) = value {
+                bytes.extend_from_slice(&value.into_bytes().0);
+            }
             bytes.extend_from_slice(&UNICODE_NUL_STR.as_bytes());
         }
     }

--- a/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
+++ b/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
@@ -36,11 +36,11 @@ impl SmartLink {
     /// KEY_PROPERTIES relationship. However, the current parameters to this function are not
     /// sufficient to do this.
     /// TODO: update this function to align with described key property list design
-    pub fn get_key(&self) -> Option<MapString> {
+    pub fn get_key(&self) -> Result<Option<MapString>, HolonError> {
         if let Some(ref map) = self.smart_property_values {
             get_key_from_property_map(map)
         } else {
-            None
+            Ok(None)
         }
     }
     pub fn to_holon_reference(&self) -> HolonReference {
@@ -303,7 +303,7 @@ fn decode_link_tag(link_tag: LinkTag) -> Result<LinkTagObject, HolonError> {
 
                 property_map.insert(
                     PropertyName(MapString(property_name.to_string())),
-                    BaseValue::StringValue(MapString(property_value.to_string())),
+                    Some(BaseValue::StringValue(MapString(property_value.to_string()))),
                 );
             }
         }
@@ -446,13 +446,13 @@ mod tests {
         let mut property_values: PropertyMap = BTreeMap::new();
         let name_1 = PropertyName(MapString("ex_name_1".to_string()));
         let value_1 = BaseValue::StringValue(MapString("ex_value_1".to_string()));
-        property_values.insert(name_1, value_1);
+        property_values.insert(name_1, Some(value_1));
         let name_2 = PropertyName(MapString("ex_name_2".to_string()));
         let value_2 = BaseValue::StringValue(MapString("ex_value_2".to_string()));
-        property_values.insert(name_2, value_2);
+        property_values.insert(name_2, Some(value_2));
         let name_3 = PropertyName(MapString("ex_name_3".to_string()));
         let value_3 = BaseValue::StringValue(MapString("ex_value_3".to_string()));
-        property_values.insert(name_3, value_3);
+        property_values.insert(name_3, Some(value_3));
 
         let encoded_link_tag =
             encode_link_tag(&relationship_name, holon_id, Some(property_values.clone())).unwrap();

--- a/crates/shared_types/holon/src/holon_node.rs
+++ b/crates/shared_types/holon/src/holon_node.rs
@@ -15,7 +15,7 @@ pub const LOCAL_HOLON_SPACE_DESCRIPTION: &str = "Default Local Holon Space";
 // 📦 Type Aliases
 // ===============================
 pub type PropertyValue = BaseValue;
-pub type PropertyMap = BTreeMap<PropertyName, PropertyValue>;
+pub type PropertyMap = BTreeMap<PropertyName, Option<PropertyValue>>;
 
 // ===============================
 // 🌳 HolonNode Struct (holochain EntryType)

--- a/zomes/coordinator/descriptors/src/boolean_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/boolean_descriptor.rs
@@ -41,11 +41,11 @@ pub fn define_boolean_type(
     boolean_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             TypeName.as_property_name(),
-            BaseValue::StringValue(definition.type_name),
+            Some(BaseValue::StringValue(definition.type_name)),
         )?;
 
     // Stage the type

--- a/zomes/coordinator/descriptors/src/collection_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/collection_descriptor.rs
@@ -69,37 +69,37 @@ pub fn define_collection_type(
     collection_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(collection_type_name.clone()),
+            Some(BaseValue::StringValue(collection_type_name.clone())),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::MaxCardinality.as_snake_case().to_string(),
             )),
-            BaseValue::IntegerValue(definition.max_cardinality),
+            Some(BaseValue::IntegerValue(definition.max_cardinality)),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::MinCardinality.as_snake_case().to_string(),
             )),
-            BaseValue::IntegerValue(definition.min_cardinality),
+            Some(BaseValue::IntegerValue(definition.min_cardinality)),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::AllowsDuplicates.as_snake_case().to_string(),
             )),
-            BaseValue::BooleanValue(definition.allows_duplicates),
+            Some(BaseValue::BooleanValue(definition.allows_duplicates)),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::IsOrdered.as_snake_case().to_string(),
             )),
-            BaseValue::BooleanValue(definition.is_ordered),
+            Some(BaseValue::BooleanValue(definition.is_ordered)),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::TypeName.as_snake_case().to_string(),
             )),
-            BaseValue::StringValue(collection_type_name),
+            Some(BaseValue::StringValue(collection_type_name)),
         )?;
 
     // Stage the type

--- a/zomes/coordinator/descriptors/src/enum_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/enum_descriptor.rs
@@ -53,11 +53,11 @@ pub fn define_enum_type(
     enum_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             TypeName.as_property_name(),
-            BaseValue::StringValue(definition.type_name),
+            Some(BaseValue::StringValue(definition.type_name)),
         )?;
 
     // Stage the type

--- a/zomes/coordinator/descriptors/src/enum_variant_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/enum_variant_descriptor.rs
@@ -50,15 +50,15 @@ pub fn define_enum_variant_type(
     enum_variant_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             TypeName.as_property_name(),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             VariantOrder.as_property_name(),
-            BaseValue::IntegerValue(definition.variant_order),
+            Some(BaseValue::IntegerValue(definition.variant_order)),
         )?;
 
     // Stage the type

--- a/zomes/coordinator/descriptors/src/holon_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/holon_descriptor.rs
@@ -52,13 +52,13 @@ pub fn define_holon_type(
     holon_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::TypeName.as_snake_case().to_string(),
             )),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?;
 
     debug!("Staging new holon_type {:#?}", holon_type.clone());

--- a/zomes/coordinator/descriptors/src/integer_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/integer_descriptor.rs
@@ -39,21 +39,21 @@ pub fn define_integer_type(
     integer_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             PropertyName(MapString(
                 CoreSchemaPropertyTypeName::TypeName.as_snake_case().to_string(),
             )),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             CoreSchemaPropertyTypeName::MinValue.as_property_name(),
-            BaseValue::IntegerValue(definition.min_value),
+            Some(BaseValue::IntegerValue(definition.min_value)),
         )?
         .with_property_value(
             CoreSchemaPropertyTypeName::MaxValue.as_property_name(),
-            BaseValue::IntegerValue(definition.max_value),
+            Some(BaseValue::IntegerValue(definition.max_value)),
         )?;
 
     // Stage new holon type

--- a/zomes/coordinator/descriptors/src/property_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/property_descriptor.rs
@@ -42,11 +42,11 @@ pub fn define_property_type(
     property_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.property_name.0.clone()),
+            Some(BaseValue::StringValue(definition.property_name.0.clone())),
         )?
         .with_property_value(
             CoreSchemaPropertyTypeName::PropertyTypeName.as_property_name(),
-            BaseValue::StringValue(definition.property_name.0.clone()),
+            Some(BaseValue::StringValue(definition.property_name.0.clone())),
         )?;
 
     // Stage the PropertyType

--- a/zomes/coordinator/descriptors/src/relationship_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/relationship_descriptor.rs
@@ -79,27 +79,27 @@ pub fn define_relationship_type(
     relationship_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.relationship_type_name.0.clone()),
+            Some(BaseValue::StringValue(definition.relationship_type_name.0.clone())),
         )?
         .with_property_value(
             CoreSchemaPropertyTypeName::RelationshipName.as_property_name(),
-            BaseValue::StringValue(definition.relationship_type_name.0.clone()),
+            Some(BaseValue::StringValue(definition.relationship_type_name.0.clone())),
         )?
         .with_property_value(
             PropertyName(MapString("source_owns_relationship".to_string())),
-            BaseValue::BooleanValue(definition.source_owns_relationship),
+            Some(BaseValue::BooleanValue(definition.source_owns_relationship)),
         )?
         .with_property_value(
             PropertyName(MapString("load_links_immediate".to_string())),
-            BaseValue::BooleanValue(definition.load_links_immediate),
+            Some(BaseValue::BooleanValue(definition.load_links_immediate)),
         )?
         .with_property_value(
             PropertyName(MapString("load_holons_immediate".to_string())),
-            BaseValue::BooleanValue(definition.load_holons_immediate),
+            Some(BaseValue::BooleanValue(definition.load_holons_immediate)),
         )?
         .with_property_value(
             PropertyName(MapString("deletion_semantic".to_string())),
-            BaseValue::EnumValue(definition.deletion_semantic.to_enum_variant()),
+            Some(BaseValue::EnumValue(definition.deletion_semantic.to_enum_variant())),
         )?;
 
     debug!("Staging new relationship_type {:#?}", relationship_type.clone());

--- a/zomes/coordinator/descriptors/src/schema.rs
+++ b/zomes/coordinator/descriptors/src/schema.rs
@@ -18,15 +18,15 @@ impl Schema {
         schema_holon
             .with_property_value(
                 PropertyName(key_property_name),
-                BaseValue::StringValue(name.clone()),
+                Some(BaseValue::StringValue(name.clone())),
             )?
             .with_property_value(
                 PropertyName(name_property_name),
-                BaseValue::StringValue(name.clone()),
+                Some(BaseValue::StringValue(name.clone())),
             )?
             .with_property_value(
                 PropertyName(description_property_name),
-                BaseValue::StringValue(description),
+                Some(BaseValue::StringValue(description)),
             )?;
 
         Ok(Schema(schema_holon))

--- a/zomes/coordinator/descriptors/src/semantic_version.rs
+++ b/zomes/coordinator/descriptors/src/semantic_version.rs
@@ -34,15 +34,15 @@ pub fn set_semantic_version(major: i64, minor: i64, patch: i64) -> Result<Holon,
     version
         .with_property_value(
             PropertyName(MapString("major".to_string())),
-            BaseValue::IntegerValue(MapInteger(major)),
+            Some(BaseValue::IntegerValue(MapInteger(major))),
         )?
         .with_property_value(
             PropertyName(MapString("minor".to_string())),
-            BaseValue::IntegerValue(MapInteger(minor)),
+            Some(BaseValue::IntegerValue(MapInteger(minor))),
         )?
         .with_property_value(
             PropertyName(MapString("patch".to_string())),
-            BaseValue::IntegerValue(MapInteger(patch)),
+            Some(BaseValue::IntegerValue(MapInteger(patch))),
         )?;
 
     Ok(version)

--- a/zomes/coordinator/descriptors/src/string_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/string_descriptor.rs
@@ -47,19 +47,19 @@ pub fn define_string_type(
     string_type
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             TypeName.as_property_name(),
-            BaseValue::StringValue(definition.type_name.clone()),
+            Some(BaseValue::StringValue(definition.type_name.clone())),
         )?
         .with_property_value(
             MinLength.as_property_name(),
-            BaseValue::IntegerValue(definition.min_length),
+            Some(BaseValue::IntegerValue(definition.min_length)),
         )?
         .with_property_value(
             MaxLength.as_property_name(),
-            BaseValue::IntegerValue(definition.max_length),
+            Some(BaseValue::IntegerValue(definition.max_length)),
         )?;
 
     // Stage new string type

--- a/zomes/coordinator/descriptors/src/type_descriptor.rs
+++ b/zomes/coordinator/descriptors/src/type_descriptor.rs
@@ -59,32 +59,32 @@ pub fn define_type_descriptor(
     descriptor
         .with_property_value(
             PropertyName(MapString("key".to_string())),
-            BaseValue::StringValue(definition.descriptor_name.clone()),
+            Some(BaseValue::StringValue(definition.descriptor_name.clone())),
         )?
         .with_property_value(
             DescriptorName.as_property_name(),
-            BaseValue::StringValue(definition.descriptor_name.clone()),
+            Some(BaseValue::StringValue(definition.descriptor_name.clone())),
         )?
         .with_property_value(
             Description.as_property_name(),
-            BaseValue::StringValue(definition.description),
+            Some(BaseValue::StringValue(definition.description)),
         )?
-        .with_property_value(Label.as_property_name(), BaseValue::StringValue(definition.label))?
+        .with_property_value(Label.as_property_name(), Some(BaseValue::StringValue(definition.label)))?
         .with_property_value(
             CoreSchemaPropertyTypeName::BaseType.as_property_name(),
-            BaseValue::EnumValue(MapEnumValue(MapString(base_type.to_string()))),
+            Some(BaseValue::EnumValue(MapEnumValue(MapString(base_type.to_string())))),
         )?
         .with_property_value(
             PropertyName(MapString("is_dependent".to_string())),
-            BaseValue::BooleanValue(definition.is_dependent),
+            Some(BaseValue::BooleanValue(definition.is_dependent)),
         )?
         .with_property_value(
             PropertyName(MapString("is_value_descriptor".to_string())),
-            BaseValue::BooleanValue(definition.is_value_type),
+            Some(BaseValue::BooleanValue(definition.is_value_type)),
         )?
         .with_property_value(
             PropertyName(MapString("version".to_string())),
-            BaseValue::StringValue(initial_version),
+            Some(BaseValue::StringValue(initial_version)),
         )?;
 
     // Stage the new TypeDescriptor


### PR DESCRIPTION
Code has been updated to handle optional properties and all sweetests pass. Remaining changes on the descriptor side to allow property descriptors to specify whether a property is required or optional and on the core_schema_loader to specify which core properties are required and which are optional is being deferred to Issue #236.