### PR TITLE
Add DAHN Wave 0 boundary and seam hardening tests per Issue 470

### DIFF
--- a/host/ui/src/dahn/boundaries/dependency-seam.test.ts
+++ b/host/ui/src/dahn/boundaries/dependency-seam.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readText } from './test-helpers';
+
+describe('DAHN dependency seam', () => {
+  it('defines a curated DAHN-local bridge to the public MAP SDK', () => {
+    const seamSource = readText('deps/map-sdk.ts');
+
+    expect(seamSource).toContain('public MAP SDK surface');
+    expect(seamSource).toContain("from '../../../../map-sdk/src'");
+    expect(seamSource).not.toContain('map-sdk/src/internal/');
+  });
+
+  it('re-exports the public SDK bridge through the local deps barrel', () => {
+    const depsIndexSource = readText('deps/index.ts');
+
+    expect(depsIndexSource).toContain("from './map-sdk'");
+  });
+
+  it('uses the local deps barrel from DAHN contracts and contract checks', () => {
+    expect(readText('contracts/targets.ts')).toContain("from '../deps'");
+    expect(readText('contracts/holon-view.ts')).toContain("from '../deps'");
+    expect(readText('contract-checks.ts')).toContain("from './deps'");
+  });
+});

--- a/host/ui/src/dahn/boundaries/exports.test.ts
+++ b/host/ui/src/dahn/boundaries/exports.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import * as dahn from '../index';
+
+describe('DAHN export surface', () => {
+  it('exports the expected Wave 0 DAHN runtime seams', () => {
+    expect(dahn.DefaultVisualizerRegistry).toBeDefined();
+    expect(dahn.DomCanvas).toBeDefined();
+    expect(dahn.Phase0Selector).toBeDefined();
+    expect(dahn.DEFAULT_DAHN_THEME).toBeDefined();
+    expect(dahn.DefaultThemeRegistry).toBeDefined();
+    expect(dahn.registerBuiltInVisualizers).toBeDefined();
+  });
+
+  it('does not leak obvious transport-facing concepts through the DAHN root export surface', () => {
+    const exportNames = Object.keys(dahn);
+
+    expect(exportNames).not.toContain('MapIpcRequest');
+    expect(exportNames).not.toContain('MapIpcResponse');
+    expect(exportNames).not.toContain('RequestOptions');
+    expect(exportNames.every((name) => !name.endsWith('Wire'))).toBe(true);
+    expect(exportNames.every((name) => !name.includes('Internal'))).toBe(true);
+  });
+});

--- a/host/ui/src/dahn/boundaries/sdk-boundary.test.ts
+++ b/host/ui/src/dahn/boundaries/sdk-boundary.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { relative } from 'node:path';
+import { dahnRoot, listDahnSourceFiles, readText } from './test-helpers';
+
+describe('DAHN SDK boundary', () => {
+  it('does not import MAP SDK internals anywhere in DAHN', () => {
+    for (const file of listDahnSourceFiles()) {
+      const relativePath = relative(dahnRoot(), file);
+
+      if (relativePath.startsWith('boundaries/')) {
+        continue;
+      }
+
+      const source = readText(relativePath);
+      expect(source).not.toContain('map-sdk/src/internal/');
+      expect(source).not.toContain("from '../../../../map-sdk/src/internal");
+      expect(source).not.toContain("from '../../../map-sdk/src/internal");
+    }
+  });
+
+  it('routes public SDK imports only through the DAHN-local dependency seam', () => {
+    for (const file of listDahnSourceFiles()) {
+      const relativePath = relative(dahnRoot(), file);
+
+      if (
+        relativePath === 'deps/map-sdk.ts' ||
+        relativePath.startsWith('boundaries/')
+      ) {
+        continue;
+      }
+
+      const source = readText(relativePath);
+      expect(source).not.toContain('map-sdk/src');
+    }
+  });
+});

--- a/host/ui/src/dahn/boundaries/structural-seams.test.ts
+++ b/host/ui/src/dahn/boundaries/structural-seams.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultVisualizerRegistry } from '../registry/default-visualizer-registry';
+import { Phase0Selector } from '../selector/phase0-selector';
+import { applyTheme } from '../themes/apply-theme';
+import { DEFAULT_DAHN_THEME } from '../themes/default-theme';
+import type {
+  CanvasDescriptor,
+  DahnTarget,
+  HolonViewAccess,
+  SelectorInput,
+  VisualizerDefinition,
+} from '../index';
+
+const canvas: CanvasDescriptor = {
+  id: 'dahn-structural',
+  slots: ['primary'],
+};
+
+function visualizer(id: string): VisualizerDefinition {
+  return {
+    id,
+    displayName: id,
+    version: '0.0.0',
+    componentTag: `test-${id}`,
+    supportedTargets: [
+      { kind: (id === 'action-menu' ? 'action' : 'holon-node') as const },
+    ],
+    load: async () => {},
+  };
+}
+
+describe('DAHN structural seams', () => {
+  it('keeps the selector as a deterministic TS-side presentation resolver', () => {
+    const selector = new Phase0Selector();
+    const input: SelectorInput = {
+      target: { reference: {} } as DahnTarget,
+      holon: {} as HolonViewAccess,
+      actions: [],
+      availableVisualizers: [visualizer('holon-node'), visualizer('action-menu')],
+      canvas,
+    };
+
+    expect(selector.select(input)).toEqual(selector.select(input));
+  });
+
+  it('keeps the registry as an id-keyed loader registry rather than canvas logic', () => {
+    const registry = new DefaultVisualizerRegistry();
+    const definition = visualizer('debug');
+
+    registry.register(definition);
+
+    expect(registry.get('debug')).toBe(definition);
+    expect(registry.list()).toEqual([definition]);
+  });
+
+  it('keeps theme application token-based at the DOM root', () => {
+    const root = document.createElement('div');
+
+    applyTheme(root, DEFAULT_DAHN_THEME);
+
+    expect(root.style.getPropertyValue('--dahn-color-surface')).toBe(
+      DEFAULT_DAHN_THEME.colorTokens['surface'],
+    );
+    expect(root.style.getPropertyValue('--dahn-space-gap')).toBe(
+      DEFAULT_DAHN_THEME.spacingTokens['gap'],
+    );
+  });
+});

--- a/host/ui/src/dahn/boundaries/test-helpers.ts
+++ b/host/ui/src/dahn/boundaries/test-helpers.ts
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+const DAHN_ROOT = join(THIS_DIR, '..');
+
+export function dahnRoot(): string {
+  return DAHN_ROOT;
+}
+
+export function readText(relativePath: string): string {
+  return readFileSync(join(DAHN_ROOT, relativePath), 'utf8');
+}
+
+export function listDahnSourceFiles(): string[] {
+  const files: string[] = [];
+
+  function walk(directory: string): void {
+    for (const entry of readdirSync(directory)) {
+      const fullPath = join(directory, entry);
+      const stats = statSync(fullPath);
+
+      if (stats.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (extname(fullPath) === '.ts') {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(DAHN_ROOT);
+  return files;
+}

--- a/host/ui/src/dahn/boundaries/visualizer-origin-agnostic.test.ts
+++ b/host/ui/src/dahn/boundaries/visualizer-origin-agnostic.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultVisualizerRegistry } from '../registry/default-visualizer-registry';
+import { Phase0Selector } from '../selector/phase0-selector';
+import type {
+  CanvasDescriptor,
+  DahnTarget,
+  HolonViewAccess,
+  SelectorInput,
+  VisualizerDefinition,
+} from '../index';
+
+const canvas: CanvasDescriptor = {
+  id: 'dahn-origin-agnostic',
+  slots: ['primary'],
+};
+
+function makeDefinition(
+  id: string,
+  componentTag: string,
+  extraMetadata?: Record<string, unknown>,
+): VisualizerDefinition {
+  return {
+    id,
+    displayName: id,
+    version: '0.0.0',
+    componentTag,
+    supportedTargets: [
+      { kind: (id === 'action-menu' ? 'action' : 'holon-node') as const },
+    ],
+    load: async () => {},
+    ...(extraMetadata as object),
+  };
+}
+
+describe('DAHN visualizer origin-agnostic seams', () => {
+  it('keys registry behavior by visualizer id rather than source metadata', () => {
+    const registry = new DefaultVisualizerRegistry();
+    const definition = makeDefinition(
+      'holon-node',
+      'visualizer-from-trust-channel',
+      {
+        sourceUrl: 'https://example.invalid/plugin.js',
+        trustChannelId: 'trust-channel-1',
+      },
+    );
+
+    registry.register(definition);
+
+    expect(registry.get('holon-node')).toBe(definition);
+  });
+
+  it('keeps selector output independent from component tag and origin metadata', () => {
+    const selector = new Phase0Selector();
+    const target = { reference: {} } as DahnTarget;
+    const input: SelectorInput = {
+      target,
+      holon: {} as HolonViewAccess,
+      actions: [{ id: 'open', kind: 'action', label: 'Open' }],
+      availableVisualizers: [
+        makeDefinition('holon-node', 'visualizer-from-i-space', {
+          signedBundleId: 'bundle-a',
+        }),
+        makeDefinition('action-menu', 'visualizer-from-integration-hub', {
+          trustChannelId: 'trust-channel-2',
+        }),
+      ],
+      canvas,
+    };
+
+    expect(selector.select(input)).toEqual({
+      visualizers: [
+        { visualizerId: 'holon-node', target, slot: 'primary' },
+        { visualizerId: 'action-menu', target, slot: 'primary' },
+      ],
+    });
+  });
+
+  it('treats load as an activation seam rather than a URL contract', async () => {
+    const registry = new DefaultVisualizerRegistry();
+    let activated = false;
+
+    registry.register({
+      id: 'debug',
+      displayName: 'Debug',
+      version: '0.0.0',
+      componentTag: 'origin-agnostic-debug-visualizer',
+      supportedTargets: [{ kind: 'debug' }],
+      load: async () => {
+        activated = true;
+        class OriginAgnosticDebugVisualizer extends HTMLElement {}
+        if (
+          customElements.get('origin-agnostic-debug-visualizer') === undefined
+        ) {
+          customElements.define(
+            'origin-agnostic-debug-visualizer',
+            OriginAgnosticDebugVisualizer,
+          );
+        }
+      },
+    });
+
+    await registry.ensureLoaded('debug');
+
+    expect(activated).toBe(true);
+    expect(customElements.get('origin-agnostic-debug-visualizer')).toBeDefined();
+  });
+});

--- a/host/ui/tsconfig.app.json
+++ b/host/ui/tsconfig.app.json
@@ -9,6 +9,7 @@
   "include": [
     "src/**/*.ts"],
   "exclude": [
+    "src/dahn/boundaries/**/*.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "conductora"


### PR DESCRIPTION
## DAHN Phase 0 PR 8a — Add Wave 0 DAHN Boundary and Seam Tests

**Closes #470**

---

### Summary

This PR implements the **Wave 0 subset** of DAHN PR 8: boundary and seam hardening tests for the DAHN runtime foundation that has been introduced so far.

It does **not** add new DAHN runtime behavior. Instead, it locks in the architectural boundaries established across the earlier DAHN slices by adding explicit tests for:

- public SDK boundary discipline
- DAHN-local dependency seam usage
- DAHN export-surface cleanliness
- structural separation of selector, registry, canvas, and theme concerns
- origin-agnostic visualizer loading assumptions

This PR is intentionally a hardening PR, not a semantic DAHN PR.

---

### What Changed

#### Added DAHN boundary/seam test suite

Added a dedicated boundary-test area under:

- `host/ui/src/dahn/boundaries/`

Files added:

- `host/ui/src/dahn/boundaries/test-helpers.ts`
- `host/ui/src/dahn/boundaries/sdk-boundary.test.ts`
- `host/ui/src/dahn/boundaries/dependency-seam.test.ts`
- `host/ui/src/dahn/boundaries/exports.test.ts`
- `host/ui/src/dahn/boundaries/structural-seams.test.ts`
- `host/ui/src/dahn/boundaries/visualizer-origin-agnostic.test.ts`

#### SDK boundary tests

Added tests that verify DAHN runtime modules:

- do not import `host/map-sdk/src/internal/*`
- do not regress back to direct deep repo-layout public SDK imports where the DAHN-local seam should be used
- remain aligned to the DAHN-owned public SDK dependency bridge

#### Dependency seam tests

Added tests that verify:

- the DAHN-local public SDK seam exists
- the local `deps/` barrel re-exports the curated public SDK bridge
- DAHN contract/check files route through that seam rather than bypassing it

#### Export-surface tests

Added tests that verify the DAHN root export surface:

- includes the expected Wave 0 runtime seams
- does not leak obvious transport-facing or internal-only concepts
- remains clean as the DAHN package seam grows

#### Structural seam tests

Added tests that lock in the intended structural responsibilities:

- selector remains deterministic TS-side presentation resolution
- registry remains an id-keyed loader registry
- theme application remains token-based at the DOM root
- the Wave 0 substrate pieces keep their concerns separated

#### Origin-agnostic visualizer seam tests

Added tests that explicitly preserve future compatibility with MAP-native trust-mediated visualizer delivery by verifying that current seams do **not** harden around conventional URL/DNS/plugin assumptions.

These tests assert that:

- registry behavior is keyed by `id`, not by source metadata
- selector output is independent from visualizer source/origin metadata
- `load()` is treated as an activation seam, not as a permanent URL-fetch contract

#### Test-only typecheck fix

Updated:

- `host/ui/tsconfig.app.json`

to exclude the new test-only boundary suite from the browser app typecheck. This avoids pulling Node-only helper imports into the app build while still allowing them to run under the DAHN UI test harness.

---

### Architectural Notes

This PR is intentionally aligned with the Wave 0 role described in the descriptor-driven implementation plan:

- harden structural seams early
- prevent architectural drift before semantic complexity arrives
- avoid prematurely implementing descriptor-backed DAHN behavior

It also preserves the clarified long-term visualizer-loading direction:

- current visualizer registry/loader behavior remains a bootstrap/local activation mechanism
- these tests avoid hardening the architecture around arbitrary URL/DNS/browser-fetch assumptions
- the seams remain compatible with a future MAP-native trust-mediated delivery model involving visualizer descriptor holons, I-Spaces, TrustChannels, and IntegrationHub-mediated retrieval

This PR does **not** implement any of that future loading model. It only protects the seams so we do not paint ourselves into a conventional-web-only corner.

---

### Out of Scope

This PR does **not** implement:

- SDK-backed holon access
- descriptor traversal
- generic `HolonNodeVisualizer` semantic rendering
- runtime orchestrator completion
- host UI DAHN mount/route integration
- action/affordance semantic completion
- IntegrationHub-mediated loading
- TrustChannel artifact retrieval
- signed bundle verification

This is a structural hardening PR only.

---

### Verification

Validated with the standard repo workflow:

- `npm run web:typecheck`
- `npm run web:test`
- `npm test`

Additional validation confirmed:

- happ builds
- host builds

Current results on this branch:

- DAHN UI boundary/seam tests pass
- DAHN UI typecheck passes
- full repo test flow passes

---

### Why This PR Helps

Earlier DAHN PRs established the Wave 0 substrate:

- PR 1: contracts and runtime seams
- PR 2: visualizer registry, minimal canvas, and theme substrate
- PR 4: trivial selector

This PR hardens that substrate before later descriptor- and adapter-driven work depends on it more heavily.

At the end of this PR, DAHN now has explicit executable checks that help prevent:

- SDK-internal import leakage
- erosion of the DAHN-owned dependency seam
- accidental export-surface drift
- collapse of selector/registry/canvas/theme boundaries
- accidental hardening of the visualizer loader around conventional network-origin assumptions

That is exactly the right kind of guardrail work for the Wave 0 subset of PR 8.
