### PR TITLE
447 support schema first domain fixtures in sweetests

### DIFF
--- a/host/crates/holons_loader_client/src/builder.rs
+++ b/host/crates/holons_loader_client/src/builder.rs
@@ -438,6 +438,8 @@ fn create_relationship_reference(
         CorePropertyTypeName::RelationshipName,
         BaseValue::StringValue(MapString(relationship_name.to_string())),
     )?;
+    // We currently treat all relationships as declared; if we allow inverse relationships in import
+    // json, we'll need a conditional here and possibly derive this from relationship type definitions
     relationship_reference.with_property_value(
         CorePropertyTypeName::IsDeclared,
         BaseValue::BooleanValue(MapBoolean(true)),

--- a/host/import_files/map-schema/bootstrap-import.schema.json
+++ b/host/import_files/map-schema/bootstrap-import.schema.json
@@ -18,7 +18,7 @@
         "generator": {
           "type": "string"
         },
-        "depends_on_files": {
+        "load_with": {
           "type": "array",
           "items": {
             "type": "string",

--- a/shared_crates/json_schema_validation/tests/fixtures/map_core_schema/bootstrap-import.schema.json
+++ b/shared_crates/json_schema_validation/tests/fixtures/map_core_schema/bootstrap-import.schema.json
@@ -134,7 +134,7 @@
       "properties": {
         "$ref": {
           "type": "string",
-          "pattern": "^(#|id:|@|ext:).+$"
+          "pattern": "^(#?(?!(id:|ext:))[^#@:].*|id:.+|@.+|ext:.+)$"
         }
       },
       "additionalProperties": false

--- a/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
+++ b/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
@@ -1,0 +1,328 @@
+{
+  "meta": {
+    "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
+    "generated_at": "2026-04-17T09:56:07",
+    "export_mode": "by-file",
+    "source_files": [
+      "MAP Schema Types-map-test-schema-book-person-inverse.csv"
+    ],
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json"
+    ]
+  },
+  "holons": [
+    {
+      "key": "BookAuthorInverseSchema",
+      "type": "#SchemaType",
+      "properties": {
+        "type_name": "BookAuthorInverseSchema",
+        "display_name": "BookAuthorInverseSchema",
+        "instance_type_kind": "Holon",
+        "description": "Minimal test schema with an inverse relationship and extending the core schema.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "DependsOn",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Book.HolonType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Book",
+        "type_name_plural": "Books",
+        "display_name": "Book",
+        "display_name_plural": "Books",
+        "instance_type_kind": "Holon",
+        "description": "A book.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#Title.PropertyType"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(Book.HolonType)-[AuthoredBy]->(Person.HolonType)"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Person.HolonType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Person",
+        "type_name_plural": "Persons",
+        "display_name": "Person",
+        "display_name_plural": "People",
+        "instance_type_kind": "Holon",
+        "description": "A person.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#Name.PropertyType"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(Person.HolonType)-[Authors]->(Book.HolonType)"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(Book.HolonType)-[AuthoredBy]->(Person.HolonType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "AuthoredBy",
+        "type_name_plural": "AuthoredByRelationships",
+        "display_name": "AuthoredBy",
+        "display_name_plural": "AuthoredBy Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Defines the author of a book.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#Book.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#Person.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(Person.HolonType)-[Authors]->(Book.HolonType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Authors",
+        "type_name_plural": "AuthorsRelationships",
+        "display_name": "Authors",
+        "display_name_plural": "Authors Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Specifies a book that a Person has authored.  Inverse of AuthoredBy.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(Book.HolonType)-[AuthoredBy]->(Person.HolonType)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#Person.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#Book.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Name.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Name",
+        "type_name_plural": "Names",
+        "display_name": "Name",
+        "display_name_plural": "Names",
+        "instance_type_kind": "Property",
+        "description": "Proper name.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapStringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Title.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Title",
+        "type_name_plural": "Titles",
+        "display_name": "Title",
+        "display_name_plural": "Title",
+        "instance_type_kind": "Property",
+        "description": "A title.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapStringValueType"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
+++ b/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
@@ -3,36 +3,30 @@ use holons_loader_client::BOOTSTRAP_IMPORT_SCHEMA_PATH;
 use holons_prelude::prelude::*;
 use std::path::PathBuf;
 
-use super::{map_core_schema_paths, read_file_data, CoreSchemaLoadMetrics};
+use super::{read_file_data, CoreSchemaLoadMetrics};
 
 const DOMAIN_SCHEMA_RELATIVE_PATH: &str =
     "import_files/MAP Schema Types-map-test-schema-book-person-inverse.json";
 
-pub const CORE_AND_BOOK_PERSON_INVERSE_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
+pub const BOOK_PERSON_INVERSE_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
     staged: 0,
     committed: 0,
     links_created: 0,
     errors: 0,
-    total_bundles: 8,
-    total_loader_holons: 189,
+    total_bundles: 1,
+    total_loader_holons: 7,
 };
 
 pub fn domain_schema_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DOMAIN_SCHEMA_RELATIVE_PATH)
 }
 
-pub fn build_core_and_book_person_inverse_content_set() -> Result<ContentSet, HolonError> {
+pub fn build_book_person_inverse_content_set() -> Result<ContentSet, HolonError> {
     let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_SCHEMA_PATH);
     let schema = read_file_data(&schema_path, "validation schema")?;
 
-    let files_to_load = map_core_schema_paths()
-        .into_iter()
-        .map(|path| read_file_data(&path, "core schema import"))
-        .chain(std::iter::once(read_file_data(
-            &domain_schema_path(),
-            "Book/Person inverse test schema import",
-        )))
-        .collect::<Result<Vec<_>, _>>()?;
+    let files_to_load =
+        vec![read_file_data(&domain_schema_path(), "Book/Person inverse test schema import")?];
 
     Ok(ContentSet { schema, files_to_load })
 }

--- a/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
+++ b/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
@@ -9,9 +9,9 @@ const DOMAIN_SCHEMA_RELATIVE_PATH: &str =
     "import_files/MAP Schema Types-map-test-schema-book-person-inverse.json";
 
 pub const BOOK_PERSON_INVERSE_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
-    staged: 0,
-    committed: 0,
-    links_created: 0,
+    staged: 7,
+    committed: 7,
+    links_created: 39,
     errors: 0,
     total_bundles: 1,
     total_loader_holons: 7,

--- a/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
+++ b/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
@@ -1,0 +1,38 @@
+use core_types::ContentSet;
+use holons_loader_client::BOOTSTRAP_IMPORT_SCHEMA_PATH;
+use holons_prelude::prelude::*;
+use std::path::PathBuf;
+
+use super::{map_core_schema_paths, read_file_data, CoreSchemaLoadMetrics};
+
+const DOMAIN_SCHEMA_RELATIVE_PATH: &str =
+    "import_files/MAP Schema Types-map-test-schema-book-person-inverse.json";
+
+pub const CORE_AND_BOOK_PERSON_INVERSE_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
+    staged: 0,
+    committed: 0,
+    links_created: 0,
+    errors: 0,
+    total_bundles: 8,
+    total_loader_holons: 189,
+};
+
+pub fn domain_schema_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DOMAIN_SCHEMA_RELATIVE_PATH)
+}
+
+pub fn build_core_and_book_person_inverse_content_set() -> Result<ContentSet, HolonError> {
+    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_SCHEMA_PATH);
+    let schema = read_file_data(&schema_path, "validation schema")?;
+
+    let files_to_load = map_core_schema_paths()
+        .into_iter()
+        .map(|path| read_file_data(&path, "core schema import"))
+        .chain(std::iter::once(read_file_data(
+            &domain_schema_path(),
+            "Book/Person inverse test schema import",
+        )))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(ContentSet { schema, files_to_load })
+}

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -55,7 +55,7 @@ pub fn build_core_schema_content_set() -> Result<ContentSet, HolonError> {
     Ok(ContentSet { schema, files_to_load })
 }
 
-fn read_file_data(path: &Path, role: &str) -> Result<FileData, HolonError> {
+pub fn read_file_data(path: &Path, role: &str) -> Result<FileData, HolonError> {
     let raw_contents = fs::read_to_string(path).map_err(|error| {
         HolonError::Misc(format!("failed to read {role} file {}: {error}", path.display()))
     })?;

--- a/tests/sweetests/src/harness/helpers/mod.rs
+++ b/tests/sweetests/src/harness/helpers/mod.rs
@@ -1,3 +1,4 @@
+pub mod book_person_inverse_schema;
 pub mod constants;
 pub mod core_schema;
 pub mod expected_test_result;
@@ -5,6 +6,7 @@ pub mod mock_conductor;
 pub mod test_context;
 pub mod tracing_utils;
 
+pub use book_person_inverse_schema::*;
 pub use constants::*;
 pub use core_schema::*;
 pub use expected_test_result::*;

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -158,6 +158,18 @@ impl DancesTestCase {
         Ok(())
     }
 
+    pub fn add_load_book_person_inverse_test_schema_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Load Book/Person inverse test schema".to_string());
+        self.steps.push(DanceTestStep::LoadBookPersonInverseTestSchema { description });
+
+        Ok(())
+    }
+
     pub fn add_load_holons_internal_step(
         &mut self,
         set: TransientReference,

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -52,6 +52,9 @@ pub enum DanceTestStep {
     LoadCoreSchema {
         description: String,
     },
+    LoadBookPersonInverseTestSchema {
+        description: String,
+    },
     MatchSavedContent,
     NewHolon {
         step_token: TestReference,
@@ -157,6 +160,9 @@ impl core::fmt::Display for DanceTestStep {
                 )
             }
             DanceTestStep::LoadCoreSchema { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::LoadBookPersonInverseTestSchema { description } => {
                 write!(f, "{description}")
             }
             DanceTestStep::MatchSavedContent => {

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -36,6 +36,7 @@ use execution_steps::begin_transaction_executor::execute_begin_transaction;
 use execution_steps::commit_executor::execute_commit;
 use execution_steps::delete_holon_executor::execute_delete_holon;
 use execution_steps::ensure_database_count_executor::execute_ensure_database_count;
+use execution_steps::load_book_person_inverse_test_schema_executor::execute_load_book_person_inverse_test_schema;
 use execution_steps::load_core_schema_executor::execute_load_core_schema;
 use execution_steps::load_holons_internal_executor::execute_load_holons_internal;
 use execution_steps::match_db_content_executor::execute_match_db_content;
@@ -52,6 +53,7 @@ use fixture_cases::abandon_staged_changes_fixture::*;
 use fixture_cases::delete_holon_fixture::*;
 use fixture_cases::ergonomic_add_remove_properties_fixture::*;
 use fixture_cases::ergonomic_add_remove_related_holons_fixture::*;
+use fixture_cases::load_book_person_inverse_schema_fixture::*;
 use fixture_cases::load_core_schema_fixture::*;
 use fixture_cases::load_holons_internal_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
@@ -103,6 +105,7 @@ use holons_prelude::prelude::*;
 #[case::stage_new_version_test(stage_new_version_fixture())]
 #[case::load_holons_internal_test(loader_incremental_fixture())]
 #[case::load_core_schema_test(load_core_schema_fixture())]
+#[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
 #[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
 #[tokio::test(flavor = "multi_thread")]
 // TODO: Support for relationships to be finished in issue 382
@@ -193,6 +196,9 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
             }
             DanceTestStep::LoadCoreSchema { .. } => {
                 execute_load_core_schema(&mut test_execution_state).await
+            }
+            DanceTestStep::LoadBookPersonInverseTestSchema { .. } => {
+                execute_load_book_person_inverse_test_schema(&mut test_execution_state).await
             }
             DanceTestStep::MatchSavedContent => {
                 execute_match_db_content(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/load_book_person_inverse_test_schema_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_book_person_inverse_test_schema_executor.rs
@@ -1,0 +1,26 @@
+use holons_prelude::prelude::*;
+
+use holons_test::harness::helpers::{
+    build_book_person_inverse_content_set, BOOK_PERSON_INVERSE_METRICS,
+};
+use holons_test::TestExecutionState;
+
+use super::load_holons_client_executor::execute_load_holons_client;
+
+pub async fn execute_load_book_person_inverse_test_schema(test_state: &mut TestExecutionState) {
+    let content_set = build_book_person_inverse_content_set().unwrap_or_else(|error| {
+        panic!("failed to build Book/Person inverse ContentSet: {error:?}")
+    });
+
+    execute_load_holons_client(
+        test_state,
+        content_set,
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.staged),
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.committed),
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.links_created),
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.errors),
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.total_bundles),
+        MapInteger(BOOK_PERSON_INVERSE_METRICS.total_loader_holons),
+    )
+    .await;
+}

--- a/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
@@ -61,6 +61,21 @@ pub async fn execute_load_holons_client(
 
     let full_dump = dump_full_response(&response_reference);
     info!("[loader-client] response_full_dump:\n{}", full_dump);
+    info!(
+        "[loader-client] metrics observed: staged={}, committed={}, links_created={}, errors={}, total_bundles={}, total_loader_holons={}; expected: staged={}, committed={}, links_created={}, errors={}, total_bundles={}, total_loader_holons={}",
+        staged,
+        committed,
+        links_created,
+        errors,
+        total_bundles,
+        total_loader_holons,
+        expect_staged.0,
+        expect_committed.0,
+        expect_links_created.0,
+        expect_errors.0,
+        expect_total_bundles.0,
+        expect_total_loader_holons.0
+    );
 
     assert_eq!(staged, expect_staged.0);
     assert_eq!(committed, expect_committed.0);

--- a/tests/sweetests/tests/execution_steps/mod.rs
+++ b/tests/sweetests/tests/execution_steps/mod.rs
@@ -4,6 +4,7 @@ pub mod begin_transaction_executor;
 pub mod commit_executor;
 pub mod delete_holon_executor;
 pub mod ensure_database_count_executor;
+pub mod load_book_person_inverse_test_schema_executor;
 pub mod load_core_schema_executor;
 pub mod load_holons_client_executor;
 pub mod load_holons_internal_executor;

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -1,0 +1,23 @@
+use holons_prelude::prelude::*;
+use holons_test::{DancesTestCase, TestCaseInit};
+
+/// Fixture for the `LoadBookPersonInverseTestSchema` preset step.
+///
+/// Loads MAP core schema first, then starts a fresh transaction and imports the
+/// Book/Person inverse test schema through public MAP Commands `LoadHolons`
+/// ingress. This exercises loader resolution against already-saved core-schema
+/// holons rather than restaging core and domain together in one import.
+pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, .. } = TestCaseInit::new(
+        "load_book_person_inverse_schema",
+        "Load Book/Person inverse test schema after committed MAP core schema",
+    );
+
+    test_case.add_load_core_schema_step(None)?;
+    test_case.add_begin_transaction_step(None, None)?;
+    test_case.add_load_book_person_inverse_test_schema_step(None)?;
+
+    test_case.finalize(&fixture_context)?;
+
+    Ok(test_case)
+}

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -2,6 +2,7 @@ pub mod abandon_staged_changes_fixture;
 pub mod delete_holon_fixture;
 pub mod ergonomic_add_remove_properties_fixture;
 pub mod ergonomic_add_remove_related_holons_fixture;
+pub mod load_book_person_inverse_schema_fixture;
 pub mod load_core_schema_fixture;
 pub mod load_holons_internal_fixture;
 pub mod setup_book_and_authors_fixture;


### PR DESCRIPTION
Closes #447. **Stacked on top of #457** — could merge that first; this PR's base should retarget to `main` automatically on merge.

## Summary

Adds the first-class sweetest preset step `LoadBookPersonInverseTestSchema`, which loads a Book/Person inverse domain schema through the public `TransactionAction::LoadHolons { content_set }` ingress path as a standalone step that runs **after** `LoadCoreSchema` has already committed core-schema types.

This is the intended design enabled by #455's staged-first / saved-fallback loader resolution: the domain import's references to core-schema types (e.g., `DescribedBy` targets) now resolve against already-saved holons, so there's no need to restage core and domain together.

## What's in it

- **Preset step** — `DanceTestStep::LoadBookPersonInverseTestSchema` + adder `add_load_book_person_inverse_test_schema_step`
- **Executor** — `execute_load_book_person_inverse_test_schema` mirrors `execute_load_core_schema`; dispatches a single `LoadHolons` with `total_bundles = 1`
- **Helper** — `book_person_inverse_schema.rs` owns the domain schema path, `ContentSet` builder, and `BOOK_PERSON_INVERSE_METRICS` (staged = 7, committed = 7, links_created = 39, errors = 0, total_bundles = 1, total_loader_holons = 7)
- **Fixture** — `load_book_person_inverse_schema_fixture` runs `LoadCoreSchema` → `BeginTransaction` → `LoadBookPersonInverseTestSchema`, proving cross-import resolution end-to-end
- **Domain fixture JSON** — 7 holons: `BookAuthorInverseSchema`, `Book.HolonType`, `Person.HolonType`, `AuthoredBy`, `Authors`, `Name.PropertyType`, `Title.PropertyType`
- **Schema housekeeping** — renames documentary meta `depends_on_files` → `load_with` in the three copies of `bootstrap-import.schema.json` (canonical + `host/ui/public/` + `holons_loader_client/resources/`); also syncs the two copies to the #455 `$ref` pattern relaxation

## Test plan

- [x] `npm run check`
- [x] `npm run test:unit`
- [x] `npm run sweetest` — new `load_book_person_inverse_schema_test` passes with `errors = 0` and the expected metrics; existing sweetests remain green
- [x] Tracing confirms a **single** `TransactionAction::LoadHolons` dispatch for the domain step (`total_bundles = 1`)

## Out of scope (per issue)

- Inverse relationship commit semantics — deferred to #442
- Generic public arbitrary-schema-loading test step
- Replacing existing Rust-built schema-sensitive fixtures