### PR TITLE
made DanceResponse summarize more shallow to prevent test hangs

### DIFF
--- a/tests/sweetests/tests/execution_steps/new_holon_executor.rs
+++ b/tests/sweetests/tests/execution_steps/new_holon_executor.rs
@@ -1,5 +1,5 @@
 use holons_prelude::prelude::*;
-use holons_test::{ExecutionReference, ExecutionHandle, TestExecutionState, TestReference};
+use holons_test::{ExecutionHandle, ExecutionReference, TestExecutionState, TestReference};
 use integrity_core_types::PropertyMap;
 use pretty_assertions::assert_eq;
 use tracing::{debug, info};
@@ -22,9 +22,8 @@ pub async fn execute_new_holon(
 
     // 2. CALL - the dance
     let dance_initiator = context.get_dance_initiator().unwrap();
-    let response = dance_initiator.initiate_dance(&context, request)
-.await;
-    info!("Dance Response: {:#?}", response.clone());
+    let response = dance_initiator.initiate_dance(&context, request).await;
+    info!("Dance Response: {}", response.summarize());
 
     // 3. VALIDATE - response status
     assert_eq!(
@@ -56,8 +55,7 @@ pub async fn execute_new_holon(
         ExecutionReference::from_token_execution(&source_token, execution_handle);
 
     // Validate expected vs execution-time content
-    execution_reference.assert_essential_content_eq()
-;
+    execution_reference.assert_essential_content_eq();
     info!("Success! Holon's essential content matched expected");
 
     // Record for downstream resolution

--- a/tests/sweetests/tests/execution_steps/stage_new_holon_executor.rs
+++ b/tests/sweetests/tests/execution_steps/stage_new_holon_executor.rs
@@ -1,4 +1,4 @@
-use holons_test::{ExecutionReference, ExecutionHandle, TestExecutionState, TestReference};
+use holons_test::{ExecutionHandle, ExecutionReference, TestExecutionState, TestReference};
 use pretty_assertions::assert_eq;
 use tracing::{debug, info};
 
@@ -18,8 +18,7 @@ pub async fn execute_stage_new_holon(
 
     // 1. LOOKUP — get the input handle for the source token
     let source_reference: HolonReference =
-        state.resolve_source_reference(&context, &source_token)
-.unwrap();
+        state.resolve_source_reference(&context, &source_token).unwrap();
 
     // Can only stage Transient
     let transient_reference = match source_reference {
@@ -35,9 +34,8 @@ pub async fn execute_stage_new_holon(
 
     // 3. CALL - the dance
     let dance_initiator = context.get_dance_initiator().unwrap();
-    let response = dance_initiator.initiate_dance(&context, request)
-.await;
-    info!("Dance Response: {:#?}", response.clone());
+    let response = dance_initiator.initiate_dance(&context, request).await;
+    info!("Dance Response: {}", response.summarize());
 
     // 4. VALIDATE - response status
     assert_eq!(
@@ -64,8 +62,7 @@ pub async fn execute_stage_new_holon(
             ExecutionReference::from_token_execution(&source_token, execution_handle);
 
         // Validate expected vs execution-time content
-        execution_reference.assert_essential_content_eq()
-;
+        execution_reference.assert_essential_content_eq();
         info!("Success! Staged holon's essential content matched expected");
 
         // 6. RECORD — make execution result available for downstream steps


### PR DESCRIPTION
## PR: Make `DanceResponse` Logging Shallow and Trace-Safe

### Summary

This PR updates `DanceResponse::summarize()` to avoid deep debug traversal of transaction-bound runtime graphs when logging.

After the Phase 1.2 transaction-aware reference refactor, `DanceResponse` contains tx-bound holon references. Formatting these with `{:#?}` can traverse:

* `HolonReference`
* `TransactionContextHandle`
* `Arc<TransactionContext>`
* Pools, staged holons, relationships, etc.

With tracing enabled, this caused severe performance degradation and apparent test hangs as the object graph grew.

---

### What Changed

* `DanceResponse::summarize()` now:

  * Avoids formatting full runtime references
  * Avoids traversing `TransactionContextHandle`
  * Logs only shallow identifiers and counts (e.g. holon IDs, tx_id)
* No changes to runtime behavior or transaction logic
* No changes to wire types or binding behavior

This strictly affects logging behavior.

---

### Why This Is Safe

* No functional logic modified
* No change to reference semantics
* No change to transaction provenance
* Only reduces logging surface depth

---

### Result

* Tests complete successfully with tracing enabled
* No more trace-level hangs due to debug graph traversal
* Logs remain readable and informative
* Logging cost remains bounded as state grows

