### PR TITLE
441 post pr440 hardening complete recovery wiring and receptor runtime finalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,9 +4092,11 @@ version = "0.1.0"
 dependencies = [
  "base_types",
  "core_types",
+ "holons_client",
  "holons_core",
  "holons_loader_client",
  "map_commands_contract",
+ "recovery_receptor",
  "serde_json",
  "tokio",
 ]

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -5220,9 +5220,11 @@ version = "0.1.0"
 dependencies = [
  "base_types",
  "core_types",
+ "holons_client",
  "holons_core",
  "holons_loader_client",
  "map_commands_contract",
+ "recovery_receptor",
  "serde_json",
  "tokio",
 ]

--- a/host/conductora/src/map_commands/root_space.rs
+++ b/host/conductora/src/map_commands/root_space.rs
@@ -7,11 +7,12 @@ use tauri::{command, State};
 pub async fn root_space (
     _receptor_factory: State<'_, ReceptorFactory>,
 ) -> Result<SpaceInfo, String> {
-    unimplemented!("This command is currently a placeholder and needs to be implemented to fetch the root space information from the appropriate receptor.");
-
+    tracing::warn!("[TAURI COMMAND] 'root_space' invoked but not implemented; returning typed error");
+    Err("root_space command is not implemented. Use dispatch_map_command instead or see issue #441 for follow-up.".to_string())
+}
     //tracing::debug!("[TAURI COMMAND] 'root_space' command invoked");
     //let spaces = receptor_factory.all_spaces_by_type(&ReceptorType::Local)
      //   .await
       //  .map_err(|e| format!("receptor service error: {:?}", e))?;
     //Ok(spaces)
-}
+

--- a/host/conductora/src/runtime/dispatch_map_command.rs
+++ b/host/conductora/src/runtime/dispatch_map_command.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use core_types::HolonError;
 use map_commands_contract::MapCommand;
-use map_commands_runtime::{ExecutionPolicy, Runtime};
+use map_commands_runtime::{Runtime}; //ExecutionPolicy
 use map_commands_wire::{
     MapCommandWire, MapIpcRequest, MapIpcResponse, MapResultWire,
 };
@@ -71,11 +71,11 @@ async fn dispatch_inner(
 
     // Execute via runtime (policy enforcement + handler routing)
     runtime
-        .execute_command_with_policy(
+        .execute_command( //_with_policy(
             command,
-            ExecutionPolicy {
-                snapshot_after: options.snapshot_after,
-            },
+            //ExecutionPolicy {
+             //   snapshot_after: options.snapshot_after,
+            //},
         )
         .await
 }

--- a/host/conductora/src/runtime/dispatch_map_command.rs
+++ b/host/conductora/src/runtime/dispatch_map_command.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use core_types::HolonError;
 use map_commands_contract::MapCommand;
-use map_commands_runtime::Runtime;
+use map_commands_runtime::{ExecutionPolicy, Runtime};
 use map_commands_wire::{
     MapCommandWire, MapIpcRequest, MapIpcResponse, MapResultWire,
 };
@@ -70,7 +70,14 @@ async fn dispatch_inner(
     let command = bind_command(&runtime, command)?;
 
     // Execute via runtime (policy enforcement + handler routing)
-    runtime.execute_command(command).await
+    runtime
+        .execute_command_with_policy(
+            command,
+            ExecutionPolicy {
+                snapshot_after: options.snapshot_after,
+            },
+        )
+        .await
 }
 
 /// Binds a wire command to its domain equivalent using the runtime session.

--- a/host/conductora/src/runtime/init_runtime.rs
+++ b/host/conductora/src/runtime/init_runtime.rs
@@ -1,38 +1,59 @@
 use std::sync::Arc;
 
 use client_shared_types::ReceptorType;
-use holons_client::{receptor_factory, ClientSession, Receptor};
+use holons_client::{init_client_runtime, receptor_factory, Receptor};
+use map_commands_runtime::{Runtime, RuntimeSession};
 use tauri::{AppHandle, Manager};
 
 use crate::runtime::RuntimeState;
-use holons_client::init_client_runtime;
-use map_commands_runtime::{Runtime, RuntimeSession};
 
 /// Stored by providers (e.g. Holochain) and consumed by runtime init.
 pub type RuntimeInitiatorState =
     std::sync::RwLock<Option<Arc<dyn holons_core::dances::DanceInitiator>>>;
 
 /// Initialize the MAP Commands runtime from the initiator stored in app state.
+///
+/// Target architecture:
+/// - build the runtime HolonSpaceManager
+/// - resolve optional recovery receptor
+/// - construct a recovery-aware RuntimeSession
+/// - restore any orphaned/open sessions before publishing Runtime
 pub fn init_from_state(handle: &AppHandle) -> bool {
     let initiator =
         handle.try_state::<RuntimeInitiatorState>().and_then(|state| state.read().ok()?.clone());
 
     let Some(initiator) = initiator else {
         tracing::warn!(
-            "[RUNTIME] No runtime initiator available — MAP Commands Runtime will not be initialized."
+            "[RUNTIME] No runtime initiator available - MAP Commands Runtime will not be initialized."
         );
         return false;
     };
 
     let space_manager = init_client_runtime(Some(initiator));
-
     let recovery_receptor = get_recovery_receptor_from_factory(handle);
 
-    let _client_session = ClientSession::new(space_manager.clone(), recovery_receptor, None);
+    let session = Arc::new(RuntimeSession::new(
+        Arc::clone(&space_manager),
+        recovery_receptor.clone(),
+    ));
 
-    //TODO: use the client_session
-
-    let session = Arc::new(RuntimeSession::new(space_manager));
+    if recovery_receptor.is_some() {
+        match session.restore_open_sessions() {
+            Ok(restored) => {
+                tracing::info!(
+                    "[RUNTIME] Runtime session initialized. Restored {} recovery session(s).",
+                    restored
+                );
+            }
+            Err(err) => {
+                tracing::error!(
+                    "[RUNTIME] Failed to restore recovery sessions during startup: {}",
+                    err
+                );
+                return false;
+            }
+        }
+    }
 
     let runtime = Runtime::new(session);
 
@@ -50,25 +71,24 @@ pub fn init_from_state(handle: &AppHandle) -> bool {
         }
     }
 
+    tracing::error!("[RUNTIME] RuntimeState missing; runtime could not be stored.");
     false
 }
 
 fn get_recovery_receptor_from_factory(handle: &AppHandle) -> Option<Arc<Receptor>> {
-    handle.try_state::<receptor_factory::ReceptorFactory>()
-    .and_then(|factory| {
-        match factory.get_default_receptor_by_type(&ReceptorType::LocalRecovery) {
-            Ok(receptor) => {
-                tracing::info!("[RUNTIME] Local recovery receptor found.");      
-                    return Some(receptor)
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "[RUNTIME] Local recovery receptor unavailable ({}); recovery features disabled.",
-                    err
-                );
-                return None
-            }
+    let factory = handle.try_state::<receptor_factory::ReceptorFactory>()?;
+
+    match factory.get_default_receptor_by_type(&ReceptorType::LocalRecovery) {
+        Ok(receptor) => {
+            tracing::info!("[RUNTIME] Local recovery receptor found.");
+            Some(receptor)
         }
-    });
-    None
+        Err(err) => {
+            tracing::warn!(
+                "[RUNTIME] Local recovery receptor unavailable ({}); recovery features disabled.",
+                err
+            );
+            None
+        }
+    }
 }

--- a/host/conductora/src/setup/providers/local/setup.rs
+++ b/host/conductora/src/setup/providers/local/setup.rs
@@ -24,6 +24,9 @@ impl LocalSetup {
         if is_recovery {
             let receptor_cfg: BaseReceptor = Self::build_recovery_receptor(&handle, name, local_cfg).await?;
             register_receptor(&handle, receptor_cfg).await?;
+        } else {
+            return Err(anyhow::anyhow!(
+                "Local storage '{}' enabled without 'recovery' feature: Registering a non-recovery receptor is currently not allowed as we have not defined other local receptors.",name));
         }
         Ok(())
     }
@@ -91,9 +94,3 @@ pub async fn create_snapshot_store<C: ProviderConfig>(
 
     Ok(Arc::new(store))
 }
-
-//helpers
-//fn generate_receptor_id(props: HashMap<String, String>) -> Result<String, Box<dyn std::error::Error>> {
-//    let json = serde_json::to_string(&props)?;
- //   Ok(hex::encode(Sha256::digest(json.as_bytes())))
-//}

--- a/host/crates/holons_client/src/client_session.rs
+++ b/host/crates/holons_client/src/client_session.rs
@@ -1,47 +1,93 @@
 use std::sync::Arc;
+
 use core_types::HolonError;
-use holons_core::core_shared_objects::{space_manager::HolonSpaceManager, transactions::TransactionContext, transactions::TxId};
+use holons_core::core_shared_objects::{
+    space_manager::HolonSpaceManager,
+    transactions::{TransactionContext, TxId},
+};
 
 use crate::Receptor;
 
+//#[derive(Debug)]
 pub struct ClientSession {
-    _context: Arc<TransactionContext>,
-    // Other session-related fields can be added here
+    context: Arc<TransactionContext>,
+    recovery: Option<Arc<Receptor>>,
 }
 
 impl ClientSession {
-    pub fn new(space_manager: Arc<HolonSpaceManager>, recovery: Option<Arc<Receptor>>, _destination: Option<Arc<Receptor>>) -> Result<Self, HolonError> {
-        if let Some(receptor_arc) = recovery {
-            if let Receptor::LocalRecovery(receptor) = receptor_arc.as_ref() {
-                if let Some(tx_id) = receptor.recover_last_tx_id_from_crash() {
-                    tracing::info!("[CLIENT SESSION] Orphaned transaction found from previous crash: {}", tx_id.clone());
-                    let transaction_context = space_manager
-                        .get_transaction_manager()
-                        .open_transaction_with_id(Arc::clone(&space_manager), TxId::from_str(&tx_id).expect("invalid tx_id"))
-                        .or_else(|_| Err(HolonError::FailedToBorrow("[CLIENT SESSION] Failed to open transaction for crash recovery".into())))?;
-                        receptor.init_session(transaction_context.clone());
-                        return Ok(Self {
-                            _context: transaction_context,
-                        });
-                } else {
-                    let transaction_context = space_manager
-                        .get_transaction_manager()
-                        .open_new_transaction(Arc::clone(&space_manager))
-                        .or_else(|_| Err(HolonError::FailedToBorrow("[CLIENT SESSION] Failed to open transaction for crash recovery".into())))?;
-                        receptor.init_session(transaction_context.clone());
-                        return Ok(Self {
-                            _context: transaction_context,
-                        });
-                }
-            } else {
-                return Err(HolonError::FailedToBorrow("[CLIENT SESSION] Provided recovery receptor is not a LocalRecoveryReceptor".into()));
-            }
-        } 
-        Err(HolonError::FailedToBorrow("[CLIENT SESSION] No valid recovery receptor provided".into()))
+    pub fn open_new(
+        space_manager: Arc<HolonSpaceManager>,
+        recovery: Option<Arc<Receptor>>,
+    ) -> Result<Self, HolonError> {
+        let context = space_manager
+            .get_transaction_manager()
+            .open_new_transaction(Arc::clone(&space_manager))?;
+
+        Ok(Self { context, recovery })
     }
 
-    // todo: add methods for session operations, e.g. add, save, undo, list, etc.
-    // commit could be handled by the receptor or by the session itself depending on design decisions around who owns the transaction context and how tightly coupled the session is to the recovery mechanism.
+    pub fn recover(
+        space_manager: Arc<HolonSpaceManager>,
+        recovery: Option<Arc<Receptor>>,
+        tx_id: String,
+    ) -> Result<Self, HolonError> {
+        let tx_id = TxId::from_str(&tx_id)
+            .ok_or_else(|| HolonError::InvalidParameter("invalid recovered tx_id".into()))?;
 
-    // Additional methods for session management can be added here
+        let context = space_manager
+            .get_transaction_manager()
+            .open_transaction_with_id(Arc::clone(&space_manager), tx_id)?;
+
+        let session = Self { context, recovery };
+        session.restore_from_recovery()?;
+        Ok(session)
+    }
+
+    pub fn tx_id(&self) -> TxId {
+        self.context.tx_id()
+    }
+
+    pub fn context(&self) -> &Arc<TransactionContext> {
+        &self.context
+    }
+
+    fn restore_from_recovery(&self) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        match recovery.as_ref() {
+            Receptor::LocalRecovery(r) => {
+                if let Some(snapshot) = r.recover_latest(&self.tx_id().value().to_string())? {
+                    snapshot.restore_into(&self.context)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    pub async fn persist(&self, description: &str, disable_undo: bool) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+            return r.persist(&self.context, description, disable_undo).await;
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn cleanup(&self) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+           return r.cleanup(&self.tx_id().value().to_string()).await;
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/host/crates/map_commands_runtime/Cargo.toml
+++ b/host/crates/map_commands_runtime/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 map_commands_contract = { workspace = true }
 holons_core = { workspace = true }
 holons_loader_client = { workspace = true }
+holons_client = { path = "../holons_client" } 
+recovery_receptor = { path = "../recovery_receptor" }
 base_types = { workspace = true }
 core_types = { workspace = true }
 

--- a/host/crates/map_commands_runtime/src/lib.rs
+++ b/host/crates/map_commands_runtime/src/lib.rs
@@ -4,7 +4,7 @@ mod runtime_session;
 mod space_handler;
 mod transaction_handler;
 
-pub use runtime::Runtime;
+pub use runtime::{ExecutionPolicy, Runtime};
 pub use runtime_session::RuntimeSession;
 
 #[cfg(test)]

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -87,7 +87,7 @@ impl Runtime {
     /// Routes a bound domain command to its scope-specific handler.
     async fn route_command(&self, command: MapCommand) -> Result<MapResult, HolonError> {
         match command {
-            MapCommand::Space(cmd) => space_handler::handle_space(&self.session, cmd),
+            MapCommand::Space(cmd) => space_handler::handle_space(&self.session, cmd).await,
             MapCommand::Transaction(cmd) => {
                 transaction_handler::handle_transaction(&self.session, cmd).await
             }

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -4,7 +4,10 @@ use core_types::HolonError;
 
 use holons_core::core_shared_objects::transactions::TransactionLifecycleState;
 
-use map_commands_contract::{MapCommand, MapResult, MutationClassification};
+use map_commands_contract::{
+    HolonAction, MapCommand, MapResult, MutationClassification, ReadableHolonAction,
+    SpaceCommand, TransactionAction,
+};
 
 use super::runtime_session::RuntimeSession;
 use super::{holon_handler, space_handler, transaction_handler};
@@ -22,6 +25,11 @@ pub struct Runtime {
     session: Arc<RuntimeSession>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExecutionPolicy {
+    pub snapshot_after: bool,
+}
+
 impl Runtime {
     pub fn new(session: Arc<RuntimeSession>) -> Self {
         Self { session }
@@ -34,7 +42,19 @@ impl Runtime {
 
     /// Enforce lifecycle policy and route a bound domain command to its handler.
     pub async fn execute_command(&self, command: MapCommand) -> Result<MapResult, HolonError> {
+        self.execute_command_with_policy(command, ExecutionPolicy::default())
+            .await
+    }
+
+    /// Enforce lifecycle policy, apply execution policy, and route a bound
+    /// domain command to its handler.
+    pub async fn execute_command_with_policy(
+        &self,
+        command: MapCommand,
+        policy: ExecutionPolicy,
+    ) -> Result<MapResult, HolonError> {
         let descriptor = command.descriptor();
+        let command_label = command_label(&command);
 
         // Extract context for lifecycle checks (Transaction and Holon commands have one)
         let context = match &command {
@@ -81,7 +101,18 @@ impl Runtime {
             }
         }
 
-        self.route_command(command).await
+        let tx_id_for_snapshot = context.as_ref().map(|ctx| ctx.tx_id());
+        let result = self.route_command(command).await?;
+
+        if policy.snapshot_after && descriptor.mutation != MutationClassification::ReadOnly {
+            if let Some(tx_id) = tx_id_for_snapshot {
+                self.session
+                    .persist_success(&tx_id, command_label, false)
+                    .await?;
+            }
+        }
+
+        Ok(result)
     }
 
     /// Routes a bound domain command to its scope-specific handler.
@@ -93,5 +124,53 @@ impl Runtime {
             }
             MapCommand::Holon(cmd) => holon_handler::handle_holon(cmd).await,
         }
+    }
+}
+
+fn command_label(command: &MapCommand) -> &'static str {
+    match command {
+        MapCommand::Space(SpaceCommand::BeginTransaction) => "begin_transaction",
+        MapCommand::Transaction(cmd) => match &cmd.action {
+            TransactionAction::Commit => "commit",
+            TransactionAction::LoadHolons { .. } => "load_holons",
+            TransactionAction::Dance(_) => "dance",
+            TransactionAction::Query(_) => "query",
+            TransactionAction::GetAllHolons => "get_all_holons",
+            TransactionAction::GetStagedHolonByBaseKey { .. } => "get_staged_holon_by_base_key",
+            TransactionAction::GetStagedHolonsByBaseKey { .. } => {
+                "get_staged_holons_by_base_key"
+            }
+            TransactionAction::GetStagedHolonByVersionedKey { .. } => {
+                "get_staged_holon_by_versioned_key"
+            }
+            TransactionAction::GetTransientHolonByBaseKey { .. } => {
+                "get_transient_holon_by_base_key"
+            }
+            TransactionAction::GetTransientHolonByVersionedKey { .. } => {
+                "get_transient_holon_by_versioned_key"
+            }
+            TransactionAction::StagedCount => "staged_count",
+            TransactionAction::TransientCount => "transient_count",
+            TransactionAction::NewHolon { .. } => "new_holon",
+            TransactionAction::StageNewHolon { .. } => "stage_new_holon",
+            TransactionAction::StageNewFromClone { .. } => "stage_new_from_clone",
+            TransactionAction::StageNewVersion { .. } => "stage_new_version",
+            TransactionAction::StageNewVersionFromId { .. } => "stage_new_version_from_id",
+            TransactionAction::DeleteHolon { .. } => "delete_holon",
+        },
+        MapCommand::Holon(cmd) => match &cmd.action {
+            HolonAction::Read(action) => match action {
+                ReadableHolonAction::CloneHolon => "clone_holon",
+                ReadableHolonAction::EssentialContent => "essential_content",
+                ReadableHolonAction::Summarize => "summarize",
+                ReadableHolonAction::HolonId => "holon_id",
+                ReadableHolonAction::Predecessor => "predecessor",
+                ReadableHolonAction::Key => "key",
+                ReadableHolonAction::VersionedKey => "versioned_key",
+                ReadableHolonAction::PropertyValue { .. } => "property_value",
+                ReadableHolonAction::RelatedHolons { .. } => "related_holons",
+            },
+            HolonAction::Write(_) => "holon_write",
+        },
     }
 }

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -42,20 +42,18 @@ impl Runtime {
 
     /// Enforce lifecycle policy and route a bound domain command to its handler.
     pub async fn execute_command(&self, command: MapCommand) -> Result<MapResult, HolonError> {
-        self.execute_command_with_policy(command, ExecutionPolicy::default())
-            .await
-    }
+        //policy: ExecutionPolicy,
 
-    /// Enforce lifecycle policy, apply execution policy, and route a bound
-    /// domain command to its handler.
-    pub async fn execute_command_with_policy(
-        &self,
-        command: MapCommand,
-        policy: ExecutionPolicy,
-    ) -> Result<MapResult, HolonError> {
+        //TODO:  execution policy will be integrated into the workflow with experience units PR
+
+        let policy = ExecutionPolicy::default();
         let descriptor = command.descriptor();
         let command_label = command_label(&command);
 
+        let is_commit = match &command {
+            MapCommand::Transaction(cmd) => matches!(cmd.action, TransactionAction::Commit),
+            _ => false,
+        };
         // Extract context for lifecycle checks (Transaction and Holon commands have one)
         let context = match &command {
             MapCommand::Transaction(cmd) => Some(Arc::clone(&cmd.context)),
@@ -104,7 +102,14 @@ impl Runtime {
         let tx_id_for_snapshot = context.as_ref().map(|ctx| ctx.tx_id());
         let result = self.route_command(command).await?;
 
-        if policy.snapshot_after && descriptor.mutation != MutationClassification::ReadOnly {
+        // Only persist a snapshot after commands that:
+        // - explicitly requested snapshot_after
+        // - are not read-only
+        // - are not a Commit (commit destroys transaction-scoped recovery state)
+        if policy.snapshot_after
+            && descriptor.mutation != MutationClassification::ReadOnly
+            && !is_commit
+        {
             if let Some(tx_id) = tx_id_for_snapshot {
                 self.session
                     .persist_success(&tx_id, command_label, false)

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -2,78 +2,108 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use core_types::HolonError;
+use holons_client::{ClientSession, Receptor};
 use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
 use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
 use holons_core::TransientReference;
 
-/// Transaction ownership layer for MAP Commands.
-///
-/// Holds strong `Arc<TransactionContext>` references for all active transactions.
-/// `TransactionManager` remains weak-registry/id-authority only (per issue 370).
-///
-/// Follow-up: once the `ClientSession` PR 418 merges, this should store
-/// `ClientSession` values instead of raw `Arc<TransactionContext>` to get
-/// undo/redo/recovery for free.
 pub struct RuntimeSession {
     space_manager: Arc<HolonSpaceManager>,
-    active_transactions: RwLock<HashMap<TxId, Arc<TransactionContext>>>,
-    archived_transactions: RwLock<HashMap<TxId, Arc<TransactionContext>>>,
+    recovery: Option<Arc<Receptor>>,
+    active_sessions: RwLock<HashMap<TxId, Arc<ClientSession>>>,
+    archived_sessions: RwLock<HashMap<TxId, Arc<ClientSession>>>,
 }
 
 impl RuntimeSession {
-    pub fn new(space_manager: Arc<HolonSpaceManager>) -> Self {
+    pub fn new(
+        space_manager: Arc<HolonSpaceManager>,
+        recovery: Option<Arc<Receptor>>,
+    ) -> Self {
         Self {
             space_manager,
-            active_transactions: RwLock::new(HashMap::new()),
-            archived_transactions: RwLock::new(HashMap::new()),
+            recovery,
+            active_sessions: RwLock::new(HashMap::new()),
+            archived_sessions: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Opens a new transaction via the space's TransactionManager and stores
-    /// the strong reference in `active_transactions`.
-    pub fn begin_transaction(&self) -> Result<TxId, HolonError> {
-        let context = self
-            .space_manager
-            .get_transaction_manager()
-            .open_new_transaction(Arc::clone(&self.space_manager))?;
+    pub fn restore_open_sessions(&self) -> Result<usize, HolonError> {
+        let Some(recovery) = self.recovery.clone() else {
+            return Ok(0);
+        };
 
-        let tx_id = context.tx_id();
+        let tx_ids = match recovery.as_ref() {
+            Receptor::LocalRecovery(r) => r.list_open_sessions()?,
+            _ => return Ok(0),
+        };
 
-        let mut guard = self.active_transactions.write().map_err(|e| {
+        let mut restored = 0usize;
+        let mut active = self.active_sessions.write().map_err(|e| {
             HolonError::FailedToAcquireLock(format!(
-                "Failed to acquire write lock on active_transactions: {}",
+                "Failed to acquire write lock on active_sessions: {}",
                 e
             ))
         })?;
-        guard.insert(tx_id, context);
+
+        for tx_id in tx_ids {
+            let session = Arc::new(ClientSession::recover(
+                Arc::clone(&self.space_manager),
+                Some(Arc::clone(&recovery)),
+                tx_id,
+            )?);
+
+            active.insert(session.tx_id(), session);
+            restored += 1;
+        }
+
+        Ok(restored)
+    }
+
+    pub async fn begin_transaction(&self) -> Result<TxId, HolonError> {
+        let session = Arc::new(ClientSession::open_new(
+            Arc::clone(&self.space_manager),
+            self.recovery.clone(),
+        )?);
+
+        session.persist("begin_transaction", true).await?;
+
+        let tx_id = session.tx_id();
+        let mut active = self.active_sessions.write().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire write lock on active_sessions: {}",
+                e
+            ))
+        })?;
+        active.insert(tx_id, session);
 
         Ok(tx_id)
     }
 
-    /// Looks up a transaction by TxId, checking active first, then archived.
-    ///
-    /// Returns an error if the transaction is not found in either pool.
     pub fn get_transaction(&self, tx_id: &TxId) -> Result<Arc<TransactionContext>, HolonError> {
-        let active_guard = self.active_transactions.read().map_err(|e| {
-            HolonError::FailedToAcquireLock(format!(
-                "Failed to acquire read lock on active_transactions: {}",
-                e
-            ))
-        })?;
+        Ok(Arc::clone(self.get_client_session(tx_id)?.context()))
+    }
 
-        if let Some(ctx) = active_guard.get(tx_id).cloned() {
-            return Ok(ctx);
+    pub fn get_client_session(&self, tx_id: &TxId) -> Result<Arc<ClientSession>, HolonError> {
+        {
+            let active = self.active_sessions.read().map_err(|e| {
+                HolonError::FailedToAcquireLock(format!(
+                    "Failed to acquire read lock on active_sessions: {}",
+                    e
+                ))
+            })?;
+            if let Some(session) = active.get(tx_id) {
+                return Ok(Arc::clone(session));
+            }
         }
-        drop(active_guard);
 
-        let archived_guard = self.archived_transactions.read().map_err(|e| {
+        let archived = self.archived_sessions.read().map_err(|e| {
             HolonError::FailedToAcquireLock(format!(
-                "Failed to acquire read lock on archived_transactions: {}",
+                "Failed to acquire read lock on archived_sessions: {}",
                 e
             ))
         })?;
 
-        archived_guard.get(tx_id).cloned().ok_or_else(|| {
+        archived.get(tx_id).cloned().ok_or_else(|| {
             HolonError::InvalidParameter(format!(
                 "No transaction found for tx_id={}",
                 tx_id.value()
@@ -81,42 +111,52 @@ impl RuntimeSession {
         })
     }
 
-    pub fn commit_transaction(&self, tx_id: &TxId) -> Result<TransientReference, HolonError> {
-        let context = self.get_transaction(tx_id)?;
-
-        // Call commit on the TransactionContext, which performs the actual commit
-        let response = context.commit()?;
-
-        // Move from active to archived
-        self.archive_transaction(tx_id)?;
-
-        Ok(response)
-    }
-
-    /// Removes a transaction from active ownership (e.g., after commit or abandon).
-    pub fn archive_transaction(&self, tx_id: &TxId) -> Result<(), HolonError> {
-        {
-            let mut active_guard = self.active_transactions.write().map_err(|e| {
-                HolonError::FailedToAcquireLock(format!(
-                    "Failed to acquire write lock on active_transactions: {}",
-                    e
-                ))
-            })?;
-            let mut archived_guard = self.archived_transactions.write().map_err(|e| {
-                HolonError::FailedToAcquireLock(format!(
-                    "Failed to acquire write lock on archived_transactions: {}",
-                    e
-                ))
-            })?;
-
-            if let Some(context) = active_guard.remove(tx_id) {
-                archived_guard.insert(*tx_id, context);
-            }
+    pub async fn persist_success(
+        &self,
+        tx_id: &TxId,
+        description: &str,
+        disable_undo: bool,
+    ) -> Result<(), HolonError> {
+        if let Ok(session) = self.get_client_session(tx_id) {
+            session.persist(description, disable_undo).await?;
         }
         Ok(())
     }
 
-    /// Returns a reference to the space manager.
+    pub async fn commit_transaction(
+        &self,
+        tx_id: &TxId,
+    ) -> Result<TransientReference, HolonError> {
+        let session = self.get_client_session(tx_id)?;
+        let transient_ref = session.context().commit()?;
+
+        session.cleanup().await?;
+        self.archive_transaction(tx_id)?;
+
+        Ok(transient_ref)
+    }
+
+    pub fn archive_transaction(&self, tx_id: &TxId) -> Result<(), HolonError> {
+        let mut active = self.active_sessions.write().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire write lock on active_sessions: {}",
+                e
+            ))
+        })?;
+        let mut archived = self.archived_sessions.write().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire write lock on archived_sessions: {}",
+                e
+            ))
+        })?;
+
+        if let Some(session) = active.remove(tx_id) {
+            archived.insert(*tx_id, session);
+        }
+
+        Ok(())
+    }
+
     pub fn space_manager(&self) -> &Arc<HolonSpaceManager> {
         &self.space_manager
     }
@@ -124,7 +164,190 @@ impl RuntimeSession {
 
 impl std::fmt::Debug for RuntimeSession {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let tx_count = self.active_transactions.read().map(|g| g.len()).unwrap_or(0);
-        f.debug_struct("RuntimeSession").field("active_transactions", &tx_count).finish()
+        let active_count = self.active_sessions.read().map(|g| g.len()).unwrap_or(0);
+        let archived_count = self.archived_sessions.read().map(|g| g.len()).unwrap_or(0);
+
+        f.debug_struct("RuntimeSession")
+            .field("active_sessions", &active_count)
+            .field("archived_sessions", &archived_count)
+            .finish()
     }
 }
+
+
+/* 
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use core_types::{HolonError, HolonId, LocalId, RelationshipName};
+    use holons_core::core_shared_objects::{
+        Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
+    };
+    use holons_core::reference_layer::{
+        HolonServiceApi, StagedReference, TransientReference,
+    };
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestHolonService;
+
+    fn unreachable_in_runtime_session_tests<T>() -> Result<T, HolonError> {
+        Err(HolonError::NotImplemented(
+            "TestHolonService".to_string(),
+        ))
+    }
+
+    impl HolonServiceApi for TestHolonService {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn commit_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _staged_references: &[StagedReference],
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn delete_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _local_id: &LocalId,
+        ) -> Result<(), HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn fetch_all_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+        ) -> Result<RelationshipMap, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn fetch_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _id: &HolonId,
+        ) -> Result<Holon, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn fetch_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+            _relationship_name: &RelationshipName,
+        ) -> Result<HolonCollection, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn get_all_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+        ) -> Result<HolonCollection, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+
+        fn load_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _bundle: TransientReference,
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_runtime_session_tests()
+        }
+    }
+
+    fn build_test_space_manager() -> Arc<HolonSpaceManager> {
+        let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
+        Arc::new(HolonSpaceManager::new_with_managers(
+            None,
+            holon_service,
+            None,
+            ServiceRoutingPolicy::BlockExternal,
+        ))
+    }
+
+    fn tx_id(value: u64) -> TxId {
+        serde_json::from_value(serde_json::json!(value)).expect("tx_id should deserialize")
+    }
+
+    fn insert_recovered_transaction(
+        session: &RuntimeSession,
+        recovered_tx_id: TxId,
+    ) -> Arc<TransactionContext> {
+        let context = session
+            .space_manager()
+            .get_transaction_manager()
+            .open_transaction_with_id(Arc::clone(session.space_manager()), recovered_tx_id)
+            .expect("recovered transaction should open");
+
+        session
+            .active_sessions
+            .write()
+            .expect("active transaction lock should succeed")
+            .insert(recovered_tx_id, Arc::clone(&context));
+
+        context
+    }
+
+    #[test]
+    fn recovered_transaction_is_retrievable_from_active_pool() {
+        let space_manager = build_test_space_manager();
+        let session = RuntimeSession::new(space_manager, None);
+        let recovered_tx_id = tx_id(41);
+
+        let recovered_context = insert_recovered_transaction(&session, recovered_tx_id);
+
+        let lookup = session
+            .get_transaction(&recovered_tx_id)
+            .expect("recovered transaction lookup should succeed");
+
+        assert!(
+            Arc::ptr_eq(&recovered_context, &lookup),
+            "runtime session should return the recovered context stored for the tx"
+        );
+    }
+
+    #[test]
+    fn archived_recovered_transaction_remains_retrievable() {
+        let space_manager = build_test_space_manager();
+        let session = RuntimeSession::new(space_manager, None);
+        let recovered_tx_id = tx_id(77);
+
+        let recovered_context = insert_recovered_transaction(&session, recovered_tx_id);
+        session
+            .archive_transaction(&recovered_tx_id)
+            .expect("archive should succeed");
+
+        let lookup = session
+            .get_transaction(&recovered_tx_id)
+            .expect("archived recovered transaction lookup should succeed");
+
+        assert!(
+            Arc::ptr_eq(&recovered_context, &lookup),
+            "archived recovered transaction should still resolve to the original context"
+        );
+    }
+
+    #[test]
+    fn begin_transaction_after_recovered_context_uses_higher_tx_id() {
+        let space_manager = build_test_space_manager();
+        let session = RuntimeSession::new(space_manager,None);
+        let recovered_tx_id = tx_id(120);
+
+        insert_recovered_transaction(&session, recovered_tx_id);
+
+        let new_tx_id = session
+            .begin_transaction()
+            .expect("new transaction should open after recovery");
+
+        assert!(
+            new_tx_id.value() > recovered_tx_id.value(),
+            "new tx_id should advance beyond the recovered tx_id to avoid collisions"
+        );
+    }
+}*/

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -79,6 +79,27 @@ impl RuntimeSession {
         Ok(tx_id)
     }
 
+    /// Registers an already-opened recovered client session into the active pool.
+    ///
+    /// This is the seam startup recovery uses after reopening a transaction
+    /// with its preserved `TxId`.
+    pub fn register_recovered_session(
+        &self,
+        session: Arc<ClientSession>,
+    ) -> Result<TxId, HolonError> {
+        let tx_id = session.tx_id();
+
+        let mut active = self.active_sessions.write().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire write lock on active_sessions: {}",
+                e
+            ))
+        })?;
+        active.insert(tx_id, session);
+
+        Ok(tx_id)
+    }
+
     pub fn get_transaction(&self, tx_id: &TxId) -> Result<Arc<TransactionContext>, HolonError> {
         Ok(Arc::clone(self.get_client_session(tx_id)?.context()))
     }
@@ -175,7 +196,7 @@ impl std::fmt::Debug for RuntimeSession {
 }
 
 
-/* 
+
 #[cfg(test)]
 mod tests {
     use std::any::Any;
@@ -278,20 +299,21 @@ mod tests {
     fn insert_recovered_transaction(
         session: &RuntimeSession,
         recovered_tx_id: TxId,
-    ) -> Arc<TransactionContext> {
-        let context = session
-            .space_manager()
-            .get_transaction_manager()
-            .open_transaction_with_id(Arc::clone(session.space_manager()), recovered_tx_id)
-            .expect("recovered transaction should open");
+    ) -> Arc<ClientSession> {
+        let recovered_session = Arc::new(
+            ClientSession::recover(
+                Arc::clone(session.space_manager()),
+                None,
+                recovered_tx_id.value().to_string(),
+            )
+            .expect("recovered session should open"),
+        );
 
         session
-            .active_sessions
-            .write()
-            .expect("active transaction lock should succeed")
-            .insert(recovered_tx_id, Arc::clone(&context));
+            .register_recovered_session(Arc::clone(&recovered_session))
+            .expect("recovered session should register");
 
-        context
+        recovered_session
     }
 
     #[test]
@@ -300,14 +322,14 @@ mod tests {
         let session = RuntimeSession::new(space_manager, None);
         let recovered_tx_id = tx_id(41);
 
-        let recovered_context = insert_recovered_transaction(&session, recovered_tx_id);
+        let recovered_session = insert_recovered_transaction(&session, recovered_tx_id);
 
         let lookup = session
             .get_transaction(&recovered_tx_id)
             .expect("recovered transaction lookup should succeed");
 
         assert!(
-            Arc::ptr_eq(&recovered_context, &lookup),
+            Arc::ptr_eq(recovered_session.context(), &lookup),
             "runtime session should return the recovered context stored for the tx"
         );
     }
@@ -318,7 +340,7 @@ mod tests {
         let session = RuntimeSession::new(space_manager, None);
         let recovered_tx_id = tx_id(77);
 
-        let recovered_context = insert_recovered_transaction(&session, recovered_tx_id);
+        let recovered_session = insert_recovered_transaction(&session, recovered_tx_id);
         session
             .archive_transaction(&recovered_tx_id)
             .expect("archive should succeed");
@@ -328,13 +350,13 @@ mod tests {
             .expect("archived recovered transaction lookup should succeed");
 
         assert!(
-            Arc::ptr_eq(&recovered_context, &lookup),
+            Arc::ptr_eq(recovered_session.context(), &lookup),
             "archived recovered transaction should still resolve to the original context"
         );
     }
 
-    #[test]
-    fn begin_transaction_after_recovered_context_uses_higher_tx_id() {
+    #[tokio::test]
+    async fn begin_transaction_after_recovered_context_uses_higher_tx_id() {
         let space_manager = build_test_space_manager();
         let session = RuntimeSession::new(space_manager,None);
         let recovered_tx_id = tx_id(120);
@@ -342,7 +364,7 @@ mod tests {
         insert_recovered_transaction(&session, recovered_tx_id);
 
         let new_tx_id = session
-            .begin_transaction()
+            .begin_transaction().await
             .expect("new transaction should open after recovery");
 
         assert!(
@@ -350,4 +372,4 @@ mod tests {
             "new tx_id should advance beyond the recovered tx_id to avoid collisions"
         );
     }
-}*/
+}

--- a/host/crates/map_commands_runtime/src/space_handler.rs
+++ b/host/crates/map_commands_runtime/src/space_handler.rs
@@ -5,13 +5,13 @@ use map_commands_contract::{MapResult, SpaceCommand};
 use super::runtime_session::RuntimeSession;
 
 /// Handles space-scoped commands.
-pub fn handle_space(
+pub async fn handle_space(
     session: &RuntimeSession,
     command: SpaceCommand,
 ) -> Result<MapResult, HolonError> {
     match command {
         SpaceCommand::BeginTransaction => {
-            let tx_id = session.begin_transaction()?;
+            let tx_id = session.begin_transaction().await?;
             Ok(MapResult::TransactionCreated { tx_id })
         }
     }

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -103,7 +103,7 @@ fn build_test_space_manager() -> Arc<HolonSpaceManager> {
 
 fn build_test_runtime() -> Runtime {
     let space_manager = build_test_space_manager();
-    let session = Arc::new(RuntimeSession::new(space_manager));
+    let session = Arc::new(RuntimeSession::new(space_manager,None));
     Runtime::new(session)
 }
 

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -16,7 +16,7 @@ pub async fn handle_transaction(
     match command.action {
         // ── Commit ───────────────────────────────────────────────────
         TransactionAction::Commit => {
-            let transient_ref = session.commit_transaction(&command.context.tx_id())?;
+            let transient_ref = session.commit_transaction(&command.context.tx_id()).await?;
             Ok(MapResult::Reference(HolonReference::Transient(transient_ref)))
         }
 

--- a/host/crates/recovery_receptor/src/local_recovery_receptor.rs
+++ b/host/crates/recovery_receptor/src/local_recovery_receptor.rs
@@ -1,184 +1,120 @@
-use core_types::{HolonError};
-//use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
-use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
-use holons_core::core_shared_objects::transactions::TransactionContext;
-use super::storage::transaction_snapshot::TransactionSnapshot;
-use super::storage::{RecoveryStore, TransactionRecoveryStore};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+
+use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
+use core_types::HolonError;
+use holons_core::core_shared_objects::transactions::TransactionContext;
+
+use super::storage::transaction_snapshot::TransactionSnapshot;
+use super::storage::{RecoveryStore, TransactionRecoveryStore};
 
 pub struct LocalRecoveryReceptor {
     receptor_id: String,
     receptor_type: ReceptorType,
     properties: HashMap<String, String>,
     recovery_store: Arc<TransactionRecoveryStore>,
-    context: OnceLock<Arc<TransactionContext>>, // OnceLock for one-time initialization
 }
 
-/// Implementation of LocalReceptor - local host level - no dancing
 impl LocalRecoveryReceptor {
-    /// Create a new LocalReceptor, returning Result to handle downcast failures
     pub fn new(base_receptor: BaseReceptor) -> Result<Self, HolonError> {
+        let client_any = base_receptor
+            .client_handler
+            .as_ref()
+            .expect("a handler is required for LocalRecoveryReceptor")
+            .clone();
 
-        // Downcast the stored client into our concrete conductor client
-        let client_any =
-            base_receptor.client_handler.as_ref().expect("a handler is required for LocalRecoveryReceptor").clone();
-
-        let client_handler = client_any
-            .downcast::<TransactionRecoveryStore>() 
-            .map_err(|_| HolonError::DowncastFailure(format!(
-                "Failed to cast client handler for LocalRecoveryReceptor '{}'",
-                base_receptor.receptor_id
-        )))?;
-        
+        let recovery_store = client_any
+            .downcast::<TransactionRecoveryStore>()
+            .map_err(|_| {
+                HolonError::DowncastFailure(format!(
+                    "Failed to cast client handler for LocalRecoveryReceptor '{}'",
+                    base_receptor.receptor_id
+                ))
+            })?;
 
         Ok(Self {
             receptor_id: base_receptor.receptor_id.clone(),
             receptor_type: base_receptor.receptor_type,
             properties: base_receptor.properties.clone(),
-            recovery_store: client_handler,
-            context: OnceLock::new(),
-            //last_tx_id: Mutex::new(None)
-            //recover_session: Mutex::new(recover_session),
+            recovery_store,
         })
     }
 
-    pub fn recover_last_tx_id_from_crash(&self) -> Option<String> {
-        let orphaned_tx_ids = match self.recovery_store.list_open_sessions() {
-            Ok(ids) => ids,
-            Err(e) => {
-                tracing::warn!("[RECOVERY] Failed to list open sessions: {e}");
-                return None;
-            }
-        };
-        let last_tx_id = orphaned_tx_ids.first().cloned().or_else(|| None);
-         // Clean up all older orphaned sessions — they are stale
-            for stale_tx_id in orphaned_tx_ids.iter().skip(1) {
-                if let Err(e) = self.recovery_store.cleanup(stale_tx_id) {
-                    tracing::warn!("[RECOVERY] Failed to clean up stale tx={stale_tx_id}: {e}");
-                } else {
-                    tracing::info!("[RECOVERY] Cleaned up stale orphaned tx={stale_tx_id}");
-                }
-            }
-        last_tx_id
-    }
-    
-    pub fn init_session(&self, context: Arc<TransactionContext>) {
-        self.context.set(context).expect("should not get here");
-        self.try_restore_session();
+    pub fn list_open_sessions(&self) -> Result<Vec<String>, HolonError> {
+        self.recovery_store.list_open_sessions()
     }
 
-
-    /// Restores a recovered crash snapshot into the given `TransactionContext`.
-    ///
-    /// Called once during startup by `init_from_state` after a fresh transaction
-    /// has been opened. Returns `true` if a snapshot was found and restored,
-    /// `false` if there was nothing to recover.
-    fn try_restore_session(&self) -> bool {
-        let Some(snapshot) = &self.recover_last_snapshot() else {
-            return false;
-        };
-        let Some(context) = &self.context.get() else {
-            return false;
-        };
-        match snapshot.restore_into(context) {
-            Ok(()) => {
-                tracing::info!(
-                    "[RECOVERY] Crash snapshot tx={} restored into context tx={}",
-                    snapshot.tx_id,
-                    context.tx_id().value()
-                );
-                true
-            }
-            Err(e) => {
-                tracing::warn!("[RECOVERY] Failed to restore crash snapshot: {e}");
-                false
-            }
-        }
+    pub fn recover_latest(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {
+        self.recovery_store.recover_latest(tx_id)
     }
 
-    /// Called after every successful command.
-    /// `description` is the command name — used in undo history display.
-    /// `disable_undo` = true for bulk/loader ops that shouldn't be individually undoable.
-    pub async fn persist(&self, description: &str, disable_undo: bool) {
-        let Some(context) = &self.context.get() else {
-            return;
-        };
+    pub async fn persist(
+        &self,
+        context: &Arc<TransactionContext>,
+        description: &str,
+        disable_undo: bool,
+    ) -> Result<(), HolonError> {
         let store = Arc::clone(&self.recovery_store);
-        let context = Arc::clone(&context);
+        let context = Arc::clone(context);
         let description = description.to_string();
 
-        let _ = tokio::task::spawn_blocking(move || {
-            if let Err(e) = store.persist(&context, &description, disable_undo) {
-                tracing::warn!("[CLIENT SESSION] Persist failed: {e}");
-            }
-        })
-        .await;
-    }
-
-    pub async fn undo(&self) -> Option<TransactionSnapshot> {
-        let Some(context) = &self.context.get() else {
-            return None;
-        };
-        let store = Arc::clone(&self.recovery_store);
-        let tx_id = context.tx_id().value().to_string();
-        tokio::task::spawn_blocking(move || store.undo(&tx_id).ok().flatten())
+        tokio::task::spawn_blocking(move || store.persist(&context, &description, disable_undo))
             .await
-            .ok()
-            .flatten()
+            .map_err(|e| HolonError::Misc(format!("persist join error: {e}")))?
     }
 
-    pub async fn redo(&self) -> Option<TransactionSnapshot> {
-        let Some(context) = &self.context.get() else {
-            return None;
-        };
+    pub async fn undo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {
         let store = Arc::clone(&self.recovery_store);
-        let tx_id = context.tx_id().value().to_string();
-        tokio::task::spawn_blocking(move || store.redo(&tx_id).ok().flatten())
+        let tx_id = tx_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.undo(&tx_id))
             .await
-            .ok()
-            .flatten()
+            .map_err(|e| HolonError::Misc(format!("undo join error: {e}")))?
     }
 
-    pub async fn list_undo_history(&self) -> Vec<String> {
-        let Some(context) = &self.context.get() else {
-            return Vec::new();
-        };
+    pub async fn redo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {
         let store = Arc::clone(&self.recovery_store);
-        let tx_id = context.tx_id().value().to_string();
-        tokio::task::spawn_blocking(move || store.undo_history(&tx_id).unwrap_or_default())
+        let tx_id = tx_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.redo(&tx_id))
             .await
-            .unwrap_or_default()
+            .map_err(|e| HolonError::Misc(format!("redo join error: {e}")))?
     }
 
-    pub fn recover_last_snapshot(&self) -> Option<TransactionSnapshot> {
-        let Some(context) = &self.context.get() else {
-            return None;
-        };
-        let store = Arc::clone(&self.recovery_store);
-        let tx_id = context.tx_id().value().to_string();
-        store.recover_latest(&tx_id.to_owned()).ok().flatten()
+    pub fn can_undo(&self, tx_id: &str) -> Result<bool, HolonError> {
+        self.recovery_store.can_undo(tx_id)
     }
 
-    pub async fn cleanup(&self) {
-        let Some(context) = &self.context.get() else {
-            return;
-        };
+    pub fn can_redo(&self, tx_id: &str) -> Result<bool, HolonError> {
+        self.recovery_store.can_redo(tx_id)
+    }
+
+    pub async fn list_undo_history(&self, tx_id: &str) -> Result<Vec<String>, HolonError> {
         let store = Arc::clone(&self.recovery_store);
-        let tx_id = context.tx_id().value().to_string();
-        let _ = tokio::task::spawn_blocking(move || store.cleanup(&tx_id)).await;
+        let tx_id = tx_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.undo_history(&tx_id))
+            .await
+            .map_err(|e| HolonError::Misc(format!("undo_history join error: {e}")))?
+    }
+
+    pub async fn cleanup(&self, tx_id: &str) -> Result<(), HolonError> {
+        let store = Arc::clone(&self.recovery_store);
+        let tx_id = tx_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.cleanup(&tx_id))
+            .await
+            .map_err(|e| HolonError::Misc(format!("cleanup join error: {e}")))?
     }
 }
 
-//is still needed?
 impl fmt::Debug for LocalRecoveryReceptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LocalReceptor")
+        f.debug_struct("LocalRecoveryReceptor")
             .field("receptor_id", &self.receptor_id)
             .field("receptor_type", &self.receptor_type)
             .field("properties", &self.properties)
-           // .field("root_space", &self.root_space)
             .finish()
     }
 }

--- a/tests/sweetests/src/harness/helpers/test_context.rs
+++ b/tests/sweetests/src/harness/helpers/test_context.rs
@@ -72,7 +72,7 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
     ));
 
     // Step 4: Create RuntimeSession and Runtime
-    let session = Arc::new(RuntimeSession::new(Arc::clone(&space_manager)));
+    let session = Arc::new(RuntimeSession::new(Arc::clone(&space_manager),None));
     let runtime = Runtime::new(session);
 
     // Step 5: Begin first transaction through the real command path


### PR DESCRIPTION
```mermaid
flowchart LR
    A[Runtime] --> B[RuntimeSession]

    B --> C[active_sessions: HashMap<TxId, Arc<ClientSession>>]
    B --> D[archived_sessions: HashMap<TxId, Arc<ClientSession>>]
    B --> E[HolonSpaceManager]
    B -- Restore Tx session --> I[LocalRecoveryReceptor]

    C --> G[ClientSession]
    D --> G

    G --> H[TransactionContext]
    G --> F[LocalRecoveryReceptor]
    
    I --> J[list_open_sessions]

    F --> K[recover_latest tx_id]
    F --> L[persist context, description, disable_undo]
    F --> M[cleanup tx_id]

```


- wiring complete
  - runtime-init does orchestration
  - runtime delegates to runtime-session
  - runtime session , takes care of recovery and manages ClientSessions
  
- tests added
-  execution policy:
runtime.rs
- added ExecutionPolicy { snapshot_after }
- kept execute_command(...) as the default wrapper
- added execute_command_with_policy(...)
- after successful dispatch, it now calls session.persist_success(...) when:
  - snapshot_after is true
  - the command is not ReadOnly
  - the command has a transaction context
  - added a small command_label(...) helper for snapshot descriptions

lib.rs
 - now exports ExecutionPolicy
 - dispatch_map_command.rs
 - now passes RequestOptions.snapshot_after into Runtime::execute_command_with_policy(...)
