### PR TITLE
DAHN PR2 Implement visualizer registry, minimal canvas, theme runtime, and UI tests per Issue 434

### DIFF
--- a/host/package.json
+++ b/host/package.json
@@ -14,6 +14,7 @@
     "test:unit:no-run": "cargo test --workspace --no-run",
     "regen:sdk-fixtures": "cargo test -p map_commands_wire --test generate_fixtures -- --ignored",
     "web:serve": "cd ui && ng serve",
+    "web:test:dahn": "cd ui && vitest run",
     "web:typecheck": "npx tsc -p ./ui/tsconfig.app.json --noEmit",
     "web:build": "cd ui && ng build --base-href ./",
     "web:dev": "npm run web:build",
@@ -59,10 +60,13 @@
     "@angular/build": "^21.0.1",
     "@angular/cli": "^21.0.1",
     "@angular/compiler-cli": "^21.0.0",
+    "@types/node": "^24.0.0",
     "@tailwindcss/postcss": "^4.1.12",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2",
-    "@tauri-apps/cli": "^2"  
+    "vitest": "^2.1.8",
+    "@tauri-apps/cli": "^2"
   }
 }

--- a/host/ui/src/dahn/canvas/create-canvas-root.ts
+++ b/host/ui/src/dahn/canvas/create-canvas-root.ts
@@ -1,0 +1,27 @@
+export interface CanvasRootParts {
+  root: HTMLDivElement;
+  primarySlot: HTMLDivElement;
+}
+
+export function createCanvasRoot(container: HTMLElement): CanvasRootParts {
+  const root = document.createElement('div');
+  root.dataset['dahnCanvas'] = 'root';
+  root.style.display = 'flex';
+  root.style.flexDirection = 'column';
+  root.style.gap = 'var(--dahn-space-gap, 16px)';
+  root.style.padding = 'var(--dahn-space-padding, 20px)';
+  root.style.background = 'var(--dahn-color-surface, #f7f5ef)';
+  root.style.color = 'var(--dahn-color-text, #1f2933)';
+  root.style.minHeight = '100%';
+
+  const primarySlot = document.createElement('div');
+  primarySlot.dataset['dahnCanvasSlot'] = 'primary';
+  primarySlot.style.display = 'flex';
+  primarySlot.style.flexDirection = 'column';
+  primarySlot.style.gap = 'var(--dahn-space-gap, 16px)';
+
+  root.append(primarySlot);
+  container.append(root);
+
+  return { root, primarySlot };
+}

--- a/host/ui/src/dahn/canvas/dom-canvas.test.ts
+++ b/host/ui/src/dahn/canvas/dom-canvas.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DomCanvas } from './dom-canvas';
+import { DefaultVisualizerRegistry } from '../registry/default-visualizer-registry';
+import type { VisualizerContext, VisualizerElement } from '../contracts/visualizers';
+import type { DahnTarget } from '../contracts/targets';
+import { DEFAULT_DAHN_THEME } from '../themes/default-theme';
+
+class TestCanvasVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  context?: VisualizerContext;
+
+  setContext(context: VisualizerContext): void {
+    this.context = context;
+    this.dataset['contextApplied'] = 'true';
+  }
+}
+
+function createTestCanvasVisualizerElementClass(): typeof TestCanvasVisualizerElement {
+  return class extends TestCanvasVisualizerElement {};
+}
+
+describe('DomCanvas', () => {
+  it('applies theme tokens to the canvas root', () => {
+    const container = document.createElement('div');
+    const registry = new DefaultVisualizerRegistry();
+    const canvas = new DomCanvas(
+      container,
+      registry,
+      () => ({}) as VisualizerContext,
+    );
+
+    canvas.setTheme(DEFAULT_DAHN_THEME);
+
+    const root = container.querySelector('[data-dahn-canvas="root"]');
+    expect(root).not.toBeNull();
+    expect(root?.style.getPropertyValue('--dahn-color-surface')).toBe(
+      DEFAULT_DAHN_THEME.colorTokens['surface'],
+    );
+  });
+
+  it('mounts a loaded visualizer and calls setContext', async () => {
+    const container = document.createElement('div');
+    const registry = new DefaultVisualizerRegistry();
+    const target = { reference: {} } as DahnTarget;
+    const context = {
+      target,
+      holon: {} as VisualizerContext['holon'],
+      actions: [],
+      theme: DEFAULT_DAHN_THEME,
+      canvas: {} as VisualizerContext['canvas'],
+    } as VisualizerContext;
+    const resolveContext = vi.fn(() => context);
+
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-canvas-visualizer',
+      supportedTargets: [{ kind: 'debug' }],
+      load: async () => {
+        if (customElements.get('test-canvas-visualizer') === undefined) {
+          customElements.define(
+            'test-canvas-visualizer',
+            createTestCanvasVisualizerElementClass(),
+          );
+        }
+      },
+    });
+
+    const canvas = new DomCanvas(container, registry, resolveContext);
+    await canvas.mountVisualizers([
+      {
+        visualizerId: 'debug',
+        target,
+        slot: 'primary',
+      },
+    ]);
+
+    const mounted = container.querySelector(
+      'test-canvas-visualizer',
+    ) as TestCanvasVisualizerElement | null;
+
+    expect(resolveContext).toHaveBeenCalledWith(target);
+    expect(mounted).not.toBeNull();
+    expect(mounted?.dataset['contextApplied']).toBe('true');
+    expect(mounted?.context).toBe(context);
+  });
+
+  it('clears the primary slot', async () => {
+    const container = document.createElement('div');
+    const registry = new DefaultVisualizerRegistry();
+    const target = { reference: {} } as DahnTarget;
+
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-canvas-visualizer-clear',
+      supportedTargets: [{ kind: 'debug' }],
+      load: async () => {
+        if (
+          customElements.get('test-canvas-visualizer-clear') === undefined
+        ) {
+          customElements.define(
+            'test-canvas-visualizer-clear',
+            createTestCanvasVisualizerElementClass(),
+          );
+        }
+      },
+    });
+
+    const canvas = new DomCanvas(
+      container,
+      registry,
+      () => ({}) as VisualizerContext,
+    );
+
+    await canvas.mountVisualizers([
+      { visualizerId: 'debug', target, slot: 'primary' },
+    ]);
+    expect(container.querySelector('test-canvas-visualizer-clear')).not.toBeNull();
+
+    canvas.clear();
+
+    expect(container.querySelector('test-canvas-visualizer-clear')).toBeNull();
+  });
+});

--- a/host/ui/src/dahn/canvas/dom-canvas.ts
+++ b/host/ui/src/dahn/canvas/dom-canvas.ts
@@ -1,0 +1,56 @@
+import type { CanvasApi, VisualizerMountPlan } from '../contracts/canvas';
+import type { VisualizerContext, VisualizerElement } from '../contracts/visualizers';
+import type { VisualizerRegistry } from '../registry/visualizer-registry';
+import { applyTheme } from '../themes/apply-theme';
+import { createCanvasRoot } from './create-canvas-root';
+import type { DahnTheme } from '../contracts/themes';
+import type { DahnTarget } from '../contracts/targets';
+
+export type VisualizerContextResolver = (
+  target: DahnTarget,
+) => VisualizerContext;
+
+export class DomCanvas implements CanvasApi {
+  private readonly root: HTMLDivElement;
+  private readonly primarySlot: HTMLDivElement;
+
+  constructor(
+    container: HTMLElement,
+    private readonly registry: VisualizerRegistry,
+    private readonly resolveContext: VisualizerContextResolver,
+  ) {
+    const parts = createCanvasRoot(container);
+    this.root = parts.root;
+    this.primarySlot = parts.primarySlot;
+  }
+
+  async mountVisualizers(plan: VisualizerMountPlan[]): Promise<void> {
+    this.clear();
+
+    for (const mount of plan) {
+      if (mount.slot !== 'primary') {
+        throw new Error(`Unsupported canvas slot '${mount.slot}'`);
+      }
+
+      const definition = await this.registry.ensureLoaded(mount.visualizerId);
+      const element = document.createElement(
+        definition.componentTag,
+      ) as VisualizerElement;
+
+      element.setContext(this.resolveContext(mount.target));
+      this.primarySlot.append(element);
+    }
+  }
+
+  clear(): void {
+    this.primarySlot.replaceChildren();
+  }
+
+  setTheme(theme: DahnTheme): void {
+    applyTheme(this.root, theme);
+  }
+
+  rootElement(): HTMLElement {
+    return this.root;
+  }
+}

--- a/host/ui/src/dahn/index.ts
+++ b/host/ui/src/dahn/index.ts
@@ -27,9 +27,22 @@ export type {
   VisualizerElement,
   VisualizerTargetRule,
 } from './contracts/visualizers';
+export { DomCanvas } from './canvas/dom-canvas';
+export { createCanvasRoot } from './canvas/create-canvas-root';
+export {
+  DefaultVisualizerRegistry,
+} from './registry/default-visualizer-registry';
+export {
+  registerBuiltInVisualizers,
+} from './registry/register-builtins';
+export type { VisualizerRegistry } from './registry/visualizer-registry';
 export { DefaultDahnRuntime } from './runtime/default-dahn-runtime';
 export type { DahnRuntime } from './runtime/dahn-runtime';
 export {
   DahnNotImplementedError,
   DahnRuntimeError,
 } from './runtime/runtime-errors';
+export { applyTheme } from './themes/apply-theme';
+export { DEFAULT_DAHN_THEME } from './themes/default-theme';
+export { DefaultThemeRegistry } from './themes/theme-registry';
+export { BUILTIN_VISUALIZER_DEFINITIONS } from './visualizers/builtins';

--- a/host/ui/src/dahn/registry/default-visualizer-registry.test.ts
+++ b/host/ui/src/dahn/registry/default-visualizer-registry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DefaultVisualizerRegistry } from './default-visualizer-registry';
+
+describe('DefaultVisualizerRegistry', () => {
+  it('registers and lists definitions', () => {
+    const registry = new DefaultVisualizerRegistry();
+    const definition = {
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-debug-visualizer-a',
+      supportedTargets: [{ kind: 'debug' as const }],
+      load: vi.fn(async () => {}),
+    };
+
+    registry.register(definition);
+
+    expect(registry.get('debug')).toBe(definition);
+    expect(registry.list()).toEqual([definition]);
+  });
+
+  it('rejects duplicate ids for different definitions', () => {
+    const registry = new DefaultVisualizerRegistry();
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-debug-visualizer-b',
+      supportedTargets: [{ kind: 'debug' as const }],
+      load: async () => {},
+    });
+
+    expect(() =>
+      registry.register({
+        id: 'debug',
+        displayName: 'Debug 2',
+        version: '0.0.1',
+        componentTag: 'test-debug-visualizer-c',
+        supportedTargets: [{ kind: 'debug' as const }],
+        load: async () => {},
+      }),
+    ).toThrow(/already registered/);
+  });
+
+  it('loads definitions idempotently', async () => {
+    const registry = new DefaultVisualizerRegistry();
+    const load = vi.fn(async () => {
+      class TestVisualizer extends HTMLElement {}
+      if (customElements.get('test-debug-visualizer-d') === undefined) {
+        customElements.define('test-debug-visualizer-d', TestVisualizer);
+      }
+    });
+
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-debug-visualizer-d',
+      supportedTargets: [{ kind: 'debug' as const }],
+      load,
+    });
+
+    await registry.ensureLoaded('debug');
+    await registry.ensureLoaded('debug');
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(customElements.get('test-debug-visualizer-d')).toBeDefined();
+  });
+
+  it('does not re-run load when the custom element is already defined', async () => {
+    class ExistingVisualizer extends HTMLElement {}
+    if (customElements.get('test-debug-visualizer-e') === undefined) {
+      customElements.define('test-debug-visualizer-e', ExistingVisualizer);
+    }
+
+    const registry = new DefaultVisualizerRegistry();
+    const load = vi.fn(async () => {});
+
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'test-debug-visualizer-e',
+      supportedTargets: [{ kind: 'debug' as const }],
+      load,
+    });
+
+    await registry.ensureLoaded('debug');
+
+    expect(load).not.toHaveBeenCalled();
+  });
+});

--- a/host/ui/src/dahn/registry/default-visualizer-registry.ts
+++ b/host/ui/src/dahn/registry/default-visualizer-registry.ts
@@ -1,0 +1,60 @@
+import type { VisualizerDefinition } from '../contracts/visualizers';
+import type { VisualizerRegistry } from './visualizer-registry';
+
+export class DefaultVisualizerRegistry implements VisualizerRegistry {
+  private readonly definitions = new Map<string, VisualizerDefinition>();
+  private readonly loadedIds = new Set<string>();
+  private readonly pendingLoads = new Map<string, Promise<VisualizerDefinition>>();
+
+  register(definition: VisualizerDefinition): void {
+    const existing = this.definitions.get(definition.id);
+    if (existing !== undefined && existing !== definition) {
+      throw new Error(
+        `Visualizer definition '${definition.id}' is already registered`,
+      );
+    }
+
+    this.definitions.set(definition.id, definition);
+  }
+
+  get(id: string): VisualizerDefinition | undefined {
+    return this.definitions.get(id);
+  }
+
+  list(): VisualizerDefinition[] {
+    return [...this.definitions.values()];
+  }
+
+  async ensureLoaded(id: string): Promise<VisualizerDefinition> {
+    const definition = this.definitions.get(id);
+    if (definition === undefined) {
+      throw new Error(`Unknown visualizer definition '${id}'`);
+    }
+
+    if (this.loadedIds.has(id)) {
+      return definition;
+    }
+
+    const existingLoad = this.pendingLoads.get(id);
+    if (existingLoad !== undefined) {
+      return existingLoad;
+    }
+
+    const loadPromise = (async () => {
+      if (customElements.get(definition.componentTag) === undefined) {
+        await definition.load();
+      }
+
+      this.loadedIds.add(id);
+      return definition;
+    })();
+
+    this.pendingLoads.set(id, loadPromise);
+
+    try {
+      return await loadPromise;
+    } finally {
+      this.pendingLoads.delete(id);
+    }
+  }
+}

--- a/host/ui/src/dahn/registry/register-builtins.ts
+++ b/host/ui/src/dahn/registry/register-builtins.ts
@@ -1,0 +1,10 @@
+import type { VisualizerRegistry } from './visualizer-registry';
+import { BUILTIN_VISUALIZER_DEFINITIONS } from '../visualizers/builtins';
+
+export function registerBuiltInVisualizers(
+  registry: VisualizerRegistry,
+): void {
+  for (const definition of BUILTIN_VISUALIZER_DEFINITIONS) {
+    registry.register(definition);
+  }
+}

--- a/host/ui/src/dahn/registry/visualizer-registry.ts
+++ b/host/ui/src/dahn/registry/visualizer-registry.ts
@@ -1,0 +1,8 @@
+import type { VisualizerDefinition } from '../contracts/visualizers';
+
+export interface VisualizerRegistry {
+  register(definition: VisualizerDefinition): void;
+  get(id: string): VisualizerDefinition | undefined;
+  list(): VisualizerDefinition[];
+  ensureLoaded(id: string): Promise<VisualizerDefinition>;
+}

--- a/host/ui/src/dahn/themes/apply-theme.test.ts
+++ b/host/ui/src/dahn/themes/apply-theme.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { applyTheme } from './apply-theme';
+import { DEFAULT_DAHN_THEME } from './default-theme';
+
+describe('applyTheme', () => {
+  it('applies theme tokens as css custom properties', () => {
+    const root = document.createElement('div');
+
+    applyTheme(root, DEFAULT_DAHN_THEME);
+
+    expect(root.dataset['dahnThemeId']).toBe(DEFAULT_DAHN_THEME.id);
+    expect(root.style.getPropertyValue('--dahn-color-surface')).toBe(
+      DEFAULT_DAHN_THEME.colorTokens['surface'],
+    );
+    expect(root.style.getPropertyValue('--dahn-type-bodyFont')).toBe(
+      DEFAULT_DAHN_THEME.typographyTokens['bodyFont'],
+    );
+  });
+});

--- a/host/ui/src/dahn/themes/apply-theme.ts
+++ b/host/ui/src/dahn/themes/apply-theme.ts
@@ -1,0 +1,21 @@
+import type { DahnTheme } from '../contracts/themes';
+
+function applyTokenGroup(
+  root: HTMLElement,
+  prefix: string,
+  tokens: Record<string, string>,
+): void {
+  for (const [token, value] of Object.entries(tokens)) {
+    root.style.setProperty(`--dahn-${prefix}-${token}`, value);
+  }
+}
+
+export function applyTheme(root: HTMLElement, theme: DahnTheme): void {
+  root.dataset['dahnThemeId'] = theme.id;
+  root.dataset['dahnThemeLabel'] = theme.label;
+
+  applyTokenGroup(root, 'color', theme.colorTokens);
+  applyTokenGroup(root, 'type', theme.typographyTokens);
+  applyTokenGroup(root, 'space', theme.spacingTokens);
+  applyTokenGroup(root, 'radius', theme.radiusTokens);
+}

--- a/host/ui/src/dahn/themes/default-theme.ts
+++ b/host/ui/src/dahn/themes/default-theme.ts
@@ -1,0 +1,24 @@
+import type { DahnTheme } from '../contracts/themes';
+
+export const DEFAULT_DAHN_THEME: DahnTheme = {
+  id: 'dahn-default',
+  label: 'DAHN Default',
+  colorTokens: {
+    surface: '#f7f5ef',
+    surfaceAlt: '#ece6d8',
+    text: '#1f2933',
+    accent: '#14532d',
+    border: '#d4cdbf',
+  },
+  typographyTokens: {
+    bodyFont: '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif',
+    headingFont: '"Avenir Next", "Segoe UI", sans-serif',
+  },
+  spacingTokens: {
+    gap: '16px',
+    padding: '20px',
+  },
+  radiusTokens: {
+    panel: '16px',
+  },
+};

--- a/host/ui/src/dahn/themes/theme-registry.test.ts
+++ b/host/ui/src/dahn/themes/theme-registry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_DAHN_THEME } from './default-theme';
+import { DefaultThemeRegistry } from './theme-registry';
+
+describe('DefaultThemeRegistry', () => {
+  it('returns the default theme and exposes it by id', () => {
+    const registry = new DefaultThemeRegistry();
+
+    expect(registry.getDefaultTheme()).toBe(DEFAULT_DAHN_THEME);
+    expect(registry.getTheme(DEFAULT_DAHN_THEME.id)).toBe(DEFAULT_DAHN_THEME);
+    expect(registry.listThemes()).toEqual([DEFAULT_DAHN_THEME]);
+  });
+});

--- a/host/ui/src/dahn/themes/theme-registry.ts
+++ b/host/ui/src/dahn/themes/theme-registry.ts
@@ -1,0 +1,20 @@
+import type { DahnTheme } from '../contracts/themes';
+import { DEFAULT_DAHN_THEME } from './default-theme';
+
+export class DefaultThemeRegistry {
+  private readonly themes = new Map<string, DahnTheme>([
+    [DEFAULT_DAHN_THEME.id, DEFAULT_DAHN_THEME],
+  ]);
+
+  getDefaultTheme(): DahnTheme {
+    return DEFAULT_DAHN_THEME;
+  }
+
+  getTheme(id: string): DahnTheme | undefined {
+    return this.themes.get(id);
+  }
+
+  listThemes(): DahnTheme[] {
+    return [...this.themes.values()];
+  }
+}

--- a/host/ui/src/dahn/visualizers/action-menu-visualizer.element.ts
+++ b/host/ui/src/dahn/visualizers/action-menu-visualizer.element.ts
@@ -1,0 +1,14 @@
+import type { VisualizerContext, VisualizerElement } from '../contracts/visualizers';
+
+export const ACTION_MENU_VISUALIZER_TAG = 'map-action-menu-visualizer';
+
+export class ActionMenuVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  setContext(context: VisualizerContext): void {
+    this.dataset['visualizerId'] = 'action-menu';
+    this.dataset['targetKind'] = 'action';
+    this.textContent = `Action menu placeholder (${context.actions.length} actions)`;
+  }
+}

--- a/host/ui/src/dahn/visualizers/builtins.test.ts
+++ b/host/ui/src/dahn/visualizers/builtins.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultVisualizerRegistry } from '../registry/default-visualizer-registry';
+import { registerBuiltInVisualizers } from '../registry/register-builtins';
+
+describe('registerBuiltInVisualizers', () => {
+  it('registers the phase 0 built-in visualizer definitions', () => {
+    const registry = new DefaultVisualizerRegistry();
+
+    registerBuiltInVisualizers(registry);
+
+    expect(registry.get('holon-node')).toBeDefined();
+    expect(registry.get('action-menu')).toBeDefined();
+    expect(registry.get('debug')).toBeDefined();
+    expect(registry.list()).toHaveLength(3);
+  });
+});

--- a/host/ui/src/dahn/visualizers/builtins.ts
+++ b/host/ui/src/dahn/visualizers/builtins.ts
@@ -1,0 +1,53 @@
+import type { VisualizerDefinition } from '../contracts/visualizers';
+import { defineCustomElementOnce } from './define-custom-element-once';
+import {
+  ACTION_MENU_VISUALIZER_TAG,
+  ActionMenuVisualizerElement,
+} from './action-menu-visualizer.element';
+import {
+  DEBUG_VISUALIZER_TAG,
+  DebugVisualizerElement,
+} from './debug-visualizer.element';
+import {
+  HOLON_NODE_VISUALIZER_TAG,
+  HolonNodeVisualizerElement,
+} from './holon-node-visualizer.element';
+
+export const BUILTIN_VISUALIZER_DEFINITIONS: VisualizerDefinition[] = [
+  {
+    id: 'holon-node',
+    displayName: 'Holon Node',
+    version: '0.0.0',
+    componentTag: HOLON_NODE_VISUALIZER_TAG,
+    supportedTargets: [{ kind: 'holon-node' }],
+    load: async () => {
+      defineCustomElementOnce(
+        HOLON_NODE_VISUALIZER_TAG,
+        HolonNodeVisualizerElement,
+      );
+    },
+  },
+  {
+    id: 'action-menu',
+    displayName: 'Action Menu',
+    version: '0.0.0',
+    componentTag: ACTION_MENU_VISUALIZER_TAG,
+    supportedTargets: [{ kind: 'action' }],
+    load: async () => {
+      defineCustomElementOnce(
+        ACTION_MENU_VISUALIZER_TAG,
+        ActionMenuVisualizerElement,
+      );
+    },
+  },
+  {
+    id: 'debug',
+    displayName: 'Debug',
+    version: '0.0.0',
+    componentTag: DEBUG_VISUALIZER_TAG,
+    supportedTargets: [{ kind: 'debug' }],
+    load: async () => {
+      defineCustomElementOnce(DEBUG_VISUALIZER_TAG, DebugVisualizerElement);
+    },
+  },
+];

--- a/host/ui/src/dahn/visualizers/debug-visualizer.element.ts
+++ b/host/ui/src/dahn/visualizers/debug-visualizer.element.ts
@@ -1,0 +1,16 @@
+import type { VisualizerContext, VisualizerElement } from '../contracts/visualizers';
+
+export const DEBUG_VISUALIZER_TAG = 'map-debug-visualizer';
+
+export class DebugVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  setContext(context: VisualizerContext): void {
+    this.dataset['visualizerId'] = 'debug';
+    this.dataset['targetKind'] = 'debug';
+    this.textContent = `Debug visualizer placeholder for ${
+      context.target.reference.constructor.name || 'target'
+    }`;
+  }
+}

--- a/host/ui/src/dahn/visualizers/define-custom-element-once.ts
+++ b/host/ui/src/dahn/visualizers/define-custom-element-once.ts
@@ -1,0 +1,8 @@
+export function defineCustomElementOnce(
+  tagName: string,
+  constructor: CustomElementConstructor,
+): void {
+  if (customElements.get(tagName) === undefined) {
+    customElements.define(tagName, constructor);
+  }
+}

--- a/host/ui/src/dahn/visualizers/holon-node-visualizer.element.ts
+++ b/host/ui/src/dahn/visualizers/holon-node-visualizer.element.ts
@@ -1,0 +1,16 @@
+import type { VisualizerContext, VisualizerElement } from '../contracts/visualizers';
+
+export const HOLON_NODE_VISUALIZER_TAG = 'map-holon-node-visualizer';
+
+export class HolonNodeVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  setContext(context: VisualizerContext): void {
+    this.dataset['visualizerId'] = 'holon-node';
+    this.dataset['targetKind'] = 'holon-node';
+    this.textContent = `Holon node visualizer placeholder for ${
+      context.target.reference.constructor.name || 'HolonReference'
+    }`;
+  }
+}

--- a/host/ui/tsconfig.app.json
+++ b/host/ui/tsconfig.app.json
@@ -9,6 +9,7 @@
   "include": [
     "src/**/*.ts"],
   "exclude": [
+    "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "conductora"
   ]

--- a/host/ui/tsconfig.spec.json
+++ b/host/ui/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"],
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/host/ui/vitest.config.ts
+++ b/host/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/dahn/**/*.test.ts'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,12 @@
         "@angular/compiler-cli": "^21.0.0",
         "@tailwindcss/postcss": "^4.1.12",
         "@tauri-apps/cli": "^2",
+        "@types/node": "^24.0.0",
+        "jsdom": "^26.1.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.12",
-        "typescript": "~5.9.2"
+        "typescript": "~5.9.2",
+        "vitest": "^2.1.8"
       }
     },
     "host/map-sdk": {
@@ -1492,6 +1495,27 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1800,6 +1824,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6069,6 +6208,34 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6086,6 +6253,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -6818,6 +6992,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -7041,6 +7228,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7127,6 +7321,72 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -8307,6 +8567,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8817,6 +9084,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -9047,6 +9324,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -9112,6 +9396,19 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -9578,6 +9875,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -9677,6 +9981,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -9685,6 +10009,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -10693,6 +11043,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -10714,6 +11077,67 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10772,6 +11196,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "npm run build:happ && npm run build:host",
     "build:host": "npm run build -w map-host",
     "build:happ": "npm run build:happ -w map-happ",
+    "web:test": "npm run web:test:dahn -w map-host",
     "web:typecheck": "npm run web:typecheck -w map-host",
 
     "check": "npm run check -w map-host && npm run check -w map-happ && npm run web:typecheck",
@@ -27,7 +28,7 @@
     "fmt:sweetests:check": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all --check",
 
     "test": "npm run test:unit && npm run sweetest",
-    "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run web:typecheck && npm run typecheck -w map-sdk && npm run test -w map-sdk",
+    "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run web:typecheck && npm run web:test && npm run typecheck -w map-sdk && npm run test -w map-sdk",
     "test:unit:shared": "cargo test --manifest-path shared_crates/type_system/base_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/integrity_core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/type_names/Cargo.toml && cargo test --manifest-path shared_crates/shared_validation/Cargo.toml && cargo test --manifest-path shared_crates/holons_core/Cargo.toml && cargo test --manifest-path shared_crates/holons_boundary/Cargo.toml && cargo test --manifest-path shared_crates/holons_prelude/Cargo.toml && cargo test --manifest-path shared_crates/holon_dance_builders/Cargo.toml && cargo test --manifest-path shared_crates/holons_trust_channel/Cargo.toml && cargo test --manifest-path shared_crates/json_schema_validation/Cargo.toml",
 
     "sweetest": "RUST_LOG=${RUST_LOG:-warn} WASM_LOG=${WASM_LOG:-warn} npm run build:happ && npm run sweet:test",


### PR DESCRIPTION
## DAHN Phase 0 PR 2 — Implement Visualizer Registry, Minimal Canvas, and Theme Application

PR 2 turns DAHN from “a set of contracts” into “a minimal runnable visualizer host,” while still staying intentionally dumb about real holon semantics.

**Closes #434**

---

### Summary

This PR implements the first behaviorful DAHN runtime substrate on top of the PR 1 contract seam.

It introduces:

- a `VisualizerRegistry`
- minimal dynamic visualizer loading support
- a minimal DOM-backed canvas with one `primary` slot
- theme token application to the canvas root
- placeholder built-in Web Component visualizers
- a DAHN-focused UI test harness for validating the new runtime substrate

This PR is intentionally limited to the visualizer/canvas/theme layer. It does **not** yet fetch holon data, implement descriptor traversal, add selector behavior beyond the existing seam, or integrate DAHN into Angular routes/components.

---

### What Changed

#### Visualizer registry

Added the registry seam and default implementation:

- `host/ui/src/dahn/registry/visualizer-registry.ts`
- `host/ui/src/dahn/registry/default-visualizer-registry.ts`

Added built-in registration helper:

- `host/ui/src/dahn/registry/register-builtins.ts`

Behavior delivered:

- `register()`
- `get()`
- `list()`
- `ensureLoaded()`
- duplicate id protection
- idempotent loading
- safe handling when a custom element is already defined

#### Minimal canvas runtime

Added a minimal DOM-backed canvas implementation:

- `host/ui/src/dahn/canvas/create-canvas-root.ts`
- `host/ui/src/dahn/canvas/dom-canvas.ts`

Behavior delivered:

- one visible slot: `primary`
- `clear()`
- `setTheme()`
- `mountVisualizers()`
- vertical flow layout
- safe mounting of loaded custom elements
- `VisualizerContext` handoff through `setContext()`

#### Themes

Added the default theme and application helpers:

- `host/ui/src/dahn/themes/default-theme.ts`
- `host/ui/src/dahn/themes/apply-theme.ts`
- `host/ui/src/dahn/themes/theme-registry.ts`

Behavior delivered:

- one default `DahnTheme`
- small helper/registry for retrieving the default theme
- theme token application to the canvas root through CSS custom properties

#### Built-in placeholder visualizers

Added initial built-in Web Component visualizers:

- `host/ui/src/dahn/visualizers/define-custom-element-once.ts`
- `host/ui/src/dahn/visualizers/holon-node-visualizer.element.ts`
- `host/ui/src/dahn/visualizers/action-menu-visualizer.element.ts`
- `host/ui/src/dahn/visualizers/debug-visualizer.element.ts`
- `host/ui/src/dahn/visualizers/builtins.ts`

These are intentionally placeholder implementations. They exist to prove the registry/load/mount/context path and to preserve the design rule that DAHN visualizers are Web Components rather than Angular components.

#### DAHN UI test harness

Added a DAHN-focused Vitest/jsdom setup for `host/ui/src/dahn/**`:

- `host/ui/vitest.config.ts`
- `host/ui/tsconfig.spec.json`

Updated host/root scripts and UI tsconfig:

- `host/package.json`
- `package.json`
- `host/ui/tsconfig.app.json`

This adds:

- `web:test:dahn` in `host`
- root `web:test`
- inclusion of the DAHN UI test path in the standard root validation flow

#### Export surface updates

Updated:

- `host/ui/src/dahn/index.ts`

to export the new PR 2 runtime pieces:

- `DomCanvas`
- `DefaultVisualizerRegistry`
- `registerBuiltInVisualizers`
- `DEFAULT_DAHN_THEME`
- `DefaultThemeRegistry`
- `applyTheme`
- built-in visualizer definitions

---

### Architectural Notes

This PR stays aligned with the Phase 0 design intent:

- runtime/canvas code remains independent of MAP transport concerns
- the registry is a bootstrap/local mechanism, not the final visualizer ecosystem storage model
- built-ins are routed through the registry rather than hardwired directly into the canvas
- theme application is DOM-level and reusable
- visualizers remain Web Components, not Angular components
- no public SDK-backed holon adapter is introduced here
- no real `HolonNodeVisualizer` semantics are introduced yet

The code is intentionally scoped to make later PRs easier:

- PR 3 can connect live holon access and descriptor handles into an already-working canvas/visualizer substrate
- later PRs can enrich placeholder visualizers rather than invent the hosting layer from scratch

---

### Out of Scope

This PR does **not** implement:

- public SDK-backed holon access
- descriptor traversal or flattening logic
- generic real holon rendering behavior
- dance discovery from live holons
- Angular route/component integration
- graph or collection visualizers
- editing behavior
- Rust-side selector/recommendation logic

---

### Tests

Added DAHN UI tests for:

- registry registration/list/get behavior
- duplicate registration protection
- `ensureLoaded()` idempotence
- safe handling when custom elements are already defined
- built-in visualizer registration
- theme token application
- canvas mount behavior
- `setContext()` invocation
- canvas clearing behavior

Test files added:

- `host/ui/src/dahn/registry/default-visualizer-registry.test.ts`
- `host/ui/src/dahn/themes/apply-theme.test.ts`
- `host/ui/src/dahn/themes/theme-registry.test.ts`
- `host/ui/src/dahn/canvas/dom-canvas.test.ts`
- `host/ui/src/dahn/visualizers/builtins.test.ts`

---

### Verification

Verified locally via:

- `npm run web:typecheck`
- `npm run web:test`
- `npm test`

Current results on this branch:

- UI TypeScript typecheck passes
- DAHN UI Vitest/jsdom tests pass
- root-level validation path includes the new DAHN UI test flow

---

### Why This PR Helps

PR 1 created the DAHN contract seam. PR 2 turns that seam into a minimal runnable presentation substrate.

At the end of this PR, DAHN now has:

- a registry for built-in visualizers
- a safe dynamic loading path
- a themed canvas host
- a working mount pipeline for Web Component visualizers
- dedicated tests for the new runtime substrate

That is enough infrastructure to support the next slice, where live holon access and descriptor-aware behavior can be introduced without mixing those concerns into the host/canvas/registry foundations.
