### PR TITLE
433 dahn phase 0 pr 1 establish runtime skeleton and core contracts

### DIFF
--- a/host/package.json
+++ b/host/package.json
@@ -14,6 +14,7 @@
     "test:unit:no-run": "cargo test --workspace --no-run",
     "regen:sdk-fixtures": "cargo test -p map_commands_wire --test generate_fixtures -- --ignored",
     "web:serve": "cd ui && ng serve",
+    "web:typecheck": "npx tsc -p ./ui/tsconfig.app.json --noEmit",
     "web:build": "cd ui && ng build --base-href ./",
     "web:dev": "npm run web:build",
     "web:prod": "npm run web:build -- -c production",

--- a/host/ui/src/dahn/contract-checks.ts
+++ b/host/ui/src/dahn/contract-checks.ts
@@ -1,0 +1,108 @@
+import { DefaultDahnRuntime } from './index';
+import type {
+  ActionNode,
+  CanvasApi,
+  CanvasDescriptor,
+  DahnRuntime,
+  DahnTarget,
+  DahnTheme,
+  DanceDescriptorHandle,
+  HolonTypeDescriptorHandle,
+  HolonViewAccess,
+  HolonViewContext,
+  PropertyDescriptorHandle,
+  RelationshipDescriptorHandle,
+  RelationshipDescriptorKind,
+  SelectorFunction,
+  SelectorInput,
+  SelectorOutput,
+  ValueTypeDescriptorHandle,
+  VisualizerContext,
+  VisualizerDefinition,
+  VisualizerElement,
+} from './index';
+import type { HolonReference } from '../../../map-sdk/src';
+
+/**
+ * Compile-time DAHN contract checks for PR 1.
+ *
+ * This file intentionally contains no runtime behavior. It exists so the host
+ * UI TypeScript build exercises the DAHN contract surface and catches obvious
+ * drift in exported types.
+ */
+
+declare const holonReference: HolonReference;
+declare const holonAccess: HolonViewAccess;
+declare const actions: ActionNode[];
+declare const canvasApi: CanvasApi;
+declare const theme: DahnTheme;
+
+const relationshipKinds: RelationshipDescriptorKind[] = [
+  'declared',
+  'inverse',
+];
+
+const target: DahnTarget = {
+  reference: holonReference,
+};
+
+const canvasDescriptor: CanvasDescriptor = {
+  id: 'dahn-2d-minimal',
+  slots: ['primary'],
+};
+
+const selectorInput: SelectorInput = {
+  target,
+  holon: holonAccess,
+  actions,
+  availableVisualizers: [],
+  canvas: canvasDescriptor,
+};
+
+const selectorOutput: SelectorOutput = {
+  visualizers: [],
+};
+
+const visualizerDefinition: VisualizerDefinition = {
+  id: 'holon-node',
+  displayName: 'Holon Node',
+  version: '0.0.0',
+  componentTag: 'map-holon-node',
+  supportedTargets: [{ kind: 'holon-node' }],
+  load: async () => {},
+};
+
+declare const visualizerElement: VisualizerElement;
+
+const visualizerContext: VisualizerContext = {
+  target,
+  holon: holonAccess,
+  actions,
+  theme,
+  canvas: canvasApi,
+};
+
+visualizerElement.setContext(visualizerContext);
+
+const runtime: DahnRuntime = new DefaultDahnRuntime();
+void runtime;
+void selectorInput;
+void selectorOutput;
+void visualizerDefinition;
+void relationshipKinds;
+
+declare const valueTypeDescriptor: ValueTypeDescriptorHandle;
+declare const propertyDescriptor: PropertyDescriptorHandle;
+declare const relationshipDescriptor: RelationshipDescriptorHandle;
+declare const danceDescriptor: DanceDescriptorHandle;
+declare const holonTypeDescriptor: HolonTypeDescriptorHandle;
+declare const holonViewContext: HolonViewContext;
+declare const selector: SelectorFunction;
+
+void valueTypeDescriptor;
+void propertyDescriptor;
+void relationshipDescriptor;
+void danceDescriptor;
+void holonTypeDescriptor;
+void holonViewContext;
+void selector;

--- a/host/ui/src/dahn/contracts/actions.ts
+++ b/host/ui/src/dahn/contracts/actions.ts
@@ -1,0 +1,12 @@
+import type { DanceDescriptorHandle } from './holon-view';
+
+/**
+ * Minimal action hierarchy node used to present dances.
+ */
+export interface ActionNode {
+  id: string;
+  kind: 'action' | 'group';
+  label: string;
+  dance?: DanceDescriptorHandle;
+  children?: ActionNode[];
+}

--- a/host/ui/src/dahn/contracts/canvas.ts
+++ b/host/ui/src/dahn/contracts/canvas.ts
@@ -1,0 +1,29 @@
+import type { DahnTheme } from './themes';
+import type { DahnTarget } from './targets';
+
+/**
+ * Phase 0 canvas descriptor. The runtime currently supports a single visible
+ * slot, but the contract leaves room for future expansion.
+ */
+export interface CanvasDescriptor {
+  id: string;
+  slots: ['primary'];
+}
+
+/**
+ * Describes which visualizer should be mounted into which canvas slot.
+ */
+export interface VisualizerMountPlan {
+  visualizerId: string;
+  target: DahnTarget;
+  slot: 'primary';
+}
+
+/**
+ * Minimal canvas API for Phase 0.
+ */
+export interface CanvasApi {
+  mountVisualizers(plan: VisualizerMountPlan[]): Promise<void>;
+  clear(): void;
+  setTheme(theme: DahnTheme): void;
+}

--- a/host/ui/src/dahn/contracts/holon-view.ts
+++ b/host/ui/src/dahn/contracts/holon-view.ts
@@ -1,0 +1,99 @@
+import type { ActionNode } from './actions';
+import type {
+  BaseValue,
+  EssentialHolonContent,
+  HolonCollection,
+  HolonId,
+  HolonReference,
+  PropertyName,
+  RelationshipName,
+} from '../../../../map-sdk/src';
+
+export type RelationshipDescriptorKind = 'declared' | 'inverse';
+
+/**
+ * Reference-backed handle over a ValueTypeDescriptor holon.
+ *
+ * These descriptor handles are accessors, not replicated TypeScript-side
+ * state. Effective descriptor traversal and inheritance flattening are assumed
+ * to be provided by the Rust layer.
+ */
+export interface ValueTypeDescriptorHandle {
+  reference(): HolonReference;
+  name(): Promise<string>;
+  kind(): Promise<string | null>;
+  format(): Promise<string | null>;
+  enumValues(): Promise<string[]>;
+}
+
+/**
+ * Reference-backed handle over a PropertyDescriptor holon.
+ */
+export interface PropertyDescriptorHandle {
+  reference(): HolonReference;
+  name(): Promise<string>;
+  label(): Promise<string | null>;
+  valueTypeDescriptor(): Promise<ValueTypeDescriptorHandle>;
+}
+
+/**
+ * Reference-backed handle over a RelationshipDescriptor holon.
+ *
+ * Relationship kind must preserve the declared vs inverse distinction even
+ * though Phase 0 does not yet expose editing behavior.
+ */
+export interface RelationshipDescriptorHandle {
+  reference(): HolonReference;
+  name(): Promise<string>;
+  label(): Promise<string | null>;
+  relationshipKind(): Promise<RelationshipDescriptorKind>;
+}
+
+/**
+ * Reference-backed handle over a DanceDescriptor holon.
+ */
+export interface DanceDescriptorHandle {
+  reference(): HolonReference;
+  name(): Promise<string>;
+  label(): Promise<string | null>;
+  description(): Promise<string | null>;
+}
+
+/**
+ * Reference-backed handle over a HolonTypeDescriptor holon.
+ *
+ * Property, relationship, and dance descriptors exposed here are assumed to be
+ * the effective flattened descriptor surface supplied by the Rust layer.
+ */
+export interface HolonTypeDescriptorHandle {
+  reference(): HolonReference;
+  typeName(): Promise<string>;
+  displayName(): Promise<string | null>;
+  propertyDescriptors(): Promise<PropertyDescriptorHandle[]>;
+  relationshipDescriptors(): Promise<RelationshipDescriptorHandle[]>;
+  danceDescriptors(): Promise<DanceDescriptorHandle[]>;
+}
+
+/**
+ * Narrow DAHN-facing access wrapper over the public SDK's bound HolonReference.
+ */
+export interface HolonViewAccess {
+  reference(): HolonReference;
+  holonId(): Promise<HolonId>;
+  key(): Promise<string | null>;
+  versionedKey(): Promise<string>;
+  summarize(): Promise<string>;
+  essentialContent(): Promise<EssentialHolonContent>;
+  holonTypeDescriptor(): Promise<HolonTypeDescriptorHandle>;
+  propertyValue(name: PropertyName): Promise<BaseValue | null>;
+  relatedHolons(name: RelationshipName): Promise<HolonCollection>;
+  availableDances(): Promise<DanceDescriptorHandle[]>;
+}
+
+/**
+ * Composite object passed from the access adapter into the runtime.
+ */
+export interface HolonViewContext {
+  holon: HolonViewAccess;
+  actions: ActionNode[];
+}

--- a/host/ui/src/dahn/contracts/selector.ts
+++ b/host/ui/src/dahn/contracts/selector.ts
@@ -1,0 +1,34 @@
+import type { ActionNode } from './actions';
+import type { CanvasDescriptor, VisualizerMountPlan } from './canvas';
+import type { HolonViewAccess } from './holon-view';
+import type { DahnTarget } from './targets';
+import type { VisualizerDefinition } from './visualizers';
+
+/**
+ * Input to the Phase 0 TypeScript-side presentation resolution seam.
+ *
+ * This is intentionally limited to runtime resolution inputs and must remain
+ * future-compatible with Rust-side semantic recommendation feeding into the
+ * TypeScript layer later.
+ */
+export interface SelectorInput {
+  target: DahnTarget;
+  holon: HolonViewAccess;
+  actions: ActionNode[];
+  availableVisualizers: VisualizerDefinition[];
+  canvas: CanvasDescriptor;
+}
+
+/**
+ * Output mount plan selected for the current runtime.
+ */
+export interface SelectorOutput {
+  visualizers: VisualizerMountPlan[];
+}
+
+/**
+ * Phase 0 TypeScript-side selector/resolution seam.
+ */
+export interface SelectorFunction {
+  select(input: SelectorInput): SelectorOutput;
+}

--- a/host/ui/src/dahn/contracts/targets.ts
+++ b/host/ui/src/dahn/contracts/targets.ts
@@ -1,0 +1,10 @@
+import type { HolonReference } from '../../../../map-sdk/src';
+
+/**
+ * Runtime-level target handle used to identify the holon DAHN should open.
+ *
+ * The underlying HolonReference is already transaction-bound by the public SDK.
+ */
+export interface DahnTarget {
+  reference: HolonReference;
+}

--- a/host/ui/src/dahn/contracts/themes.ts
+++ b/host/ui/src/dahn/contracts/themes.ts
@@ -1,0 +1,11 @@
+/**
+ * Semantic theme token payload applied to the DAHN canvas root.
+ */
+export interface DahnTheme {
+  id: string;
+  label: string;
+  colorTokens: Record<string, string>;
+  typographyTokens: Record<string, string>;
+  spacingTokens: Record<string, string>;
+  radiusTokens: Record<string, string>;
+}

--- a/host/ui/src/dahn/contracts/visualizers.ts
+++ b/host/ui/src/dahn/contracts/visualizers.ts
@@ -1,0 +1,49 @@
+import type { ActionNode } from './actions';
+import type { CanvasApi } from './canvas';
+import type { HolonViewAccess } from './holon-view';
+import type { DahnTarget } from './targets';
+import type { DahnTheme } from './themes';
+
+/**
+ * Minimal target classification metadata for Phase 0. Definitions stay local
+ * and bootstrap-oriented for now, but must remain compatible with future
+ * MAP-backed visualizer descriptor holons.
+ */
+export interface VisualizerTargetRule {
+  kind:
+    | 'holon-node'
+    | 'action'
+    | 'property'
+    | 'relationship'
+    | 'debug';
+}
+
+/**
+ * Runtime/local representation of a visualizer descriptor.
+ */
+export interface VisualizerDefinition {
+  id: string;
+  displayName: string;
+  version: string;
+  componentTag: string;
+  supportedTargets: VisualizerTargetRule[];
+  load: () => Promise<void>;
+}
+
+/**
+ * Common context passed into Web Component visualizers.
+ */
+export interface VisualizerContext {
+  target: DahnTarget;
+  holon: HolonViewAccess;
+  actions: ActionNode[];
+  theme: DahnTheme;
+  canvas: CanvasApi;
+}
+
+/**
+ * Common surface all DAHN visualizer elements must implement.
+ */
+export interface VisualizerElement extends HTMLElement {
+  setContext(context: VisualizerContext): void;
+}

--- a/host/ui/src/dahn/index.ts
+++ b/host/ui/src/dahn/index.ts
@@ -1,0 +1,35 @@
+export type { ActionNode } from './contracts/actions';
+export type {
+  CanvasApi,
+  CanvasDescriptor,
+  VisualizerMountPlan,
+} from './contracts/canvas';
+export type {
+  DanceDescriptorHandle,
+  HolonTypeDescriptorHandle,
+  HolonViewAccess,
+  HolonViewContext,
+  PropertyDescriptorHandle,
+  RelationshipDescriptorHandle,
+  RelationshipDescriptorKind,
+  ValueTypeDescriptorHandle,
+} from './contracts/holon-view';
+export type {
+  SelectorFunction,
+  SelectorInput,
+  SelectorOutput,
+} from './contracts/selector';
+export type { DahnTarget } from './contracts/targets';
+export type { DahnTheme } from './contracts/themes';
+export type {
+  VisualizerContext,
+  VisualizerDefinition,
+  VisualizerElement,
+  VisualizerTargetRule,
+} from './contracts/visualizers';
+export { DefaultDahnRuntime } from './runtime/default-dahn-runtime';
+export type { DahnRuntime } from './runtime/dahn-runtime';
+export {
+  DahnNotImplementedError,
+  DahnRuntimeError,
+} from './runtime/runtime-errors';

--- a/host/ui/src/dahn/runtime/dahn-runtime.ts
+++ b/host/ui/src/dahn/runtime/dahn-runtime.ts
@@ -1,0 +1,8 @@
+import type { DahnTarget } from '../contracts/targets';
+
+/**
+ * Minimal DAHN runtime interface for Phase 0.
+ */
+export interface DahnRuntime {
+  open(target: DahnTarget): Promise<void>;
+}

--- a/host/ui/src/dahn/runtime/default-dahn-runtime.ts
+++ b/host/ui/src/dahn/runtime/default-dahn-runtime.ts
@@ -1,0 +1,16 @@
+import type { DahnTarget } from '../contracts/targets';
+import type { DahnRuntime } from './dahn-runtime';
+import { DahnNotImplementedError } from './runtime-errors';
+
+/**
+ * Placeholder runtime implementation for PR 1.
+ *
+ * This class exists only to establish the seam that later PRs will implement.
+ */
+export class DefaultDahnRuntime implements DahnRuntime {
+  async open(_target: DahnTarget): Promise<void> {
+    throw new DahnNotImplementedError(
+      'DefaultDahnRuntime.open() is not implemented in Phase 0 / PR 1',
+    );
+  }
+}

--- a/host/ui/src/dahn/runtime/runtime-errors.ts
+++ b/host/ui/src/dahn/runtime/runtime-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Base class for DAHN runtime errors.
+ */
+export class DahnRuntimeError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'DahnRuntimeError';
+  }
+}
+
+/**
+ * Raised when DAHN runtime behavior is invoked before the relevant Phase 0
+ * implementation slice is in place.
+ */
+export class DahnNotImplementedError extends DahnRuntimeError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'DahnNotImplementedError';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "build": "npm run build:happ && npm run build:host",
     "build:host": "npm run build -w map-host",
     "build:happ": "npm run build:happ -w map-happ",
+    "web:typecheck": "npm run web:typecheck -w map-host",
 
-    "check": "npm run check -w map-host && npm run check -w map-happ",
+    "check": "npm run check -w map-host && npm run check -w map-happ && npm run web:typecheck",
     "fmt": "npm run fmt -w map-host && npm run fmt -w map-happ && npm run fmt:sweetests",
     "fmt:check": "npm run fmt:check -w map-host && npm run fmt:check -w map-happ && npm run fmt:sweetests:check",
     "fmt:sweetests": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all",
     "fmt:sweetests:check": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all --check",
 
     "test": "npm run test:unit && npm run sweetest",
-    "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run typecheck -w map-sdk && npm run test -w map-sdk",
+    "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run web:typecheck && npm run typecheck -w map-sdk && npm run test -w map-sdk",
     "test:unit:shared": "cargo test --manifest-path shared_crates/type_system/base_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/integrity_core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/type_names/Cargo.toml && cargo test --manifest-path shared_crates/shared_validation/Cargo.toml && cargo test --manifest-path shared_crates/holons_core/Cargo.toml && cargo test --manifest-path shared_crates/holons_boundary/Cargo.toml && cargo test --manifest-path shared_crates/holons_prelude/Cargo.toml && cargo test --manifest-path shared_crates/holon_dance_builders/Cargo.toml && cargo test --manifest-path shared_crates/holons_trust_channel/Cargo.toml && cargo test --manifest-path shared_crates/json_schema_validation/Cargo.toml",
 
     "sweetest": "RUST_LOG=${RUST_LOG:-warn} WASM_LOG=${WASM_LOG:-warn} npm run build:happ && npm run sweet:test",


### PR DESCRIPTION
## DAHN Phase 0 PR 1 — Establish Runtime Skeleton and Core Contracts

**Closes #433 **

---

### Summary

This PR establishes the initial DAHN Phase 0 code skeleton and core runtime contracts inside `host/ui`, following the Phase 0 DAHN spec and implementation blueprint.

The goal of this slice is to create a clean, package-shaped DAHN seam with stable TypeScript contracts that later PRs can implement against. It intentionally does **not** introduce DAHN behavior yet. There is no selector implementation, no visualizer loader, no canvas mounting logic, no SDK-backed adapter, and no Angular integration in this PR.

This PR also adds `web:typecheck` as a first-class validation path in both `host` and the repo root, and folds it into the standard root validation flow.

---

### What Changed

#### DAHN scaffold and contracts

Added the initial DAHN module boundary under:

- `host/ui/src/dahn/`

Added core contract modules for:

- `DahnTarget`
- `HolonViewAccess`
- `HolonViewContext`
- descriptor handles:
  - `HolonTypeDescriptorHandle`
  - `PropertyDescriptorHandle`
  - `ValueTypeDescriptorHandle`
  - `RelationshipDescriptorHandle`
  - `DanceDescriptorHandle`
- `ActionNode`
- `VisualizerDefinition`
- `VisualizerContext`
- `VisualizerElement`
- `CanvasApi`
- `VisualizerMountPlan`
- `CanvasDescriptor`
- `SelectorInput`
- `SelectorOutput`
- `SelectorFunction`
- `DahnTheme`

Added the initial runtime seam:

- `DahnRuntime`
- `DahnRuntimeError`
- `DahnNotImplementedError`
- `DefaultDahnRuntime`

Added a compile-time contract-check module to exercise the DAHN export surface during TypeScript compilation:

- `host/ui/src/dahn/contract-checks.ts`

Added the DAHN module root export surface:

- `host/ui/src/dahn/index.ts`

#### Validation / testing posture

Added a host-level UI typecheck script:

- `host/package.json`
  - `web:typecheck`

Added a root-level delegating script and included it in the standard repo validation flow:

- `package.json`
  - `web:typecheck`
  - `check`
  - `test:unit`

This means DAHN-relevant UI typechecking now runs through the normal root-level workflow.

---

### Architectural Notes

This PR is intentionally narrow and aligned with the clarified DAHN architecture:

- DAHN core contracts remain framework-agnostic
- DAHN contracts do not expose MAP wire types, IPC envelope types, or `host/map-sdk` internal transport concerns
- DAHN contracts align with the existing public SDK active-handle model, where public `HolonReference` objects are already transaction-bound handles
- descriptor handles are modeled as reference-backed accessor interfaces, not replicated TS-side descriptor state
- descriptor inheritance flattening is assumed to be provided by Rust
- relationship descriptor handles preserve `declared | inverse`
- selector contracts are framed as the **Phase 0 TS-side presentation-resolution seam**, while preserving the future split:
  - Rust-side semantic recommendation
  - TypeScript-side runtime presentation resolution

---

### Out of Scope

This PR does **not** implement:

- visualizer loading
- canvas mounting behavior
- SDK-backed DAHN access adapters
- selector logic
- Angular route/component integration
- graph or collection visualizers
- editing behavior
- Rust-side selector/recommendation logic

This is a scaffolding-and-contracts PR only.

---

### Verification

Verified via the standard repo workflow:

- `npm run web:typecheck`
- `npm test`

Current results on this branch:

- `web:typecheck` passes
- full root `npm test` passes
- DAHN contracts compile cleanly as part of the host UI TypeScript build

---

### Why This PR Helps

This gives DAHN a clean starting seam in the codebase without entangling it with the older `host/ui` TS-side replicated model/store approach.

It should make subsequent PRs much easier to reason about:

- PR 2 can implement the visualizer registry, minimal canvas, and theme application against stable contracts
- PR 3 can implement the SDK-backed holon access adapter and descriptor-handle seam against stable contracts

This PR is intentionally low-risk and aimed at reducing architectural drift before behavior starts landing.
