### PR TITLE
468 dahn phase 0 pr4 implement trivial phase 0 selector and presentation resolution

### DIFF
--- a/host/ui/src/dahn/contract-checks.ts
+++ b/host/ui/src/dahn/contract-checks.ts
@@ -22,7 +22,7 @@ import type {
   VisualizerDefinition,
   VisualizerElement,
 } from './index';
-import type { HolonReference } from './deps/map-sdk';
+import type { HolonReference } from './deps';
 
 /**
  * Compile-time DAHN contract checks for PR 1.

--- a/host/ui/src/dahn/contract-checks.ts
+++ b/host/ui/src/dahn/contract-checks.ts
@@ -13,6 +13,7 @@ import type {
   PropertyDescriptorHandle,
   RelationshipDescriptorHandle,
   RelationshipDescriptorKind,
+  Phase0Selector,
   SelectorFunction,
   SelectorInput,
   SelectorOutput,
@@ -21,7 +22,7 @@ import type {
   VisualizerDefinition,
   VisualizerElement,
 } from './index';
-import type { HolonReference } from '../../../map-sdk/src';
+import type { HolonReference } from './deps/map-sdk';
 
 /**
  * Compile-time DAHN contract checks for PR 1.
@@ -98,6 +99,7 @@ declare const danceDescriptor: DanceDescriptorHandle;
 declare const holonTypeDescriptor: HolonTypeDescriptorHandle;
 declare const holonViewContext: HolonViewContext;
 declare const selector: SelectorFunction;
+declare const phase0Selector: Phase0Selector;
 
 void valueTypeDescriptor;
 void propertyDescriptor;
@@ -106,3 +108,4 @@ void danceDescriptor;
 void holonTypeDescriptor;
 void holonViewContext;
 void selector;
+void phase0Selector;

--- a/host/ui/src/dahn/contracts/holon-view.ts
+++ b/host/ui/src/dahn/contracts/holon-view.ts
@@ -7,7 +7,7 @@ import type {
   HolonReference,
   PropertyName,
   RelationshipName,
-} from '../../../../map-sdk/src';
+} from '../deps/map-sdk';
 
 export type RelationshipDescriptorKind = 'declared' | 'inverse';
 

--- a/host/ui/src/dahn/contracts/holon-view.ts
+++ b/host/ui/src/dahn/contracts/holon-view.ts
@@ -7,7 +7,7 @@ import type {
   HolonReference,
   PropertyName,
   RelationshipName,
-} from '../deps/map-sdk';
+} from '../deps';
 
 export type RelationshipDescriptorKind = 'declared' | 'inverse';
 

--- a/host/ui/src/dahn/contracts/targets.ts
+++ b/host/ui/src/dahn/contracts/targets.ts
@@ -1,4 +1,4 @@
-import type { HolonReference } from '../../../../map-sdk/src';
+import type { HolonReference } from '../deps/map-sdk';
 
 /**
  * Runtime-level target handle used to identify the holon DAHN should open.

--- a/host/ui/src/dahn/contracts/targets.ts
+++ b/host/ui/src/dahn/contracts/targets.ts
@@ -1,4 +1,4 @@
-import type { HolonReference } from '../deps/map-sdk';
+import type { HolonReference } from '../deps';
 
 /**
  * Runtime-level target handle used to identify the holon DAHN should open.

--- a/host/ui/src/dahn/deps/index.ts
+++ b/host/ui/src/dahn/deps/index.ts
@@ -1,0 +1,9 @@
+export type {
+  BaseValue,
+  EssentialHolonContent,
+  HolonCollection,
+  HolonId,
+  HolonReference,
+  PropertyName,
+  RelationshipName,
+} from './map-sdk';

--- a/host/ui/src/dahn/deps/map-sdk.ts
+++ b/host/ui/src/dahn/deps/map-sdk.ts
@@ -1,0 +1,15 @@
+/**
+ * DAHN-local bridge to the public MAP SDK surface.
+ *
+ * DAHN runtime code must depend only on the public SDK seam re-exported here,
+ * never on MAP SDK internal modules or transport-layer types.
+ */
+export type {
+  BaseValue,
+  EssentialHolonContent,
+  HolonCollection,
+  HolonId,
+  HolonReference,
+  PropertyName,
+  RelationshipName,
+} from '../../../../map-sdk/src';

--- a/host/ui/src/dahn/index.ts
+++ b/host/ui/src/dahn/index.ts
@@ -36,6 +36,7 @@ export {
   registerBuiltInVisualizers,
 } from './registry/register-builtins';
 export type { VisualizerRegistry } from './registry/visualizer-registry';
+export { Phase0Selector } from './selector/phase0-selector';
 export { DefaultDahnRuntime } from './runtime/default-dahn-runtime';
 export type { DahnRuntime } from './runtime/dahn-runtime';
 export {

--- a/host/ui/src/dahn/selector/phase0-selector.test.ts
+++ b/host/ui/src/dahn/selector/phase0-selector.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { Phase0Selector } from './phase0-selector';
+import type {
+  ActionNode,
+  CanvasDescriptor,
+  DahnTarget,
+  HolonViewAccess,
+  SelectorInput,
+  VisualizerDefinition,
+} from '../index';
+
+const canvas: CanvasDescriptor = {
+  id: 'dahn-primary',
+  slots: ['primary'],
+};
+
+const target = { reference: {} } as DahnTarget;
+const holon = {} as HolonViewAccess;
+
+function visualizer(id: string): VisualizerDefinition {
+  return {
+    id,
+    displayName: id,
+    version: '0.0.0',
+    componentTag: `test-${id}`,
+    supportedTargets: [{ kind: id === 'action-menu' ? 'action' : 'holon-node' }],
+    load: async () => {},
+  };
+}
+
+function makeInput(overrides?: Partial<SelectorInput>): SelectorInput {
+  return {
+    target,
+    holon,
+    actions: [],
+    availableVisualizers: [
+      visualizer('holon-node'),
+      visualizer('action-menu'),
+      visualizer('debug'),
+    ],
+    canvas,
+    ...overrides,
+  };
+}
+
+describe('Phase0Selector', () => {
+  it('always selects the holon-node visualizer for node rendering', () => {
+    const selector = new Phase0Selector();
+
+    const result = selector.select(makeInput());
+
+    expect(result.visualizers).toEqual([
+      {
+        visualizerId: 'holon-node',
+        target,
+        slot: 'primary',
+      },
+    ]);
+  });
+
+  it('adds the default action visualizer when actions are present', () => {
+    const selector = new Phase0Selector();
+    const actions: ActionNode[] = [
+      {
+        id: 'open',
+        kind: 'action',
+        label: 'Open',
+      },
+    ];
+
+    const result = selector.select(makeInput({ actions }));
+
+    expect(result.visualizers).toEqual([
+      {
+        visualizerId: 'holon-node',
+        target,
+        slot: 'primary',
+      },
+      {
+        visualizerId: 'action-menu',
+        target,
+        slot: 'primary',
+      },
+    ]);
+  });
+
+  it('remains deterministic across repeated calls', () => {
+    const selector = new Phase0Selector();
+    const input = makeInput({
+      actions: [{ id: 'edit', kind: 'action', label: 'Edit' }],
+    });
+
+    expect(selector.select(input)).toEqual(selector.select(input));
+  });
+
+  it('does not require the action visualizer when no actions are present', () => {
+    const selector = new Phase0Selector();
+
+    const result = selector.select(
+      makeInput({
+        availableVisualizers: [visualizer('holon-node')],
+      }),
+    );
+
+    expect(result.visualizers).toEqual([
+      {
+        visualizerId: 'holon-node',
+        target,
+        slot: 'primary',
+      },
+    ]);
+  });
+
+  it('fails clearly if the required node visualizer is unavailable', () => {
+    const selector = new Phase0Selector();
+
+    expect(() =>
+      selector.select(
+        makeInput({
+          availableVisualizers: [visualizer('action-menu')],
+        }),
+      ),
+    ).toThrow(/holon-node/);
+  });
+});

--- a/host/ui/src/dahn/selector/phase0-selector.ts
+++ b/host/ui/src/dahn/selector/phase0-selector.ts
@@ -1,0 +1,52 @@
+import type {
+  SelectorFunction,
+  SelectorInput,
+  SelectorOutput,
+} from '../contracts/selector';
+
+const HOLON_NODE_VISUALIZER_ID = 'holon-node';
+const ACTION_MENU_VISUALIZER_ID = 'action-menu';
+
+function hasVisualizer(input: SelectorInput, visualizerId: string): boolean {
+  return input.availableVisualizers.some(
+    (definition) => definition.id === visualizerId,
+  );
+}
+
+/**
+ * Static Phase 0 presentation-resolution selector.
+ *
+ * This implementation is intentionally deterministic and runtime-local. It is
+ * the TS-side final resolution step, not the long-term semantic home of
+ * selector intelligence.
+ */
+export class Phase0Selector implements SelectorFunction {
+  select(input: SelectorInput): SelectorOutput {
+    const visualizers = [];
+
+    if (hasVisualizer(input, HOLON_NODE_VISUALIZER_ID)) {
+      visualizers.push({
+        visualizerId: HOLON_NODE_VISUALIZER_ID,
+        target: input.target,
+        slot: 'primary' as const,
+      });
+    } else {
+      throw new Error(
+        `Phase0Selector requires the '${HOLON_NODE_VISUALIZER_ID}' visualizer`,
+      );
+    }
+
+    if (
+      input.actions.length > 0 &&
+      hasVisualizer(input, ACTION_MENU_VISUALIZER_ID)
+    ) {
+      visualizers.push({
+        visualizerId: ACTION_MENU_VISUALIZER_ID,
+        target: input.target,
+        slot: 'primary' as const,
+      });
+    }
+
+    return { visualizers };
+  }
+}


### PR DESCRIPTION
## DAHN Phase 0 PR 4 — Implement Trivial Phase 0 Selector and Presentation Resolution

**Closes #468**

---

### Summary

This PR implements the concrete Phase 0 DAHN selector as a deterministic TypeScript-side presentation-resolution layer.

It turns the selector contract introduced in PR 1 into an executable runtime behavior and completes another piece of the structural Phase 0 substrate alongside:

- PR 1: DAHN contracts and runtime seams
- PR 2: visualizer registry, minimal canvas, and theme application

The selector remains intentionally small and static in this PR. It does **not** introduce semantic recommendation, personalization, affinity/salience logic, type-specific heuristics, or Rust-side selector behavior.

This PR also tightens the DAHN-to-public-SDK dependency pattern by routing DAHN imports through a DAHN-local SDK dependency seam.

---

### What Changed

#### Phase 0 selector implementation

Added a concrete selector implementation:

- `host/ui/src/dahn/selector/phase0-selector.ts`

Behavior delivered:

- always selects the built-in `holon-node` visualizer for node rendering
- selects the built-in `action-menu` visualizer when actions are present and the visualizer is available
- returns `VisualizerMountPlan[]`
- remains fully deterministic
- fails clearly when the required `holon-node` visualizer is unavailable

This is the intended Phase 0 TS-side final presentation-resolution layer.

#### Selector tests

Added tests for the selector implementation:

- `host/ui/src/dahn/selector/phase0-selector.test.ts`

Coverage includes:

- deterministic node visualizer selection
- default action visualizer selection
- repeatability across repeated calls
- clear failure when the required node visualizer is unavailable
- behavior when actions are absent or the action visualizer is unavailable

#### Export surface update

Updated:

- `host/ui/src/dahn/index.ts`

to export:

- `Phase0Selector`

#### DAHN-local SDK dependency seam

Added a DAHN-local dependency barrel for the public SDK seam:

- `host/ui/src/dahn/deps/map-sdk.ts`
- `host/ui/src/dahn/deps/index.ts`

Updated DAHN imports to flow through that seam rather than importing directly through longer repo-layout paths.

Updated files include:

- `host/ui/src/dahn/contracts/targets.ts`
- `host/ui/src/dahn/contracts/holon-view.ts`
- `host/ui/src/dahn/contract-checks.ts`

This does not change behavior, but it improves boundary clarity and establishes a cleaner precedent for future DAHN code.

---

### Architectural Notes

This PR is intentionally narrow and aligned with the DAHN design direction:

- selector behavior remains entirely in TypeScript for Phase 0
- the selector is treated as the TS-side final runtime resolution layer, not the long-term home of semantic recommendation
- the future split is preserved:
  - Rust-side semantic recommendation later
  - TypeScript-side final runtime presentation resolution always
- no holon-access adapter work is introduced here
- no descriptor traversal or semantic heuristics are introduced here
- no selector intelligence is inferred from current holon semantics yet

This keeps PR 4 in the correct structural-groundwork lane while still making the runtime more executable.

---

### Out of Scope

This PR does **not** implement:

- Rust-side selector/recommendation behavior
- public SDK-backed holon access
- descriptor traversal
- generic `HolonNodeVisualizer` semantic rendering
- type-specific visualizer selection
- personalization or community signals
- DAHN route integration
- runtime orchestrator behavior

This is a trivial Phase 0 selector PR only.

---

### Tests

Added selector tests in:

- `host/ui/src/dahn/selector/phase0-selector.test.ts`

Verification performed:

- `npm run web:test`
- `npm run web:typecheck`
- `npm test`

Additional validation on this branch:

- happ builds
- host builds
- app runs as expected

Current results:

- DAHN UI tests pass
- DAHN UI typecheck passes
- full repo test flow passes
- no regression observed from the DAHN-local SDK import seam repackaging

---

### Why This PR Helps

PR 2 gave DAHN a visualizer registry, theme system, and minimal canvas. This PR gives that runtime substrate a deterministic way to decide what to mount.

That matters because it moves DAHN one step closer to a complete render cycle without prematurely entangling the selector with descriptor semantics that belong to later waves.

At the end of this PR, DAHN now has:

- contracts and runtime seams
- visualizer registry and minimal canvas
- theme application
- a concrete trivial selector
- a cleaner DAHN-owned dependency seam for public SDK imports

This is the right stopping point before moving on to later adapter/orchestrator work and, eventually, real descriptor-driven rendering.
