### PR TITLE
453 descriptors    pr1    implement descriptor runtime abstractions and shared access patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "fmt:sweetests:check": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all --check",
 
     "test": "npm run test:unit && npm run sweetest",
-    "test:unit": "npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run typecheck -w map-sdk && npm run test -w map-sdk",
+    "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run typecheck -w map-sdk && npm run test -w map-sdk",
+    "test:unit:shared": "cargo test --manifest-path shared_crates/type_system/base_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/integrity_core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/type_names/Cargo.toml && cargo test --manifest-path shared_crates/shared_validation/Cargo.toml && cargo test --manifest-path shared_crates/holons_core/Cargo.toml && cargo test --manifest-path shared_crates/holons_boundary/Cargo.toml && cargo test --manifest-path shared_crates/holons_prelude/Cargo.toml && cargo test --manifest-path shared_crates/holon_dance_builders/Cargo.toml && cargo test --manifest-path shared_crates/holons_trust_channel/Cargo.toml && cargo test --manifest-path shared_crates/json_schema_validation/Cargo.toml",
 
     "sweetest": "RUST_LOG=${RUST_LOG:-warn} WASM_LOG=${WASM_LOG:-warn} npm run build:happ && npm run sweet:test",
     "sweetest:nocapture": "RUST_LOG=${RUST_LOG:-warn} WASM_LOG=${WASM_LOG:-warn} npm run build:happ && npm run sweet:test:nocapture",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "host/map-sdk"
   ],
   "scripts": {
-    "start": "npm run build:happ && RUST_LOG=${RUST_LOG:-host:warn} WASM_LOG=${WASM_LOG:-warn} HC_DEV_MODE=${HC_DEV_MODE:-1} npm run start -w host",
+    "start": "npm run build:happ && RUST_LOG=${RUST_LOG:-host:warn} WASM_LOG=${WASM_LOG:-warn} HC_DEV_MODE=${HC_DEV_MODE:-1} npm run start -w map-host",
     "start:info": "npm run build:happ && RUST_LOG=host=info npm run start:host",
     "start:debug": "npm run build:happ && RUST_LOG=host=debug npm run start:host",
     "start:host": "npm run start -w map-host",
-    "start:nobuild": "RUST_LOG=host:debug WASM_LOG=info HC_DEV_MODE=1 npm run start -w host",
+    "start:nobuild": "RUST_LOG=host:debug WASM_LOG=info HC_DEV_MODE=1 npm run start -w map-host",
 
     "build": "npm run build:happ && npm run build:host",
     "build:host": "npm run build -w map-host",

--- a/shared_crates/holons_core/src/dances/dance_response.rs
+++ b/shared_crates/holons_core/src/dances/dance_response.rs
@@ -202,6 +202,10 @@ impl From<HolonError> for ResponseStatusCode {
 
             // 422-ish (semantic validation / parse errors)
             HolonError::LoaderParsingError(_) => ResponseStatusCode::UnprocessableEntity,
+            HolonError::MissingDescribedBy { .. } => ResponseStatusCode::UnprocessableEntity,
+            HolonError::MultipleDescribedBy { .. } => ResponseStatusCode::UnprocessableEntity,
+            HolonError::MultipleExtends { .. } => ResponseStatusCode::UnprocessableEntity,
+            HolonError::CyclicExtends { .. } => ResponseStatusCode::UnprocessableEntity,
             HolonError::ReferenceBindingFailed { .. } => ResponseStatusCode::UnprocessableEntity,
             HolonError::ReferenceResolutionFailed { .. } => ResponseStatusCode::UnprocessableEntity,
             HolonError::ValidationError(_) => ResponseStatusCode::UnprocessableEntity,

--- a/shared_crates/holons_core/src/descriptors/descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/descriptor.rs
@@ -1,5 +1,10 @@
 use crate::reference_layer::HolonReference;
 
+/// Common runtime contract for thin descriptor wrappers.
+///
+/// Descriptor wrappers stay intentionally small: they expose their backing
+/// holon reference and layer any descriptor-specific behavior on top.
 pub trait Descriptor {
+    /// Returns the backing holon reference for this descriptor wrapper.
     fn holon(&self) -> &HolonReference;
 }

--- a/shared_crates/holons_core/src/descriptors/descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/descriptor.rs
@@ -1,0 +1,5 @@
+use crate::reference_layer::HolonReference;
+
+pub trait Descriptor {
+    fn holon(&self) -> &HolonReference;
+}

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -1,0 +1,121 @@
+use crate::descriptors::{Descriptor, TypeHeader};
+use crate::reference_layer::HolonReference;
+
+pub struct HolonDescriptor {
+    holon: HolonReference,
+}
+
+impl HolonDescriptor {
+    pub(crate) fn new(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+}
+
+impl Descriptor for HolonDescriptor {
+    fn holon(&self) -> &HolonReference {
+        &self.holon
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_shared_objects::transactions::TransactionContext;
+    use crate::descriptors::test_support::{build_context, new_test_holon};
+    use crate::reference_layer::{ReadableHolon, WritableHolon};
+    use crate::TransientReference;
+    use base_types::MapString;
+    use core_types::HolonError;
+    use std::sync::Arc;
+    use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
+
+    fn new_descriptor_holon(
+        context: &Arc<TransactionContext>,
+        key: &str,
+        type_name: &str,
+    ) -> Result<TransientReference, HolonError> {
+        let mut descriptor = new_test_holon(context, key)?;
+        descriptor
+            .with_property_value(CorePropertyTypeName::TypeName, type_name)?
+            .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
+            .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
+        Ok(descriptor)
+    }
+
+    fn assert_is_descriptor<T: Descriptor>(descriptor: &T) {
+        let _ = descriptor.holon().reference_id_string();
+    }
+
+    #[test]
+    fn holon_descriptor_resolves_for_transient_source() -> Result<(), HolonError> {
+        let context = build_context();
+        let descriptor =
+            new_descriptor_holon(&context, "descriptor-transient", "TransientDescriptor")?;
+        let mut source = new_test_holon(&context, "source-transient")?;
+        source.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![descriptor.clone().into()],
+        )?;
+
+        let resolved = source.holon_descriptor()?;
+
+        assert_eq!(resolved.header().type_name()?, MapString("TransientDescriptor".to_string()));
+        assert_eq!(resolved.holon(), &HolonReference::from(&descriptor));
+        assert_is_descriptor(&resolved);
+
+        Ok(())
+    }
+
+    #[test]
+    fn holon_descriptor_resolves_for_staged_source() -> Result<(), HolonError> {
+        let context = build_context();
+        let descriptor = new_descriptor_holon(&context, "descriptor-staged", "StagedDescriptor")?;
+        let staged_descriptor = context.mutation().stage_new_holon(descriptor)?;
+        let source = new_test_holon(&context, "source-staged")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        staged_source.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![staged_descriptor.into()],
+        )?;
+
+        let resolved = staged_source.holon_descriptor()?;
+
+        assert_eq!(resolved.header().type_name()?, MapString("StagedDescriptor".to_string()));
+        assert_is_descriptor(&resolved);
+
+        Ok(())
+    }
+
+    #[test]
+    fn holon_descriptor_errors_when_described_by_missing() -> Result<(), HolonError> {
+        let context = build_context();
+        let source = new_test_holon(&context, "missing-descriptor")?;
+
+        assert!(matches!(source.holon_descriptor(), Err(HolonError::MissingDescribedBy { .. })));
+
+        Ok(())
+    }
+
+    #[test]
+    fn holon_descriptor_errors_when_multiple_described_by_present() -> Result<(), HolonError> {
+        let context = build_context();
+        let descriptor_a = new_descriptor_holon(&context, "descriptor-a", "DescriptorA")?;
+        let descriptor_b = new_descriptor_holon(&context, "descriptor-b", "DescriptorB")?;
+        let mut source = new_test_holon(&context, "multiple-descriptor-source")?;
+        source.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![descriptor_a.into(), descriptor_b.into()],
+        )?;
+
+        assert!(matches!(
+            source.holon_descriptor(),
+            Err(HolonError::MultipleDescribedBy { count, .. }) if count == 2
+        ));
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -1,6 +1,10 @@
 use crate::descriptors::{Descriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 
+/// Runtime wrapper for holon-type descriptors.
+///
+/// This is the main descriptor surface that callers will reach from ordinary
+/// holon instances via `ReadableHolon::holon_descriptor()`.
 pub struct HolonDescriptor {
     holon: HolonReference,
 }
@@ -10,6 +14,7 @@ impl HolonDescriptor {
         Self { holon }
     }
 
+    /// Projects the shared descriptor header view for this descriptor holon.
     pub fn header(&self) -> TypeHeader<'_> {
         TypeHeader::new(&self.holon)
     }
@@ -38,6 +43,7 @@ mod tests {
         key: &str,
         type_name: &str,
     ) -> Result<TransientReference, HolonError> {
+        // Descriptor tests only need the shared header surface in this phase.
         let mut descriptor = new_test_holon(context, key)?;
         descriptor
             .with_property_value(CorePropertyTypeName::TypeName, type_name)?
@@ -47,6 +53,7 @@ mod tests {
     }
 
     fn assert_is_descriptor<T: Descriptor>(descriptor: &T) {
+        // Compile-time trait membership plus one trivial runtime use.
         let _ = descriptor.holon().reference_id_string();
     }
 

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -10,13 +10,20 @@ pub struct HolonDescriptor {
 }
 
 impl HolonDescriptor {
-    pub(crate) fn new(holon: HolonReference) -> Self {
+    /// Wraps an already-resolved descriptor holon reference.
+    pub fn from_holon(holon: HolonReference) -> Self {
         Self { holon }
     }
 
     /// Projects the shared descriptor header view for this descriptor holon.
     pub fn header(&self) -> TypeHeader<'_> {
         TypeHeader::new(&self.holon)
+    }
+}
+
+impl From<HolonReference> for HolonDescriptor {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
     }
 }
 
@@ -55,6 +62,21 @@ mod tests {
     fn assert_is_descriptor<T: Descriptor>(descriptor: &T) {
         // Compile-time trait membership plus one trivial runtime use.
         let _ = descriptor.holon().reference_id_string();
+    }
+
+    #[test]
+    fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon =
+            HolonReference::from(&new_descriptor_holon(&context, "holon-descriptor", "HolonType")?);
+
+        let descriptor = HolonDescriptor::from_holon(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+        assert_eq!(descriptor.header().type_name()?, MapString("HolonType".to_string()));
+        assert_is_descriptor(&descriptor);
+
+        Ok(())
     }
 
     #[test]

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -1,0 +1,248 @@
+use std::collections::HashSet;
+use std::sync::RwLockReadGuard;
+
+use crate::core_shared_objects::{holon::state::AccessType, HolonCollection};
+use crate::reference_layer::{HolonReference, ReadableHolon};
+use core_types::HolonError;
+use type_names::relationship_names::CoreRelationshipTypeName;
+
+/// Resolves the direct `Extends` parent for a descriptor holon.
+///
+/// Cardinality is enforced here so all iterator-based callers inherit the same
+/// multiple-parent error semantics.
+pub(crate) fn extends_parent(holon: &HolonReference) -> Result<Option<HolonReference>, HolonError> {
+    holon.is_accessible(AccessType::Read)?;
+    let collection_arc = holon.related_holons(CoreRelationshipTypeName::Extends)?;
+    let collection = collection_arc.read().map_err(lock_error)?;
+    collection.is_accessible(AccessType::Read)?;
+    let members = collection.get_members();
+
+    match members.as_slice() {
+        [] => Ok(None),
+        [single] => Ok(Some(single.clone())),
+        many => Err(HolonError::MultipleExtends {
+            descriptor: descriptor_label(holon),
+            count: many.len(),
+        }),
+    }
+}
+
+/// Returns a lazy iterator over the effective `Extends` chain.
+///
+/// Iteration always yields `self` first, then successive parents. Structural
+/// errors are reported at the point the iterator discovers them so callers can
+/// stop early once they have enough context.
+pub fn walk_extends_chain(start: &HolonReference) -> ExtendsIter {
+    ExtendsIter::new(start)
+}
+
+/// Materializes the full `Extends` chain including `self`.
+///
+/// This is the eager helper for callers that truly need the whole lineage
+/// rather than a short-circuiting iterator walk.
+pub fn ancestors(start: &HolonReference) -> Result<Vec<HolonReference>, HolonError> {
+    walk_extends_chain(start).collect()
+}
+
+/// Lazy iterator over a descriptor's `Extends` lineage.
+///
+/// State model:
+/// - `next` is the next descriptor to yield
+/// - `pending_error` stores a structural error discovered while preparing the
+///   next step
+/// - `visited` tracks already-yielded descriptors for cycle detection
+/// - `finished` marks terminal exhaustion after either the root or an error
+pub struct ExtendsIter {
+    next: Option<HolonReference>,
+    pending_error: Option<HolonError>,
+    visited: HashSet<String>,
+    finished: bool,
+}
+
+impl ExtendsIter {
+    fn new(start: &HolonReference) -> Self {
+        Self {
+            next: Some(start.clone()),
+            pending_error: None,
+            visited: HashSet::new(),
+            finished: false,
+        }
+    }
+}
+
+impl Iterator for ExtendsIter {
+    type Item = Result<HolonReference, HolonError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Terminal state: once the chain is exhausted or an error has been
+        // emitted, iteration stays closed.
+        if self.finished {
+            return None;
+        }
+
+        // Deferred error emission preserves the current item for callers that
+        // intentionally stop early (for example, first-match inheritance lookups).
+        if let Some(error) = self.pending_error.take() {
+            self.finished = true;
+            return Some(Err(error));
+        }
+
+        let current = self.next.take()?;
+        self.visited.insert(current.reference_id_string());
+
+        // Resolve the next step after capturing the current item. This keeps
+        // the iterator self-first while still surfacing cycles and
+        // multiple-parent structures on the following call.
+        match extends_parent(&current) {
+            Ok(Some(parent)) => {
+                if self.visited.contains(&parent.reference_id_string()) {
+                    self.pending_error =
+                        Some(HolonError::CyclicExtends { descriptor: descriptor_label(&parent) });
+                } else {
+                    self.next = Some(parent);
+                }
+            }
+            Ok(None) => {
+                self.finished = true;
+            }
+            Err(error) => {
+                self.pending_error = Some(error);
+            }
+        }
+
+        Some(Ok(current))
+    }
+}
+
+/// Best-effort descriptor label for structural inheritance errors.
+///
+/// Prefer the human-readable summary when available, but fall back to the
+/// stable reference id so error construction never cascades into a second
+/// failure path.
+fn descriptor_label(holon: &HolonReference) -> String {
+    match holon.summarize() {
+        Ok(summary) => summary,
+        Err(_) => holon.reference_id_string(),
+    }
+}
+
+/// Normalizes poisoned collection-lock errors into the crate's standard
+/// `FailedToAcquireLock` surface.
+fn lock_error(error: std::sync::PoisonError<RwLockReadGuard<'_, HolonCollection>>) -> HolonError {
+    HolonError::FailedToAcquireLock(format!(
+        "Failed to acquire read lock on holon collection: {}",
+        error
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{build_context, new_test_holon};
+    use crate::reference_layer::WritableHolon;
+    use type_names::relationship_names::CoreRelationshipTypeName;
+
+    #[test]
+    fn ancestors_returns_self_for_root_descriptor() -> Result<(), HolonError> {
+        let context = build_context();
+        let root = new_test_holon(&context, "root")?;
+        let root_ref = HolonReference::from(&root);
+
+        assert_eq!(ancestors(&root_ref)?, vec![root_ref]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn ancestors_returns_linear_chain_in_self_first_order() -> Result<(), HolonError> {
+        let context = build_context();
+        let root = new_test_holon(&context, "a")?;
+        let mut middle = new_test_holon(&context, "b")?;
+        let mut leaf = new_test_holon(&context, "c")?;
+
+        middle.add_related_holons(CoreRelationshipTypeName::Extends, vec![root.clone().into()])?;
+        leaf.add_related_holons(CoreRelationshipTypeName::Extends, vec![middle.clone().into()])?;
+
+        assert_eq!(
+            ancestors(&HolonReference::from(&leaf))?,
+            vec![
+                HolonReference::from(&leaf),
+                HolonReference::from(&middle),
+                HolonReference::from(&root),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn ancestors_errors_when_descriptor_has_multiple_extends() -> Result<(), HolonError> {
+        let context = build_context();
+        let parent_a = new_test_holon(&context, "parent-a")?;
+        let parent_b = new_test_holon(&context, "parent-b")?;
+        let mut child = new_test_holon(&context, "child")?;
+
+        child.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![parent_a.into(), parent_b.into()],
+        )?;
+
+        assert!(matches!(
+            ancestors(&HolonReference::from(&child)),
+            Err(HolonError::MultipleExtends { count, .. }) if count == 2
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn ancestors_errors_on_extends_cycles_and_self_loops() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut a = new_test_holon(&context, "cycle-a")?;
+        let mut b = new_test_holon(&context, "cycle-b")?;
+
+        a.add_related_holons(CoreRelationshipTypeName::Extends, vec![b.clone().into()])?;
+        b.add_related_holons(CoreRelationshipTypeName::Extends, vec![a.clone().into()])?;
+
+        assert!(matches!(
+            ancestors(&HolonReference::from(&a)),
+            Err(HolonError::CyclicExtends { .. })
+        ));
+
+        let mut self_loop = new_test_holon(&context, "self-loop")?;
+        self_loop.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![self_loop.clone().into()],
+        )?;
+
+        assert!(matches!(
+            ancestors(&HolonReference::from(&self_loop)),
+            Err(HolonError::CyclicExtends { .. })
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn walk_extends_chain_short_circuits_before_errors_further_up_chain() -> Result<(), HolonError>
+    {
+        let context = build_context();
+        let mut ancestor = new_test_holon(&context, "ancestor")?;
+        let mut middle = new_test_holon(&context, "middle")?;
+        let mut leaf = new_test_holon(&context, "leaf")?;
+
+        ancestor
+            .add_related_holons(CoreRelationshipTypeName::Extends, vec![ancestor.clone().into()])?;
+        middle
+            .add_related_holons(CoreRelationshipTypeName::Extends, vec![ancestor.clone().into()])?;
+        leaf.add_related_holons(CoreRelationshipTypeName::Extends, vec![middle.clone().into()])?;
+
+        let first_two = walk_extends_chain(&HolonReference::from(&leaf))
+            .take(2)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(first_two, vec![HolonReference::from(&leaf), HolonReference::from(&middle)]);
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::RwLockReadGuard;
 
-use crate::core_shared_objects::{holon::state::AccessType, HolonCollection};
+use crate::core_shared_objects::HolonCollection;
 use crate::reference_layer::{HolonReference, ReadableHolon};
 use core_types::HolonError;
 use type_names::relationship_names::CoreRelationshipTypeName;
@@ -11,10 +11,8 @@ use type_names::relationship_names::CoreRelationshipTypeName;
 /// Cardinality is enforced here so all iterator-based callers inherit the same
 /// multiple-parent error semantics.
 pub(crate) fn extends_parent(holon: &HolonReference) -> Result<Option<HolonReference>, HolonError> {
-    holon.is_accessible(AccessType::Read)?;
     let collection_arc = holon.related_holons(CoreRelationshipTypeName::Extends)?;
     let collection = collection_arc.read().map_err(lock_error)?;
-    collection.is_accessible(AccessType::Read)?;
     let members = collection.get_members();
 
     match members.as_slice() {

--- a/shared_crates/holons_core/src/descriptors/mod.rs
+++ b/shared_crates/holons_core/src/descriptors/mod.rs
@@ -1,5 +1,6 @@
 pub mod descriptor;
 pub mod holon_descriptor;
+pub mod inheritance;
 pub mod property_descriptor;
 pub mod relationship_descriptor;
 #[cfg(test)]
@@ -9,6 +10,7 @@ pub mod value_descriptor;
 
 pub use descriptor::Descriptor;
 pub use holon_descriptor::HolonDescriptor;
+pub use inheritance::{ancestors, walk_extends_chain, ExtendsIter};
 pub use property_descriptor::PropertyDescriptor;
 pub use relationship_descriptor::RelationshipDescriptor;
 pub use type_header::TypeHeader;

--- a/shared_crates/holons_core/src/descriptors/mod.rs
+++ b/shared_crates/holons_core/src/descriptors/mod.rs
@@ -1,0 +1,5 @@
+pub mod descriptor;
+pub mod type_header;
+
+pub use descriptor::Descriptor;
+pub use type_header::TypeHeader;

--- a/shared_crates/holons_core/src/descriptors/mod.rs
+++ b/shared_crates/holons_core/src/descriptors/mod.rs
@@ -1,5 +1,15 @@
 pub mod descriptor;
+pub mod holon_descriptor;
+pub mod property_descriptor;
+pub mod relationship_descriptor;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod type_header;
+pub mod value_descriptor;
 
 pub use descriptor::Descriptor;
+pub use holon_descriptor::HolonDescriptor;
+pub use property_descriptor::PropertyDescriptor;
+pub use relationship_descriptor::RelationshipDescriptor;
 pub use type_header::TypeHeader;
+pub use value_descriptor::ValueDescriptor;

--- a/shared_crates/holons_core/src/descriptors/property_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/property_descriptor.rs
@@ -1,0 +1,25 @@
+use crate::descriptors::Descriptor;
+use crate::reference_layer::HolonReference;
+
+pub struct PropertyDescriptor {
+    holon: HolonReference,
+}
+
+impl PropertyDescriptor {
+    #[allow(dead_code)]
+    pub(crate) fn new(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+}
+
+impl Descriptor for PropertyDescriptor {
+    fn holon(&self) -> &HolonReference {
+        &self.holon
+    }
+}
+
+#[cfg(test)]
+const _: fn() = || {
+    fn assert_impl<T: Descriptor>() {}
+    assert_impl::<PropertyDescriptor>();
+};

--- a/shared_crates/holons_core/src/descriptors/property_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/property_descriptor.rs
@@ -1,6 +1,10 @@
 use crate::descriptors::Descriptor;
 use crate::reference_layer::HolonReference;
 
+/// Runtime wrapper for property descriptors.
+///
+/// This remains a thin view in Phase 1/2 so later value-type behavior can land
+/// on a stable wrapper without changing call-site types.
 pub struct PropertyDescriptor {
     holon: HolonReference,
 }
@@ -20,6 +24,7 @@ impl Descriptor for PropertyDescriptor {
 
 #[cfg(test)]
 const _: fn() = || {
+    // Compile-time guard: this wrapper must continue implementing Descriptor.
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<PropertyDescriptor>();
 };

--- a/shared_crates/holons_core/src/descriptors/property_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/property_descriptor.rs
@@ -1,4 +1,4 @@
-use crate::descriptors::Descriptor;
+use crate::descriptors::{Descriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 
 /// Runtime wrapper for property descriptors.
@@ -10,9 +10,20 @@ pub struct PropertyDescriptor {
 }
 
 impl PropertyDescriptor {
-    #[allow(dead_code)]
-    pub(crate) fn new(holon: HolonReference) -> Self {
+    /// Wraps an already-resolved descriptor holon reference.
+    pub fn from_holon(holon: HolonReference) -> Self {
         Self { holon }
+    }
+
+    /// Projects the shared descriptor header view for this descriptor holon.
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+}
+
+impl From<HolonReference> for PropertyDescriptor {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
     }
 }
 
@@ -28,3 +39,29 @@ const _: fn() = || {
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<PropertyDescriptor>();
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{build_context, new_descriptor_holon};
+    use base_types::MapString;
+    use core_types::HolonError;
+
+    #[test]
+    fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = HolonReference::from(&new_descriptor_holon(
+            &context,
+            "property-descriptor",
+            "PropertyType",
+            "Property",
+        )?);
+
+        let descriptor = PropertyDescriptor::from_holon(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+        assert_eq!(descriptor.header().type_name()?, MapString("PropertyType".to_string()));
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
@@ -1,0 +1,25 @@
+use crate::descriptors::Descriptor;
+use crate::reference_layer::HolonReference;
+
+pub struct RelationshipDescriptor {
+    holon: HolonReference,
+}
+
+impl RelationshipDescriptor {
+    #[allow(dead_code)]
+    pub(crate) fn new(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+}
+
+impl Descriptor for RelationshipDescriptor {
+    fn holon(&self) -> &HolonReference {
+        &self.holon
+    }
+}
+
+#[cfg(test)]
+const _: fn() = || {
+    fn assert_impl<T: Descriptor>() {}
+    assert_impl::<RelationshipDescriptor>();
+};

--- a/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
@@ -1,4 +1,4 @@
-use crate::descriptors::Descriptor;
+use crate::descriptors::{Descriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 
 /// Runtime wrapper for relationship descriptors.
@@ -10,9 +10,20 @@ pub struct RelationshipDescriptor {
 }
 
 impl RelationshipDescriptor {
-    #[allow(dead_code)]
-    pub(crate) fn new(holon: HolonReference) -> Self {
+    /// Wraps an already-resolved descriptor holon reference.
+    pub fn from_holon(holon: HolonReference) -> Self {
         Self { holon }
+    }
+
+    /// Projects the shared descriptor header view for this descriptor holon.
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+}
+
+impl From<HolonReference> for RelationshipDescriptor {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
     }
 }
 
@@ -28,3 +39,29 @@ const _: fn() = || {
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<RelationshipDescriptor>();
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{build_context, new_descriptor_holon};
+    use base_types::MapString;
+    use core_types::HolonError;
+
+    #[test]
+    fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = HolonReference::from(&new_descriptor_holon(
+            &context,
+            "relationship-descriptor",
+            "RelationshipType",
+            "Relationship",
+        )?);
+
+        let descriptor = RelationshipDescriptor::from_holon(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+        assert_eq!(descriptor.header().type_name()?, MapString("RelationshipType".to_string()));
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/relationship_descriptor.rs
@@ -1,6 +1,10 @@
 use crate::descriptors::Descriptor;
 use crate::reference_layer::HolonReference;
 
+/// Runtime wrapper for relationship descriptors.
+///
+/// Relationship-specific structural and inverse-link behavior will accumulate
+/// here in later phases while the wrapper itself stays just a typed view.
 pub struct RelationshipDescriptor {
     holon: HolonReference,
 }
@@ -20,6 +24,7 @@ impl Descriptor for RelationshipDescriptor {
 
 #[cfg(test)]
 const _: fn() = || {
+    // Compile-time guard: this wrapper must continue implementing Descriptor.
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<RelationshipDescriptor>();
 };

--- a/shared_crates/holons_core/src/descriptors/test_support.rs
+++ b/shared_crates/holons_core/src/descriptors/test_support.rs
@@ -7,6 +7,10 @@ use core_types::{HolonError, HolonId, LocalId, RelationshipName};
 use std::any::Any;
 use std::sync::Arc;
 
+// Minimal fail-fast holon service for descriptor unit tests.
+//
+// Descriptor runtime tests stay entirely in-memory in this phase, so any call
+// that would cross into the real holon service is a test bug.
 #[derive(Debug)]
 struct TestHolonService;
 
@@ -76,6 +80,10 @@ impl HolonServiceApi for TestHolonService {
     }
 }
 
+/// Builds a fresh in-memory transaction context for descriptor tests.
+///
+/// This mirrors the transaction-context test harness so descriptor tests can
+/// stage transient and staged holons without involving host or guest services.
 pub(crate) fn build_context() -> Arc<TransactionContext> {
     let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
     let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
@@ -91,6 +99,10 @@ pub(crate) fn build_context() -> Arc<TransactionContext> {
         .expect("default transaction should open")
 }
 
+/// Creates a transient holon with a deterministic test key.
+///
+/// Descriptor tests use keyed transients because the underlying runtime rejects
+/// keyless transient creation in normal mutation flows.
 pub(crate) fn new_test_holon(
     context: &Arc<TransactionContext>,
     key: &str,

--- a/shared_crates/holons_core/src/descriptors/test_support.rs
+++ b/shared_crates/holons_core/src/descriptors/test_support.rs
@@ -1,7 +1,7 @@
 use crate::core_shared_objects::space_manager::HolonSpaceManager;
 use crate::core_shared_objects::transactions::TransactionContext;
 use crate::core_shared_objects::{Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy};
-use crate::reference_layer::{HolonServiceApi, StagedReference, TransientReference};
+use crate::reference_layer::{HolonServiceApi, StagedReference, TransientReference, WritableHolon};
 use base_types::MapString;
 use core_types::{HolonError, HolonId, LocalId, RelationshipName};
 use std::any::Any;
@@ -108,4 +108,22 @@ pub(crate) fn new_test_holon(
     key: &str,
 ) -> Result<TransientReference, HolonError> {
     context.mutation().new_holon(Some(MapString(key.to_string())))
+}
+
+/// Creates a transient descriptor holon with the shared header properties.
+pub(crate) fn new_descriptor_holon(
+    context: &Arc<TransactionContext>,
+    key: &str,
+    type_name: &str,
+    instance_type_kind: &str,
+) -> Result<TransientReference, HolonError> {
+    let mut descriptor = new_test_holon(context, key)?;
+    descriptor
+        .with_property_value(type_names::CorePropertyTypeName::TypeName, type_name)?
+        .with_property_value(type_names::CorePropertyTypeName::IsAbstractType, false)?
+        .with_property_value(
+            type_names::CorePropertyTypeName::InstanceTypeKind,
+            instance_type_kind,
+        )?;
+    Ok(descriptor)
 }

--- a/shared_crates/holons_core/src/descriptors/test_support.rs
+++ b/shared_crates/holons_core/src/descriptors/test_support.rs
@@ -1,0 +1,99 @@
+use crate::core_shared_objects::space_manager::HolonSpaceManager;
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::core_shared_objects::{Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy};
+use crate::reference_layer::{HolonServiceApi, StagedReference, TransientReference};
+use base_types::MapString;
+use core_types::{HolonError, HolonId, LocalId, RelationshipName};
+use std::any::Any;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct TestHolonService;
+
+fn unreachable_in_descriptor_tests<T>() -> Result<T, HolonError> {
+    Err(HolonError::NotImplemented("TestHolonService".to_string()))
+}
+
+impl HolonServiceApi for TestHolonService {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn commit_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _staged_references: &[StagedReference],
+    ) -> Result<TransientReference, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn delete_holon_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _local_id: &LocalId,
+    ) -> Result<(), HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn fetch_all_related_holons_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _source_id: &HolonId,
+    ) -> Result<RelationshipMap, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn fetch_holon_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _id: &HolonId,
+    ) -> Result<Holon, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn fetch_related_holons_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _source_id: &HolonId,
+        _relationship_name: &RelationshipName,
+    ) -> Result<HolonCollection, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn get_all_holons_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+    ) -> Result<HolonCollection, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+
+    fn load_holons_internal(
+        &self,
+        _context: &Arc<TransactionContext>,
+        _bundle: TransientReference,
+    ) -> Result<TransientReference, HolonError> {
+        unreachable_in_descriptor_tests()
+    }
+}
+
+pub(crate) fn build_context() -> Arc<TransactionContext> {
+    let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
+    let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
+        None,
+        holon_service,
+        None,
+        ServiceRoutingPolicy::BlockExternal,
+    ));
+
+    space_manager
+        .get_transaction_manager()
+        .open_new_transaction(Arc::clone(&space_manager))
+        .expect("default transaction should open")
+}
+
+pub(crate) fn new_test_holon(
+    context: &Arc<TransactionContext>,
+    key: &str,
+) -> Result<TransientReference, HolonError> {
+    context.mutation().new_holon(Some(MapString(key.to_string())))
+}

--- a/shared_crates/holons_core/src/descriptors/type_header.rs
+++ b/shared_crates/holons_core/src/descriptors/type_header.rs
@@ -8,7 +8,6 @@ pub struct TypeHeader<'a> {
 }
 
 impl<'a> TypeHeader<'a> {
-    #[allow(dead_code)]
     pub(crate) fn new(holon: &'a HolonReference) -> Self {
         Self { holon }
     }
@@ -77,105 +76,14 @@ impl<'a> TypeHeader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core_shared_objects::space_manager::HolonSpaceManager;
-    use crate::core_shared_objects::transactions::TransactionContext;
-    use crate::core_shared_objects::{
-        Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
-    };
-    use crate::reference_layer::{
-        HolonServiceApi, StagedReference, TransientReference, WritableHolon,
-    };
+    use crate::descriptors::test_support::{build_context, new_test_holon};
+    use crate::reference_layer::WritableHolon;
     use base_types::MapString;
-    use core_types::{HolonId, LocalId, RelationshipName};
-    use std::any::Any;
-    use std::sync::Arc;
-
-    #[derive(Debug)]
-    struct TestHolonService;
-
-    fn unreachable_in_type_header_tests<T>() -> Result<T, HolonError> {
-        Err(HolonError::NotImplemented("TestHolonService".to_string()))
-    }
-
-    impl HolonServiceApi for TestHolonService {
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn commit_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _staged_references: &[StagedReference],
-        ) -> Result<TransientReference, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn delete_holon_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _local_id: &LocalId,
-        ) -> Result<(), HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn fetch_all_related_holons_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _source_id: &HolonId,
-        ) -> Result<RelationshipMap, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn fetch_holon_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _id: &HolonId,
-        ) -> Result<Holon, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn fetch_related_holons_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _source_id: &HolonId,
-            _relationship_name: &RelationshipName,
-        ) -> Result<HolonCollection, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn get_all_holons_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-        ) -> Result<HolonCollection, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-
-        fn load_holons_internal(
-            &self,
-            _context: &Arc<TransactionContext>,
-            _bundle: TransientReference,
-        ) -> Result<TransientReference, HolonError> {
-            unreachable_in_type_header_tests()
-        }
-    }
-
-    fn build_context() -> Arc<TransactionContext> {
-        let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
-        let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
-            None,
-            holon_service,
-            None,
-            ServiceRoutingPolicy::BlockExternal,
-        ));
-
-        space_manager
-            .get_transaction_manager()
-            .open_new_transaction(Arc::clone(&space_manager))
-            .expect("default transaction should open")
-    }
+    use core_types::HolonError;
 
     fn build_header_holon() -> Result<HolonReference, HolonError> {
-        let mut holon = new_test_holon("header-holon")?;
+        let context = build_context();
+        let mut holon = new_test_holon(&context, "header-holon")?;
         holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")
             .and_then(|holon| {
@@ -200,11 +108,6 @@ mod tests {
 
         Ok(HolonReference::Transient(holon))
     }
-
-    fn new_test_holon(key: &str) -> Result<TransientReference, HolonError> {
-        build_context().mutation().new_holon(Some(MapString(key.to_string())))
-    }
-
     #[test]
     fn header_accessors_return_expected_values() -> Result<(), HolonError> {
         let holon_ref = build_header_holon()?;
@@ -226,7 +129,8 @@ mod tests {
 
     #[test]
     fn type_name_errors_when_required_property_missing() -> Result<(), HolonError> {
-        let mut holon = new_test_holon("missing-type-name")?;
+        let context = build_context();
+        let mut holon = new_test_holon(&context, "missing-type-name")?;
         holon
             .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
             .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
@@ -244,7 +148,8 @@ mod tests {
 
     #[test]
     fn optional_accessors_return_none_when_absent() -> Result<(), HolonError> {
-        let mut holon = new_test_holon("optional-header")?;
+        let context = build_context();
+        let mut holon = new_test_holon(&context, "optional-header")?;
         holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
             .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
@@ -263,7 +168,8 @@ mod tests {
 
     #[test]
     fn type_name_errors_when_property_value_has_wrong_type() -> Result<(), HolonError> {
-        let mut holon = new_test_holon("wrong-type-name")?;
+        let context = build_context();
+        let mut holon = new_test_holon(&context, "wrong-type-name")?;
         holon
             .with_property_value(CorePropertyTypeName::TypeName, true)?
             .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
@@ -282,7 +188,8 @@ mod tests {
 
     #[test]
     fn required_header_accessors_error_when_property_missing() -> Result<(), HolonError> {
-        let mut missing_bool_holon = new_test_holon("missing-is-abstract")?;
+        let context = build_context();
+        let mut missing_bool_holon = new_test_holon(&context, "missing-is-abstract")?;
         missing_bool_holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
             .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
@@ -295,7 +202,7 @@ mod tests {
             Err(HolonError::EmptyField(field)) if field == "IsAbstractType"
         ));
 
-        let mut missing_kind_holon = new_test_holon("missing-instance-type-kind")?;
+        let mut missing_kind_holon = new_test_holon(&context, "missing-instance-type-kind")?;
         missing_kind_holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
             .with_property_value(CorePropertyTypeName::IsAbstractType, false)?;

--- a/shared_crates/holons_core/src/descriptors/type_header.rs
+++ b/shared_crates/holons_core/src/descriptors/type_header.rs
@@ -1,0 +1,313 @@
+use crate::reference_layer::{HolonReference, ReadableHolon};
+use base_types::{BaseValue, MapString};
+use core_types::HolonError;
+use type_names::CorePropertyTypeName;
+
+pub struct TypeHeader<'a> {
+    holon: &'a HolonReference,
+}
+
+impl<'a> TypeHeader<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn new(holon: &'a HolonReference) -> Self {
+        Self { holon }
+    }
+
+    pub fn type_name(&self) -> Result<MapString, HolonError> {
+        self.require_string(CorePropertyTypeName::TypeName)
+    }
+
+    pub fn type_name_plural(&self) -> Result<Option<MapString>, HolonError> {
+        self.optional_string(CorePropertyTypeName::TypeNamePlural)
+    }
+
+    pub fn display_name(&self) -> Result<Option<MapString>, HolonError> {
+        self.optional_string(CorePropertyTypeName::DisplayName)
+    }
+
+    pub fn display_name_plural(&self) -> Result<Option<MapString>, HolonError> {
+        self.optional_string(CorePropertyTypeName::DisplayNamePlural)
+    }
+
+    pub fn description(&self) -> Result<Option<MapString>, HolonError> {
+        self.optional_string(CorePropertyTypeName::Description)
+    }
+
+    pub fn is_abstract_type(&self) -> Result<bool, HolonError> {
+        self.require_bool(CorePropertyTypeName::IsAbstractType)
+    }
+
+    pub fn instance_type_kind(&self) -> Result<MapString, HolonError> {
+        self.require_string(CorePropertyTypeName::InstanceTypeKind)
+    }
+
+    fn require_string(&self, prop: CorePropertyTypeName) -> Result<MapString, HolonError> {
+        let property_name = prop.as_property_name();
+        match self.holon.property_value(prop)? {
+            Some(BaseValue::StringValue(value)) => Ok(value),
+            Some(other) => {
+                Err(HolonError::UnexpectedValueType(format!("{:?}", other), "String".to_string()))
+            }
+            None => Err(HolonError::EmptyField(property_name.to_string())),
+        }
+    }
+
+    fn optional_string(&self, prop: CorePropertyTypeName) -> Result<Option<MapString>, HolonError> {
+        match self.holon.property_value(prop)? {
+            Some(BaseValue::StringValue(value)) => Ok(Some(value)),
+            Some(other) => {
+                Err(HolonError::UnexpectedValueType(format!("{:?}", other), "String".to_string()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn require_bool(&self, prop: CorePropertyTypeName) -> Result<bool, HolonError> {
+        let property_name = prop.as_property_name();
+        match self.holon.property_value(prop)? {
+            Some(BaseValue::BooleanValue(value)) => Ok(value.0),
+            Some(other) => {
+                Err(HolonError::UnexpectedValueType(format!("{:?}", other), "Boolean".to_string()))
+            }
+            None => Err(HolonError::EmptyField(property_name.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_shared_objects::space_manager::HolonSpaceManager;
+    use crate::core_shared_objects::transactions::TransactionContext;
+    use crate::core_shared_objects::{
+        Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
+    };
+    use crate::reference_layer::{
+        HolonServiceApi, StagedReference, TransientReference, WritableHolon,
+    };
+    use base_types::MapString;
+    use core_types::{HolonId, LocalId, RelationshipName};
+    use std::any::Any;
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct TestHolonService;
+
+    fn unreachable_in_type_header_tests<T>() -> Result<T, HolonError> {
+        Err(HolonError::NotImplemented("TestHolonService".to_string()))
+    }
+
+    impl HolonServiceApi for TestHolonService {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn commit_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _staged_references: &[StagedReference],
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn delete_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _local_id: &LocalId,
+        ) -> Result<(), HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn fetch_all_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+        ) -> Result<RelationshipMap, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn fetch_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _id: &HolonId,
+        ) -> Result<Holon, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn fetch_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+            _relationship_name: &RelationshipName,
+        ) -> Result<HolonCollection, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn get_all_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+        ) -> Result<HolonCollection, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+
+        fn load_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _bundle: TransientReference,
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_type_header_tests()
+        }
+    }
+
+    fn build_context() -> Arc<TransactionContext> {
+        let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
+        let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
+            None,
+            holon_service,
+            None,
+            ServiceRoutingPolicy::BlockExternal,
+        ));
+
+        space_manager
+            .get_transaction_manager()
+            .open_new_transaction(Arc::clone(&space_manager))
+            .expect("default transaction should open")
+    }
+
+    fn build_header_holon() -> Result<HolonReference, HolonError> {
+        let mut holon = new_test_holon("header-holon")?;
+        holon
+            .with_property_value(CorePropertyTypeName::TypeName, "HolonType")
+            .and_then(|holon| {
+                holon.with_property_value(CorePropertyTypeName::TypeNamePlural, "HolonTypes")
+            })
+            .and_then(|holon| {
+                holon.with_property_value(CorePropertyTypeName::DisplayName, "Holon Type")
+            })
+            .and_then(|holon| {
+                holon.with_property_value(CorePropertyTypeName::DisplayNamePlural, "Holon Types")
+            })
+            .and_then(|holon| {
+                holon.with_property_value(
+                    CorePropertyTypeName::Description,
+                    "Descriptor header test holon",
+                )
+            })
+            .and_then(|holon| holon.with_property_value(CorePropertyTypeName::IsAbstractType, true))
+            .and_then(|holon| {
+                holon.with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")
+            })?;
+
+        Ok(HolonReference::Transient(holon))
+    }
+
+    fn new_test_holon(key: &str) -> Result<TransientReference, HolonError> {
+        build_context().mutation().new_holon(Some(MapString(key.to_string())))
+    }
+
+    #[test]
+    fn header_accessors_return_expected_values() -> Result<(), HolonError> {
+        let holon_ref = build_header_holon()?;
+        let header = TypeHeader::new(&holon_ref);
+
+        assert_eq!(header.type_name()?, MapString("HolonType".to_string()));
+        assert_eq!(header.type_name_plural()?, Some(MapString("HolonTypes".to_string())));
+        assert_eq!(header.display_name()?, Some(MapString("Holon Type".to_string())));
+        assert_eq!(header.display_name_plural()?, Some(MapString("Holon Types".to_string())));
+        assert_eq!(
+            header.description()?,
+            Some(MapString("Descriptor header test holon".to_string()))
+        );
+        assert!(header.is_abstract_type()?);
+        assert_eq!(header.instance_type_kind()?, MapString("Holon".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn type_name_errors_when_required_property_missing() -> Result<(), HolonError> {
+        let mut holon = new_test_holon("missing-type-name")?;
+        holon
+            .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
+            .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
+
+        let holon_ref = HolonReference::Transient(holon);
+        let header = TypeHeader::new(&holon_ref);
+
+        assert!(matches!(
+            header.type_name(),
+            Err(HolonError::EmptyField(field)) if field == "TypeName"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_accessors_return_none_when_absent() -> Result<(), HolonError> {
+        let mut holon = new_test_holon("optional-header")?;
+        holon
+            .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
+            .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
+            .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
+
+        let holon_ref = HolonReference::Transient(holon);
+        let header = TypeHeader::new(&holon_ref);
+
+        assert_eq!(header.type_name_plural()?, None);
+        assert_eq!(header.display_name()?, None);
+        assert_eq!(header.display_name_plural()?, None);
+        assert_eq!(header.description()?, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn type_name_errors_when_property_value_has_wrong_type() -> Result<(), HolonError> {
+        let mut holon = new_test_holon("wrong-type-name")?;
+        holon
+            .with_property_value(CorePropertyTypeName::TypeName, true)?
+            .with_property_value(CorePropertyTypeName::IsAbstractType, false)?
+            .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
+
+        let holon_ref = HolonReference::Transient(holon);
+        let header = TypeHeader::new(&holon_ref);
+
+        assert!(matches!(
+            header.type_name(),
+            Err(HolonError::UnexpectedValueType(_, expected)) if expected == "String"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_header_accessors_error_when_property_missing() -> Result<(), HolonError> {
+        let mut missing_bool_holon = new_test_holon("missing-is-abstract")?;
+        missing_bool_holon
+            .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
+            .with_property_value(CorePropertyTypeName::InstanceTypeKind, "Holon")?;
+
+        let missing_bool_ref = HolonReference::Transient(missing_bool_holon);
+        let missing_bool_header = TypeHeader::new(&missing_bool_ref);
+
+        assert!(matches!(
+            missing_bool_header.is_abstract_type(),
+            Err(HolonError::EmptyField(field)) if field == "IsAbstractType"
+        ));
+
+        let mut missing_kind_holon = new_test_holon("missing-instance-type-kind")?;
+        missing_kind_holon
+            .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?
+            .with_property_value(CorePropertyTypeName::IsAbstractType, false)?;
+
+        let missing_kind_ref = HolonReference::Transient(missing_kind_holon);
+        let missing_kind_header = TypeHeader::new(&missing_kind_ref);
+
+        assert!(matches!(
+            missing_kind_header.instance_type_kind(),
+            Err(HolonError::EmptyField(field)) if field == "InstanceTypeKind"
+        ));
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/type_header.rs
+++ b/shared_crates/holons_core/src/descriptors/type_header.rs
@@ -3,6 +3,10 @@ use base_types::{BaseValue, MapString};
 use core_types::HolonError;
 use type_names::CorePropertyTypeName;
 
+/// Borrowed projection of the shared descriptor header fields.
+///
+/// `TypeHeader` does not own data or cache values; it centralizes the common
+/// property extraction logic used across descriptor wrappers.
 pub struct TypeHeader<'a> {
     holon: &'a HolonReference,
 }
@@ -12,35 +16,43 @@ impl<'a> TypeHeader<'a> {
         Self { holon }
     }
 
+    /// Returns the required singular type name from the backing descriptor.
     pub fn type_name(&self) -> Result<MapString, HolonError> {
         self.require_string(CorePropertyTypeName::TypeName)
     }
 
+    /// Returns the optional plural type name when the schema provides one.
     pub fn type_name_plural(&self) -> Result<Option<MapString>, HolonError> {
         self.optional_string(CorePropertyTypeName::TypeNamePlural)
     }
 
+    /// Returns the optional human-facing display name.
     pub fn display_name(&self) -> Result<Option<MapString>, HolonError> {
         self.optional_string(CorePropertyTypeName::DisplayName)
     }
 
+    /// Returns the optional plural display name.
     pub fn display_name_plural(&self) -> Result<Option<MapString>, HolonError> {
         self.optional_string(CorePropertyTypeName::DisplayNamePlural)
     }
 
+    /// Returns the optional human-facing description.
     pub fn description(&self) -> Result<Option<MapString>, HolonError> {
         self.optional_string(CorePropertyTypeName::Description)
     }
 
+    /// Returns whether the descriptor is marked abstract.
     pub fn is_abstract_type(&self) -> Result<bool, HolonError> {
         self.require_bool(CorePropertyTypeName::IsAbstractType)
     }
 
+    /// Returns the required instance kind string from the header.
     pub fn instance_type_kind(&self) -> Result<MapString, HolonError> {
         self.require_string(CorePropertyTypeName::InstanceTypeKind)
     }
 
     fn require_string(&self, prop: CorePropertyTypeName) -> Result<MapString, HolonError> {
+        // Required string fields share the same missing-vs-wrong-type semantics.
         let property_name = prop.as_property_name();
         match self.holon.property_value(prop)? {
             Some(BaseValue::StringValue(value)) => Ok(value),
@@ -52,6 +64,7 @@ impl<'a> TypeHeader<'a> {
     }
 
     fn optional_string(&self, prop: CorePropertyTypeName) -> Result<Option<MapString>, HolonError> {
+        // Optional string fields still fail loudly when the stored value shape is wrong.
         match self.holon.property_value(prop)? {
             Some(BaseValue::StringValue(value)) => Ok(Some(value)),
             Some(other) => {
@@ -62,6 +75,7 @@ impl<'a> TypeHeader<'a> {
     }
 
     fn require_bool(&self, prop: CorePropertyTypeName) -> Result<bool, HolonError> {
+        // Boolean header fields mirror the required-string contract with a different base type.
         let property_name = prop.as_property_name();
         match self.holon.property_value(prop)? {
             Some(BaseValue::BooleanValue(value)) => Ok(value.0),
@@ -83,6 +97,7 @@ mod tests {
 
     fn build_header_holon() -> Result<HolonReference, HolonError> {
         let context = build_context();
+        // Populate the full shared header surface for the happy-path assertions.
         let mut holon = new_test_holon(&context, "header-holon")?;
         holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")
@@ -108,6 +123,7 @@ mod tests {
 
         Ok(HolonReference::Transient(holon))
     }
+
     #[test]
     fn header_accessors_return_expected_values() -> Result<(), HolonError> {
         let holon_ref = build_header_holon()?;
@@ -189,6 +205,7 @@ mod tests {
     #[test]
     fn required_header_accessors_error_when_property_missing() -> Result<(), HolonError> {
         let context = build_context();
+        // Exercise each required accessor with its own missing-property shape.
         let mut missing_bool_holon = new_test_holon(&context, "missing-is-abstract")?;
         missing_bool_holon
             .with_property_value(CorePropertyTypeName::TypeName, "HolonType")?

--- a/shared_crates/holons_core/src/descriptors/value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor.rs
@@ -1,4 +1,4 @@
-use crate::descriptors::Descriptor;
+use crate::descriptors::{Descriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 
 /// Runtime wrapper for value-type descriptors.
@@ -10,9 +10,20 @@ pub struct ValueDescriptor {
 }
 
 impl ValueDescriptor {
-    #[allow(dead_code)]
-    pub(crate) fn new(holon: HolonReference) -> Self {
+    /// Wraps an already-resolved descriptor holon reference.
+    pub fn from_holon(holon: HolonReference) -> Self {
         Self { holon }
+    }
+
+    /// Projects the shared descriptor header view for this descriptor holon.
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+}
+
+impl From<HolonReference> for ValueDescriptor {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
     }
 }
 
@@ -28,3 +39,29 @@ const _: fn() = || {
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<ValueDescriptor>();
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{build_context, new_descriptor_holon};
+    use base_types::MapString;
+    use core_types::HolonError;
+
+    #[test]
+    fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = HolonReference::from(&new_descriptor_holon(
+            &context,
+            "value-descriptor",
+            "StringValueType",
+            "Value",
+        )?);
+
+        let descriptor = ValueDescriptor::from_holon(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+        assert_eq!(descriptor.header().type_name()?, MapString("StringValueType".to_string()));
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor.rs
@@ -1,6 +1,10 @@
 use crate::descriptors::Descriptor;
 use crate::reference_layer::HolonReference;
 
+/// Runtime wrapper for value-type descriptors.
+///
+/// Validation and operator behavior will dispatch through this wrapper in later
+/// phases, so the typed shell lands early even while behavior is still deferred.
 pub struct ValueDescriptor {
     holon: HolonReference,
 }
@@ -20,6 +24,7 @@ impl Descriptor for ValueDescriptor {
 
 #[cfg(test)]
 const _: fn() = || {
+    // Compile-time guard: this wrapper must continue implementing Descriptor.
     fn assert_impl<T: Descriptor>() {}
     assert_impl::<ValueDescriptor>();
 };

--- a/shared_crates/holons_core/src/descriptors/value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor.rs
@@ -1,0 +1,25 @@
+use crate::descriptors::Descriptor;
+use crate::reference_layer::HolonReference;
+
+pub struct ValueDescriptor {
+    holon: HolonReference,
+}
+
+impl ValueDescriptor {
+    #[allow(dead_code)]
+    pub(crate) fn new(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+}
+
+impl Descriptor for ValueDescriptor {
+    fn holon(&self) -> &HolonReference {
+        &self.holon
+    }
+}
+
+#[cfg(test)]
+const _: fn() = || {
+    fn assert_impl<T: Descriptor>() {}
+    assert_impl::<ValueDescriptor>();
+};

--- a/shared_crates/holons_core/src/lib.rs
+++ b/shared_crates/holons_core/src/lib.rs
@@ -22,8 +22,8 @@ pub use core_shared_objects::{
 };
 pub use core_types::HolonError;
 pub use descriptors::{
-    Descriptor, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
-    ValueDescriptor,
+    ancestors, walk_extends_chain, Descriptor, ExtendsIter, HolonDescriptor, PropertyDescriptor,
+    RelationshipDescriptor, TypeHeader, ValueDescriptor,
 };
 pub use reference_layer::{
     HolonCollectionApi, HolonReference, HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior,

--- a/shared_crates/holons_core/src/lib.rs
+++ b/shared_crates/holons_core/src/lib.rs
@@ -21,7 +21,10 @@ pub use core_shared_objects::{
     StagedRelationshipMap, TransientCollection,
 };
 pub use core_types::HolonError;
-pub use descriptors::{Descriptor, TypeHeader};
+pub use descriptors::{
+    Descriptor, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
+    ValueDescriptor,
+};
 pub use reference_layer::{
     HolonCollectionApi, HolonReference, HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior,
     ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior, TransientReference,

--- a/shared_crates/holons_core/src/lib.rs
+++ b/shared_crates/holons_core/src/lib.rs
@@ -7,6 +7,7 @@
 
 // Public Modules
 pub mod core_shared_objects;
+pub mod descriptors;
 pub mod reference_layer;
 // Utility modules (if needed outside the crate)
 pub mod dances;
@@ -20,6 +21,7 @@ pub use core_shared_objects::{
     StagedRelationshipMap, TransientCollection,
 };
 pub use core_types::HolonError;
+pub use descriptors::{Descriptor, TypeHeader};
 pub use reference_layer::{
     HolonCollectionApi, HolonReference, HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior,
     ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior, TransientReference,

--- a/shared_crates/holons_core/src/reference_layer/readable_holon.rs
+++ b/shared_crates/holons_core/src/reference_layer/readable_holon.rs
@@ -76,6 +76,15 @@ pub trait ReadableHolon: ReadableHolonImpl {
         ReadableHolonImpl::into_model_impl(self)
     }
 
+    /// Checks whether this reference can support the requested access type.
+    ///
+    /// This is primarily a reference-layer boundary concern. Normal callers should
+    /// prefer the higher-level read/write methods and rely on those methods to
+    /// enforce accessibility internally rather than pre-checking access manually.
+    ///
+    /// TODO: Reconsider whether this belongs on the public trait surface. The
+    /// concrete reference types still need internal accessibility checks, but
+    /// exposing this here can encourage higher layers to duplicate boundary logic.
     #[inline]
     fn is_accessible(&self, access: AccessType) -> Result<(), HolonError> {
         ReadableHolonImpl::is_accessible_impl(self, access)

--- a/shared_crates/holons_core/src/reference_layer/readable_holon.rs
+++ b/shared_crates/holons_core/src/reference_layer/readable_holon.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use super::{HolonReference, TransientReference};
+use crate::descriptors::HolonDescriptor;
 use crate::reference_layer::readable_impl::ReadableHolonImpl;
 use crate::{
     core_shared_objects::{
@@ -11,7 +12,7 @@ use crate::{
 };
 use base_types::MapString;
 use core_types::{HolonError, HolonId, HolonNodeModel, PropertyValue};
-use type_names::relationship_names::ToRelationshipName;
+use type_names::relationship_names::{CoreRelationshipTypeName, ToRelationshipName};
 use type_names::ToPropertyName;
 
 // Façade: ergonomic + complete; default bodies delegate to *_impl.
@@ -143,6 +144,22 @@ pub trait ReadableHolon: ReadableHolonImpl {
     ) -> Result<Arc<RwLock<HolonCollection>>, HolonError> {
         let rel = name.to_relationship_name();
         ReadableHolonImpl::related_holons_impl(self, &rel)
+    }
+
+    fn holon_descriptor(&self) -> Result<HolonDescriptor, HolonError> {
+        self.is_accessible(AccessType::Read)?;
+        let collection_arc = self.related_holons(CoreRelationshipTypeName::DescribedBy)?;
+        let collection =
+            collection_arc.read().map_err(|e| HolonError::FailedToAcquireLock(format!("{e}")))?;
+        let members = collection.get_members();
+
+        match members.as_slice() {
+            [] => Err(HolonError::MissingDescribedBy { holon: self.summarize()? }),
+            [single] => Ok(HolonDescriptor::new(single.clone())),
+            many => {
+                Err(HolonError::MultipleDescribedBy { holon: self.summarize()?, count: many.len() })
+            }
+        }
     }
 }
 

--- a/shared_crates/holons_core/src/reference_layer/readable_holon.rs
+++ b/shared_crates/holons_core/src/reference_layer/readable_holon.rs
@@ -147,7 +147,6 @@ pub trait ReadableHolon: ReadableHolonImpl {
     }
 
     fn holon_descriptor(&self) -> Result<HolonDescriptor, HolonError> {
-        self.is_accessible(AccessType::Read)?;
         let collection_arc = self.related_holons(CoreRelationshipTypeName::DescribedBy)?;
         let collection =
             collection_arc.read().map_err(|e| HolonError::FailedToAcquireLock(format!("{e}")))?;
@@ -155,7 +154,7 @@ pub trait ReadableHolon: ReadableHolonImpl {
 
         match members.as_slice() {
             [] => Err(HolonError::MissingDescribedBy { holon: self.summarize()? }),
-            [single] => Ok(HolonDescriptor::new(single.clone())),
+            [single] => Ok(HolonDescriptor::from_holon(single.clone())),
             many => {
                 Err(HolonError::MultipleDescribedBy { holon: self.summarize()?, count: many.len() })
             }

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -54,7 +54,10 @@ pub use holons_core::reference_layer::{
     HolonCollectionApi, HolonReference, HolonSpaceBehavior, HolonStagingBehavior, ReadableHolon,
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
-pub use holons_core::{Descriptor, TypeHeader};
+pub use holons_core::{
+    Descriptor, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
+    ValueDescriptor,
+};
 
 pub use type_names::{
     CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName, CoreValueTypeName,

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -54,6 +54,7 @@ pub use holons_core::reference_layer::{
     HolonCollectionApi, HolonReference, HolonSpaceBehavior, HolonStagingBehavior, ReadableHolon,
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
+pub use holons_core::{Descriptor, TypeHeader};
 
 pub use type_names::{
     CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName, CoreValueTypeName,

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -55,8 +55,8 @@ pub use holons_core::reference_layer::{
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
 pub use holons_core::{
-    Descriptor, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
-    ValueDescriptor,
+    Descriptor, ExtendsIter, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor,
+    TypeHeader, ValueDescriptor, ancestors, walk_extends_chain,
 };
 
 pub use type_names::{

--- a/shared_crates/json_schema_validate_cli/Cargo.toml
+++ b/shared_crates/json_schema_validate_cli/Cargo.toml
@@ -14,3 +14,5 @@ path = "../json_schema_validation"
 [[bin]]
 name = "jsv"
 path = "src/main.rs"
+
+[workspace]

--- a/shared_crates/json_schema_validation/tests/fixtures/invalid-map-json/bad-ref-format.json
+++ b/shared_crates/json_schema_validation/tests/fixtures/invalid-map-json/bad-ref-format.json
@@ -9,7 +9,7 @@
         {
           "name": "InvalidRef",
           "target": {
-            "$ref": "foo-bar-baz"
+            "$ref": "#:foo-bar-baz"
           }
         }
       ]

--- a/shared_crates/type_system/integrity_core_types/src/holon_error.rs
+++ b/shared_crates/type_system/integrity_core_types/src/holon_error.rs
@@ -67,6 +67,14 @@ pub enum HolonError {
     Misc(String),
     #[error("{0} relationship is missing StagedCollection")]
     MissingStagedCollection(String),
+    #[error("Missing DescribedBy relationship for holon: {holon}")]
+    MissingDescribedBy { holon: String },
+    #[error("Multiple DescribedBy relationships found for holon {holon}: {count}")]
+    MultipleDescribedBy { holon: String, count: usize },
+    #[error("Multiple Extends relationships found for descriptor {descriptor}: {count}")]
+    MultipleExtends { descriptor: String, count: usize },
+    #[error("Cyclic Extends relationship detected for descriptor: {descriptor}")]
+    CyclicExtends { descriptor: String },
     #[error("{0} access not allowed while holon is in {1} state")]
     NotAccessible(String, String),
     #[error("{0} Not Implemented")]
@@ -137,6 +145,10 @@ pub enum HolonErrorKind {
     LoaderParsingError,
     Misc,
     MissingStagedCollection,
+    MissingDescribedBy,
+    MultipleDescribedBy,
+    MultipleExtends,
+    CyclicExtends,
     NotAccessible,
     NotImplemented,
     RecordConversion,
@@ -181,6 +193,10 @@ impl From<&HolonError> for HolonErrorKind {
             HolonError::LoaderParsingError(_) => Self::LoaderParsingError,
             HolonError::Misc(_) => Self::Misc,
             HolonError::MissingStagedCollection(_) => Self::MissingStagedCollection,
+            HolonError::MissingDescribedBy { .. } => Self::MissingDescribedBy,
+            HolonError::MultipleDescribedBy { .. } => Self::MultipleDescribedBy,
+            HolonError::MultipleExtends { .. } => Self::MultipleExtends,
+            HolonError::CyclicExtends { .. } => Self::CyclicExtends,
             HolonError::NotAccessible(_, _) => Self::NotAccessible,
             HolonError::NotImplemented(_) => Self::NotImplemented,
             HolonError::RecordConversion(_) => Self::RecordConversion,


### PR DESCRIPTION
## Summary

Implements Descriptor PR1 / Phase 1 of the Descriptors Phased Implementation Plan by introducing the structural runtime descriptor layer in `holons_core`.  Closes #453. 

This PR is intentionally structural only. It adds the runtime home for later descriptor-driven behavior without implementing validation, operators, commands, dances, or TS/DAHN behavior yet.

## What’s Included

- Added thin runtime descriptor wrappers:
  - `HolonDescriptor`
  - `PropertyDescriptor`
  - `RelationshipDescriptor`
  - `ValueDescriptor`
- Added shared descriptor abstractions:
  - `Descriptor` trait
  - `TypeHeader`
  - `walk_extends_chain`, `ancestors`, and supporting inheritance traversal helpers
- Added typed descriptor lookup on `ReadableHolon`:
  - `holon_descriptor() -> Result<HolonDescriptor, HolonError>`
- Added descriptor-structural error variants:
  - `MissingDescribedBy`
  - `MultipleDescribedBy`
  - `MultipleExtends`
  - `CyclicExtends`
- Wired descriptor exports through `holons_core` and `holons_prelude`
- Added shared descriptor test support and improved comment clarity across the `descriptors` module

## Notes

- Wrappers remain thin views over `HolonReference`
- No ontology state is duplicated into wrapper structs
- `TypeHeader` is a runtime projection, not an ontology element
- Inheritance traversal is lazy and supports caller short-circuiting while still enforcing structural errors

## Tests

Added unit coverage for:
- `TypeHeader` required/optional field access and wrong-type errors
- `ReadableHolon::holon_descriptor()` on transient and staged holons
- missing and multiple `DescribedBy`
- `Extends` traversal for root, linear inheritance, multiple parents, cycles, self-loops, and iterator short-circuit behavior

Verified with:
- `cargo test -p holons_core`
- `npm run check`

Existing `npm run test` tests continue to pass