### PR TITLE
450 redo/undo/markers/disable_undo e2e with RequestOptions and ExecutionPolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ workspaces/**/target/**/
 .idea/
 .venv/
 .vscode/
+.notes/
 .running
 settings.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4091,6 +4091,7 @@ name = "map_commands_runtime"
 version = "0.1.0"
 dependencies = [
  "base_types",
+ "client_shared_types",
  "core_types",
  "holons_client",
  "holons_core",

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -5219,6 +5219,7 @@ name = "map_commands_runtime"
 version = "0.1.0"
 dependencies = [
  "base_types",
+ "client_shared_types",
  "core_types",
  "holons_client",
  "holons_core",

--- a/host/conductora/src/runtime/dispatch_map_command.rs
+++ b/host/conductora/src/runtime/dispatch_map_command.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use core_types::HolonError;
 use map_commands_contract::MapCommand;
-use map_commands_runtime::Runtime; //ExecutionPolicy
+use map_commands_runtime::{ExecutionPolicy, Runtime}; //ExecutionPolicy
 use map_commands_wire::{MapCommandWire, MapIpcRequest, MapIpcResponse, MapResultWire};
 use tauri::{command, State};
 
@@ -50,12 +50,12 @@ async fn dispatch_inner(
     })?;
 
     // Log gesture context if present
-    if let Some(ref gesture_id) = options.gesture_id {
-        let label = options.gesture_label.as_deref().unwrap_or("<no label>");
+    if let Some(ref marker_id) = options.marker_id {
+        let label = options.marker_label.as_deref().unwrap_or("<no label>");
         tracing::info!(
-            "dispatch_map_command request_id={} gesture_id={:?} label={}",
+            "dispatch_map_command request_id={} marker_id={:?} label={}",
             request_id.value(),
-            gesture_id.0,
+            marker_id.0,
             label
         );
     }
@@ -66,11 +66,13 @@ async fn dispatch_inner(
     // Execute via runtime (policy enforcement + handler routing)
     runtime
         .execute_command(
-            //_with_policy(
             command,
-            //ExecutionPolicy {
-            //   snapshot_after: options.snapshot_after,
-            //},
+            ExecutionPolicy {
+                snapshot_after: options.snapshot_after,
+                disable_undo: options.disable_undo,
+                marker_id: options.marker_id.map(|m| m.0.0),
+                label: options.marker_label,
+            },
         )
         .await
 }

--- a/host/conductora/src/runtime/dispatch_map_command.rs
+++ b/host/conductora/src/runtime/dispatch_map_command.rs
@@ -70,7 +70,7 @@ async fn dispatch_inner(
             ExecutionPolicy {
                 snapshot_after: options.snapshot_after,
                 disable_undo: options.disable_undo,
-                marker_id: options.marker_id.map(|m| m.0.0),
+                marker_id: options.marker_id.map(|m| m.0 .0),
                 label: options.marker_label,
             },
         )

--- a/host/crates/holons_client/src/client_session.rs
+++ b/host/crates/holons_client/src/client_session.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
 use core_types::HolonError;
-use holons_core::core_shared_objects::{
-    space_manager::HolonSpaceManager,
-    transactions::{TransactionContext, TxId},
+use holons_core::{
+    core_shared_objects::{
+        space_manager::HolonSpaceManager,
+        transactions::{TransactionContext, TxId},
+    },
+    HolonPool,
 };
 
 use crate::Receptor;
@@ -77,18 +80,24 @@ impl ClientSession {
         };
 
         if let Receptor::LocalRecovery(r) = recovery.as_ref() {
-            if let Some(tx_snapshot) = r.undo(&self.tx_id().value().to_string()).await? {
-                tx_snapshot.restore_into(&self.context)?;
-                return Ok(());
-            } else {
+            let tx_id_str = self.tx_id().value().to_string();
+            if !r.can_undo(&tx_id_str)? {
                 return Err(HolonError::Misc(format!(
                     "No undo snapshot available for tx_id={}",
                     &self.tx_id().value()
                 )));
             }
-        } else {
-            Ok(())
+            // Stack was non-empty before the call. After popping the last EU,
+            // None means there is no prior snapshot — restore to baseline.
+            match r.undo(&tx_id_str).await? {
+                Some(snapshot) => snapshot.restore_into(&self.context)?,
+                None => {
+                    self.context.import_staged_holons(HolonPool::new())?;
+                    self.context.import_transient_holons(HolonPool::new())?;
+                }
+            }
         }
+        Ok(())
     }
 
     /// Redo the last undone transaction, if available.
@@ -103,7 +112,7 @@ impl ClientSession {
                 return Ok(());
             } else {
                 return Err(HolonError::Misc(format!(
-                    "No napshot available for tx_id={}",
+                    "No redo snapshot available for tx_id={}",
                     &self.tx_id().value()
                 )));
             }
@@ -122,7 +131,11 @@ impl ClientSession {
             let tx_id = self.tx_id().value().to_string();
             match r.undo_to_marker(&tx_id, marker_id).await? {
                 Some(snapshot) => snapshot.restore_into(&self.context)?,
-                None => {} // restored to baseline — no snapshot to apply
+                None => {
+                    // Marker was the first EU — restore to baseline.
+                    self.context.import_staged_holons(HolonPool::new())?;
+                    self.context.import_transient_holons(HolonPool::new())?;
+                }
             }
         }
         Ok(())

--- a/host/crates/holons_client/src/client_session.rs
+++ b/host/crates/holons_client/src/client_session.rs
@@ -112,6 +112,38 @@ impl ClientSession {
         }
     }
 
+    /// Undo all ExperienceUnits back to (and including) the one with `marker_id`.
+    pub async fn undo_to_marker(&self, marker_id: &str) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+            let tx_id = self.tx_id().value().to_string();
+            match r.undo_to_marker(&tx_id, marker_id).await? {
+                Some(snapshot) => snapshot.restore_into(&self.context)?,
+                None => {} // restored to baseline — no snapshot to apply
+            }
+        }
+        Ok(())
+    }
+
+    /// Redo all ExperienceUnits up to (and including) the one with `marker_id`.
+    pub async fn redo_to_marker(&self, marker_id: &str) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+            let tx_id = self.tx_id().value().to_string();
+            match r.redo_to_marker(&tx_id, marker_id).await? {
+                Some(snapshot) => snapshot.restore_into(&self.context)?,
+                None => {} // no-op (no redo units found — already handled as Err by store)
+            }
+        }
+        Ok(())
+    }
+
     /// Persist the current transaction state with the given description and options.
     pub async fn persist(
         &self,

--- a/host/crates/holons_client/src/client_session.rs
+++ b/host/crates/holons_client/src/client_session.rs
@@ -90,7 +90,7 @@ impl ClientSession {
             Ok(())
         }
     }
-    
+
     /// Redo the last undone transaction, if available.
     pub async fn redo_last(&self) -> Result<(), HolonError> {
         let Some(recovery) = self.recovery.as_ref() else {
@@ -113,13 +113,29 @@ impl ClientSession {
     }
 
     /// Persist the current transaction state with the given description and options.
-    pub async fn persist(&self, description: &str, disable_undo: bool, snapshot_after: bool, marker_id: Option<String>, marker_label: Option<String>) -> Result<(), HolonError> {
+    pub async fn persist(
+        &self,
+        description: &str,
+        disable_undo: bool,
+        snapshot_after: bool,
+        marker_id: Option<String>,
+        marker_label: Option<String>,
+    ) -> Result<(), HolonError> {
         let Some(recovery) = self.recovery.as_ref() else {
             return Ok(());
         };
 
         if let Receptor::LocalRecovery(r) = recovery.as_ref() {
-            return r.persist(&self.context, description, disable_undo, snapshot_after, marker_id, marker_label).await;
+            return r
+                .persist(
+                    &self.context,
+                    description,
+                    disable_undo,
+                    snapshot_after,
+                    marker_id,
+                    marker_label,
+                )
+                .await;
         } else {
             Ok(())
         }

--- a/host/crates/holons_client/src/client_session.rs
+++ b/host/crates/holons_client/src/client_session.rs
@@ -15,6 +15,7 @@ pub struct ClientSession {
 }
 
 impl ClientSession {
+    /// Open a new session for a new transaction, optionally with a recovery receptor for state persistence.
     pub fn open_new(
         space_manager: Arc<HolonSpaceManager>,
         recovery: Option<Arc<Receptor>>,
@@ -26,6 +27,7 @@ impl ClientSession {
         Ok(Self { context, recovery })
     }
 
+    /// Open a session for an existing transaction, restoring state from the recovery receptor if available.
     pub fn recover(
         space_manager: Arc<HolonSpaceManager>,
         recovery: Option<Arc<Receptor>>,
@@ -51,6 +53,7 @@ impl ClientSession {
         &self.context
     }
 
+    /// Restore transaction state from the recovery receptor, if available.
     fn restore_from_recovery(&self) -> Result<(), HolonError> {
         let Some(recovery) = self.recovery.as_ref() else {
             return Ok(());
@@ -67,18 +70,62 @@ impl ClientSession {
         }
     }
 
-    pub async fn persist(&self, description: &str, disable_undo: bool) -> Result<(), HolonError> {
+    /// Undo the last transaction command, if possible.
+    pub async fn undo_last(&self) -> Result<(), HolonError> {
         let Some(recovery) = self.recovery.as_ref() else {
             return Ok(());
         };
 
         if let Receptor::LocalRecovery(r) = recovery.as_ref() {
-            return r.persist(&self.context, description, disable_undo).await;
+            if let Some(tx_snapshot) = r.undo(&self.tx_id().value().to_string()).await? {
+                tx_snapshot.restore_into(&self.context)?;
+                return Ok(());
+            } else {
+                return Err(HolonError::Misc(format!(
+                    "No undo snapshot available for tx_id={}",
+                    &self.tx_id().value()
+                )));
+            }
+        } else {
+            Ok(())
+        }
+    }
+    
+    /// Redo the last undone transaction, if available.
+    pub async fn redo_last(&self) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+            if let Some(tx_snapshot) = r.redo(&self.tx_id().value().to_string()).await? {
+                tx_snapshot.restore_into(&self.context)?;
+                return Ok(());
+            } else {
+                return Err(HolonError::Misc(format!(
+                    "No napshot available for tx_id={}",
+                    &self.tx_id().value()
+                )));
+            }
         } else {
             Ok(())
         }
     }
 
+    /// Persist the current transaction state with the given description and options.
+    pub async fn persist(&self, description: &str, disable_undo: bool, snapshot_after: bool, marker_id: Option<String>, marker_label: Option<String>) -> Result<(), HolonError> {
+        let Some(recovery) = self.recovery.as_ref() else {
+            return Ok(());
+        };
+
+        if let Receptor::LocalRecovery(r) = recovery.as_ref() {
+            return r.persist(&self.context, description, disable_undo, snapshot_after, marker_id, marker_label).await;
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Cleanup recovery state for this transaction, if applicable.
     pub async fn cleanup(&self) -> Result<(), HolonError> {
         let Some(recovery) = self.recovery.as_ref() else {
             return Ok(());

--- a/host/crates/map_commands_contract/src/holon_command.rs
+++ b/host/crates/map_commands_contract/src/holon_command.rs
@@ -35,6 +35,21 @@ impl HolonAction {
             HolonAction::Write(_) => CommandDescriptor::mutating(),
         }
     }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            HolonAction::Read(ReadableHolonAction::CloneHolon) => "clone_holon",
+            HolonAction::Read(ReadableHolonAction::EssentialContent) => "essential_content",
+            HolonAction::Read(ReadableHolonAction::Summarize) => "summarize",
+            HolonAction::Read(ReadableHolonAction::HolonId) => "holon_id",
+            HolonAction::Read(ReadableHolonAction::Predecessor) => "predecessor",
+            HolonAction::Read(ReadableHolonAction::Key) => "key",
+            HolonAction::Read(ReadableHolonAction::VersionedKey) => "versioned_key",
+            HolonAction::Read(ReadableHolonAction::PropertyValue { .. }) => "property_value",
+            HolonAction::Read(ReadableHolonAction::RelatedHolons { .. }) => "related_holons",
+            HolonAction::Write(_) => "holon_write",
+        }
+    }
 }
 
 /// Non-mutating holon actions.

--- a/host/crates/map_commands_contract/src/map_command.rs
+++ b/host/crates/map_commands_contract/src/map_command.rs
@@ -19,4 +19,12 @@ impl MapCommand {
             MapCommand::Holon(cmd) => cmd.action.descriptor(),
         }
     }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            MapCommand::Space(cmd) => cmd.label(),
+            MapCommand::Transaction(cmd) => cmd.action.label(),
+            MapCommand::Holon(cmd) => cmd.action.label(),
+        }
+    }
 }

--- a/host/crates/map_commands_contract/src/map_result.rs
+++ b/host/crates/map_commands_contract/src/map_result.rs
@@ -22,6 +22,12 @@ pub enum MapResult {
     /// Command completed a redo operation.
     RedoComplete,
 
+    /// Command completed an undo to marker operation.
+    UndoToMarkerComplete,
+
+    /// Command completed a redo to marker operation.
+    RedoToMarkerComplete,
+
     /// Returns a new transaction id (from BeginTransaction).
     TransactionCreated { tx_id: TxId },
 

--- a/host/crates/map_commands_contract/src/map_result.rs
+++ b/host/crates/map_commands_contract/src/map_result.rs
@@ -16,6 +16,12 @@ pub enum MapResult {
     /// Command completed with no return value (also used for "not found").
     None,
 
+    /// Command completed an undo operation.
+    UndoComplete,
+
+    /// Command completed a redo operation.
+    RedoComplete,
+
     /// Returns a new transaction id (from BeginTransaction).
     TransactionCreated { tx_id: TxId },
 

--- a/host/crates/map_commands_contract/src/space_command.rs
+++ b/host/crates/map_commands_contract/src/space_command.rs
@@ -19,4 +19,10 @@ impl SpaceCommand {
             },
         }
     }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            SpaceCommand::BeginTransaction => "begin_transaction",
+        }
+    }
 }

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -34,6 +34,12 @@ pub enum TransactionAction {
     /// Redoes the last undone mutation in this transaction.
     RedoLast,
 
+    /// Undoes mutations up to the specified marker.
+    UndoToMarker { marker_id: String },
+
+    /// Redoes mutations up to the specified marker.
+    RedoToMarker { marker_id: String },
+
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
@@ -93,6 +99,9 @@ impl TransactionAction {
         match self {
             TransactionAction::Commit => CommandDescriptor::mutating_with_guard(),
             TransactionAction::UndoLast | TransactionAction::RedoLast => {
+                CommandDescriptor::transaction_read_only()
+            }
+            TransactionAction::UndoToMarker { .. } | TransactionAction::RedoToMarker { .. } => {
                 CommandDescriptor::transaction_read_only()
             }
             TransactionAction::LoadHolons { .. } => CommandDescriptor::mutating_with_guard(),

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -131,4 +131,37 @@ impl TransactionAction {
             | TransactionAction::DeleteHolon { .. } => CommandDescriptor::mutating(),
         }
     }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            TransactionAction::Commit => "commit",
+            TransactionAction::UndoLast => "undo_last",
+            TransactionAction::RedoLast => "redo_last",
+            TransactionAction::UndoToMarker { .. } => "undo_to_marker",
+            TransactionAction::RedoToMarker { .. } => "redo_to_marker",
+            TransactionAction::LoadHolons { .. } => "load_holons",
+            TransactionAction::Dance(_) => "dance",
+            TransactionAction::Query(_) => "query",
+            TransactionAction::GetAllHolons => "get_all_holons",
+            TransactionAction::GetStagedHolonByBaseKey { .. } => "get_staged_holon_by_base_key",
+            TransactionAction::GetStagedHolonsByBaseKey { .. } => "get_staged_holons_by_base_key",
+            TransactionAction::GetStagedHolonByVersionedKey { .. } => {
+                "get_staged_holon_by_versioned_key"
+            }
+            TransactionAction::GetTransientHolonByBaseKey { .. } => {
+                "get_transient_holon_by_base_key"
+            }
+            TransactionAction::GetTransientHolonByVersionedKey { .. } => {
+                "get_transient_holon_by_versioned_key"
+            }
+            TransactionAction::StagedCount => "staged_count",
+            TransactionAction::TransientCount => "transient_count",
+            TransactionAction::NewHolon { .. } => "new_holon",
+            TransactionAction::StageNewHolon { .. } => "stage_new_holon",
+            TransactionAction::StageNewFromClone { .. } => "stage_new_from_clone",
+            TransactionAction::StageNewVersion { .. } => "stage_new_version",
+            TransactionAction::StageNewVersionFromId { .. } => "stage_new_version_from_id",
+            TransactionAction::DeleteHolon { .. } => "delete_holon",
+        }
+    }
 }

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -28,9 +28,9 @@ pub enum TransactionAction {
     /// Commits the transaction.
     Commit,
 
-     /// Undoes the last mutation in this transaction.
+    /// Undoes the last mutation in this transaction.
     UndoLast,
-    
+
     /// Redoes the last undone mutation in this transaction.
     RedoLast,
 
@@ -92,7 +92,9 @@ impl TransactionAction {
     pub fn descriptor(&self) -> CommandDescriptor {
         match self {
             TransactionAction::Commit => CommandDescriptor::mutating_with_guard(),
-            TransactionAction::UndoLast | TransactionAction::RedoLast => CommandDescriptor::transaction_read_only(),
+            TransactionAction::UndoLast | TransactionAction::RedoLast => {
+                CommandDescriptor::transaction_read_only()
+            }
             TransactionAction::LoadHolons { .. } => CommandDescriptor::mutating_with_guard(),
             TransactionAction::Dance(_) => CommandDescriptor {
                 mutation: MutationClassification::RuntimeDetected,

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -28,6 +28,12 @@ pub enum TransactionAction {
     /// Commits the transaction.
     Commit,
 
+     /// Undoes the last mutation in this transaction.
+    UndoLast,
+    
+    /// Redoes the last undone mutation in this transaction.
+    RedoLast,
+
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
@@ -86,6 +92,7 @@ impl TransactionAction {
     pub fn descriptor(&self) -> CommandDescriptor {
         match self {
             TransactionAction::Commit => CommandDescriptor::mutating_with_guard(),
+            TransactionAction::UndoLast | TransactionAction::RedoLast => CommandDescriptor::transaction_read_only(),
             TransactionAction::LoadHolons { .. } => CommandDescriptor::mutating_with_guard(),
             TransactionAction::Dance(_) => CommandDescriptor {
                 mutation: MutationClassification::RuntimeDetected,

--- a/host/crates/map_commands_runtime/Cargo.toml
+++ b/host/crates/map_commands_runtime/Cargo.toml
@@ -15,3 +15,4 @@ core_types = { workspace = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 serde_json = { workspace = true }
+client_shared_types = { path = "../shared_types" }

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -44,8 +44,11 @@ impl Runtime {
     }
 
     /// Enforce lifecycle policy and route a bound domain command to its handler.
-    pub async fn execute_command(&self, command: MapCommand, policy: ExecutionPolicy) -> Result<MapResult, HolonError> {
-    
+    pub async fn execute_command(
+        &self,
+        command: MapCommand,
+        policy: ExecutionPolicy,
+    ) -> Result<MapResult, HolonError> {
         let descriptor = command.descriptor();
         let command_label = command_label(&command);
 
@@ -135,7 +138,7 @@ fn command_label(command: &MapCommand) -> &'static str {
         MapCommand::Transaction(cmd) => match &cmd.action {
             TransactionAction::Commit => "commit",
             TransactionAction::UndoLast => "undo_last",
-            TransactionAction::RedoLast => "redo_last", 
+            TransactionAction::RedoLast => "redo_last",
             TransactionAction::LoadHolons { .. } => "load_holons",
             TransactionAction::Dance(_) => "dance",
             TransactionAction::Query(_) => "query",

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -50,7 +50,7 @@ impl Runtime {
         policy: ExecutionPolicy,
     ) -> Result<MapResult, HolonError> {
         let descriptor = command.descriptor();
-        let command_label = command_label(&command);
+        let command_label = command.label();
 
         let is_commit = match &command {
             MapCommand::Transaction(cmd) => matches!(cmd.action, TransactionAction::Commit),
@@ -129,55 +129,5 @@ impl Runtime {
             }
             MapCommand::Holon(cmd) => holon_handler::handle_holon(cmd).await,
         }
-    }
-}
-
-fn command_label(command: &MapCommand) -> &'static str {
-    match command {
-        MapCommand::Space(SpaceCommand::BeginTransaction) => "begin_transaction",
-        MapCommand::Transaction(cmd) => match &cmd.action {
-            TransactionAction::Commit => "commit",
-            TransactionAction::UndoLast => "undo_last",
-            TransactionAction::RedoLast => "redo_last",
-            TransactionAction::UndoToMarker { .. } => "undo_to_marker",
-            TransactionAction::RedoToMarker { .. } => "redo_to_marker",
-            TransactionAction::LoadHolons { .. } => "load_holons",
-            TransactionAction::Dance(_) => "dance",
-            TransactionAction::Query(_) => "query",
-            TransactionAction::GetAllHolons => "get_all_holons",
-            TransactionAction::GetStagedHolonByBaseKey { .. } => "get_staged_holon_by_base_key",
-            TransactionAction::GetStagedHolonsByBaseKey { .. } => "get_staged_holons_by_base_key",
-            TransactionAction::GetStagedHolonByVersionedKey { .. } => {
-                "get_staged_holon_by_versioned_key"
-            }
-            TransactionAction::GetTransientHolonByBaseKey { .. } => {
-                "get_transient_holon_by_base_key"
-            }
-            TransactionAction::GetTransientHolonByVersionedKey { .. } => {
-                "get_transient_holon_by_versioned_key"
-            }
-            TransactionAction::StagedCount => "staged_count",
-            TransactionAction::TransientCount => "transient_count",
-            TransactionAction::NewHolon { .. } => "new_holon",
-            TransactionAction::StageNewHolon { .. } => "stage_new_holon",
-            TransactionAction::StageNewFromClone { .. } => "stage_new_from_clone",
-            TransactionAction::StageNewVersion { .. } => "stage_new_version",
-            TransactionAction::StageNewVersionFromId { .. } => "stage_new_version_from_id",
-            TransactionAction::DeleteHolon { .. } => "delete_holon",
-        },
-        MapCommand::Holon(cmd) => match &cmd.action {
-            HolonAction::Read(action) => match action {
-                ReadableHolonAction::CloneHolon => "clone_holon",
-                ReadableHolonAction::EssentialContent => "essential_content",
-                ReadableHolonAction::Summarize => "summarize",
-                ReadableHolonAction::HolonId => "holon_id",
-                ReadableHolonAction::Predecessor => "predecessor",
-                ReadableHolonAction::Key => "key",
-                ReadableHolonAction::VersionedKey => "versioned_key",
-                ReadableHolonAction::PropertyValue { .. } => "property_value",
-                ReadableHolonAction::RelatedHolons { .. } => "related_holons",
-            },
-            HolonAction::Write(_) => "holon_write",
-        },
     }
 }

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -139,6 +139,8 @@ fn command_label(command: &MapCommand) -> &'static str {
             TransactionAction::Commit => "commit",
             TransactionAction::UndoLast => "undo_last",
             TransactionAction::RedoLast => "redo_last",
+            TransactionAction::UndoToMarker { .. } => "undo_to_marker",
+            TransactionAction::RedoToMarker { .. } => "redo_to_marker",
             TransactionAction::LoadHolons { .. } => "load_holons",
             TransactionAction::Dance(_) => "dance",
             TransactionAction::Query(_) => "query",

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -4,10 +4,7 @@ use core_types::HolonError;
 
 use holons_core::core_shared_objects::transactions::TransactionLifecycleState;
 
-use map_commands_contract::{
-    HolonAction, MapCommand, MapResult, MutationClassification, ReadableHolonAction, SpaceCommand,
-    TransactionAction,
-};
+use map_commands_contract::{MapCommand, MapResult, MutationClassification, TransactionAction};
 
 use super::runtime_session::RuntimeSession;
 use super::{holon_handler, space_handler, transaction_handler};
@@ -104,14 +101,10 @@ impl Runtime {
         let tx_id_for_snapshot = context.as_ref().map(|ctx| ctx.tx_id());
         let result = self.route_command(command).await?;
 
-        // Only persist a snapshot after commands that:
-        // - explicitly requested snapshot_after
-        // - are not read-only
-        // - are not a Commit (commit destroys transaction-scoped recovery state)
-        if policy.snapshot_after
-            && descriptor.mutation != MutationClassification::ReadOnly
-            && !is_commit
-        {
+        // Persist after every mutable non-commit command so the store can clear
+        // the redo stack unconditionally. EU creation only happens when
+        // snapshot_after=true; crash-recovery state is always written.
+        if descriptor.mutation != MutationClassification::ReadOnly && !is_commit {
             if let Some(tx_id) = tx_id_for_snapshot {
                 self.session.persist_success(&tx_id, command_label, policy).await?;
             }

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -25,9 +25,12 @@ pub struct Runtime {
     session: Arc<RuntimeSession>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ExecutionPolicy {
     pub snapshot_after: bool,
+    pub disable_undo: bool,
+    pub marker_id: Option<String>,
+    pub label: Option<String>,
 }
 
 impl Runtime {
@@ -41,12 +44,8 @@ impl Runtime {
     }
 
     /// Enforce lifecycle policy and route a bound domain command to its handler.
-    pub async fn execute_command(&self, command: MapCommand) -> Result<MapResult, HolonError> {
-        //policy: ExecutionPolicy,
-
-        //TODO:  execution policy will be integrated into the workflow with experience units PR
-
-        let policy = ExecutionPolicy::default();
+    pub async fn execute_command(&self, command: MapCommand, policy: ExecutionPolicy) -> Result<MapResult, HolonError> {
+    
         let descriptor = command.descriptor();
         let command_label = command_label(&command);
 
@@ -111,7 +110,7 @@ impl Runtime {
             && !is_commit
         {
             if let Some(tx_id) = tx_id_for_snapshot {
-                self.session.persist_success(&tx_id, command_label, false).await?;
+                self.session.persist_success(&tx_id, command_label, policy).await?;
             }
         }
 
@@ -135,6 +134,8 @@ fn command_label(command: &MapCommand) -> &'static str {
         MapCommand::Space(SpaceCommand::BeginTransaction) => "begin_transaction",
         MapCommand::Transaction(cmd) => match &cmd.action {
             TransactionAction::Commit => "commit",
+            TransactionAction::UndoLast => "undo_last",
+            TransactionAction::RedoLast => "redo_last", 
             TransactionAction::LoadHolons { .. } => "load_holons",
             TransactionAction::Dance(_) => "dance",
             TransactionAction::Query(_) => "query",

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -175,6 +175,20 @@ impl RuntimeSession {
         Ok(())
     }
 
+    pub async fn undo_to_marker(&self, tx_id: &TxId, marker_id: &str) -> Result<(), HolonError> {
+        if let Ok(session) = self.get_client_session(tx_id) {
+            session.undo_to_marker(marker_id).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn redo_to_marker(&self, tx_id: &TxId, marker_id: &str) -> Result<(), HolonError> {
+        if let Ok(session) = self.get_client_session(tx_id) {
+            session.redo_to_marker(marker_id).await?;
+        }
+        Ok(())
+    }
+
     pub fn archive_transaction(&self, tx_id: &TxId) -> Result<(), HolonError> {
         let mut active = self.active_sessions.write().map_err(|e| {
             HolonError::FailedToAcquireLock(format!(

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -64,7 +64,7 @@ impl RuntimeSession {
             self.recovery.clone(),
         )?);
 
-        session.persist("begin_transaction", false, false,None, None).await?;
+        session.persist("begin_transaction", false, false, None, None).await?;
 
         let tx_id = session.tx_id();
         let mut active = self.active_sessions.write().map_err(|e| {
@@ -138,7 +138,15 @@ impl RuntimeSession {
         policy: ExecutionPolicy,
     ) -> Result<(), HolonError> {
         if let Ok(session) = self.get_client_session(tx_id) {
-            session.persist(description, policy.disable_undo, policy.snapshot_after, policy.marker_id, policy.label).await?;
+            session
+                .persist(
+                    description,
+                    policy.disable_undo,
+                    policy.snapshot_after,
+                    policy.marker_id,
+                    policy.label,
+                )
+                .await?;
         }
         Ok(())
     }

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -7,6 +7,8 @@ use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
 use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
 use holons_core::TransientReference;
 
+use crate::ExecutionPolicy;
+
 pub struct RuntimeSession {
     space_manager: Arc<HolonSpaceManager>,
     recovery: Option<Arc<Receptor>>,
@@ -62,7 +64,7 @@ impl RuntimeSession {
             self.recovery.clone(),
         )?);
 
-        session.persist("begin_transaction", true).await?;
+        session.persist("begin_transaction", false, false,None, None).await?;
 
         let tx_id = session.tx_id();
         let mut active = self.active_sessions.write().map_err(|e| {
@@ -133,10 +135,10 @@ impl RuntimeSession {
         &self,
         tx_id: &TxId,
         description: &str,
-        disable_undo: bool,
+        policy: ExecutionPolicy,
     ) -> Result<(), HolonError> {
         if let Ok(session) = self.get_client_session(tx_id) {
-            session.persist(description, disable_undo).await?;
+            session.persist(description, policy.disable_undo, policy.snapshot_after, policy.marker_id, policy.label).await?;
         }
         Ok(())
     }
@@ -149,6 +151,20 @@ impl RuntimeSession {
         self.archive_transaction(tx_id)?;
 
         Ok(transient_ref)
+    }
+
+    pub async fn undo_last(&self, tx_id: &TxId) -> Result<(), HolonError> {
+        if let Ok(session) = self.get_client_session(tx_id) {
+            session.undo_last().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn redo_last(&self, tx_id: &TxId) -> Result<(), HolonError> {
+        if let Ok(session) = self.get_client_session(tx_id) {
+            session.redo_last().await?;
+        }
+        Ok(())
     }
 
     pub fn archive_transaction(&self, tx_id: &TxId) -> Result<(), HolonError> {

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -1,4 +1,6 @@
 use std::any::Any;
+use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use base_types::{BaseValue, MapInteger, MapString};
@@ -12,11 +14,15 @@ use holons_core::reference_layer::{
     HolonReference, HolonServiceApi, StagedReference, TransientReference,
 };
 
+use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
+use holons_client::{LocalRecoveryReceptor, Receptor};
+use recovery_receptor::{RecoveryStore, TransactionRecoveryStore};
+
 use map_commands_contract::{
     MapCommand, MapResult, SpaceCommand, TransactionAction, TransactionCommand,
 };
 
-use crate::{Runtime, RuntimeSession};
+use crate::{ExecutionPolicy, Runtime, RuntimeSession};
 
 // ── Test double ─────────────────────────────────────────────────────
 
@@ -110,7 +116,7 @@ fn build_test_runtime() -> Runtime {
 /// Helper: begin a transaction and return the tx_id.
 async fn begin_tx(runtime: &Runtime) -> TxId {
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction))
+        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction), ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
     match result {
@@ -132,7 +138,7 @@ async fn begin_transaction_returns_valid_tx_id() {
     let runtime = build_test_runtime();
 
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction))
+        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction), ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
 
@@ -151,7 +157,7 @@ async fn begin_transaction_ids_are_unique() {
     let mut tx_ids = Vec::new();
     for _ in 0..3 {
         let result = runtime
-            .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction))
+            .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction),ExecutionPolicy::default())
             .await
             .expect("execute_command should succeed");
         match result {
@@ -190,7 +196,7 @@ async fn staged_count_returns_zero_for_new_tx() {
     let tx_id = begin_tx(&runtime).await;
 
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount))
+        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
 
@@ -206,7 +212,7 @@ async fn transient_count_returns_zero_for_new_tx() {
     let tx_id = begin_tx(&runtime).await;
 
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount))
+        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount), ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
 
@@ -229,7 +235,7 @@ async fn new_holon_then_transient_count() {
         &tx_id,
         TransactionAction::NewHolon { key: Some(MapString::from("test-key")) },
     );
-    let result = runtime.execute_command(cmd).await.expect("execute_command should succeed");
+    let result = runtime.execute_command(cmd, ExecutionPolicy::default()).await.expect("execute_command should succeed");
     match &result {
         MapResult::Reference(HolonReference::Transient(_)) => {}
         other => panic!("expected Transient reference, got {:?}", other),
@@ -237,7 +243,7 @@ async fn new_holon_then_transient_count() {
 
     // Transient count should be 1
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount))
+        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount), ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
     match result {
@@ -257,7 +263,7 @@ async fn new_holon_stage_then_staged_count() {
         &tx_id,
         TransactionAction::NewHolon { key: Some(MapString::from("stage-test")) },
     );
-    let result = runtime.execute_command(cmd).await.expect("execute_command should succeed");
+    let result = runtime.execute_command(cmd,ExecutionPolicy::default()).await.expect("execute_command should succeed");
     let transient_ref = match result {
         MapResult::Reference(HolonReference::Transient(t)) => t,
         other => panic!("expected Transient reference, got {:?}", other),
@@ -265,7 +271,7 @@ async fn new_holon_stage_then_staged_count() {
 
     // StageNewHolon using the transient ref directly
     let cmd = tx_cmd(&runtime, &tx_id, TransactionAction::StageNewHolon { source: transient_ref });
-    let result = runtime.execute_command(cmd).await.expect("execute_command should succeed");
+    let result = runtime.execute_command(cmd, ExecutionPolicy::default()).await.expect("execute_command should succeed");
     match &result {
         MapResult::Reference(HolonReference::Staged(_)) => {}
         other => panic!("expected Staged reference, got {:?}", other),
@@ -273,11 +279,245 @@ async fn new_holon_stage_then_staged_count() {
 
     // StagedCount should be 1
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount))
+        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount), ExecutionPolicy::default())
         .await
         .expect("execute_command should succeed");
     match result {
         MapResult::Value(BaseValue::IntegerValue(MapInteger(1))) => {}
         other => panic!("expected Value(IntegerValue(1)), got {:?}", other),
     }
+}
+
+// ── Recovery-backed runtime helpers ────────────────────────────────
+
+fn build_test_recovery_receptor() -> Arc<Receptor> {
+    let store = Arc::new(
+        TransactionRecoveryStore::new(Path::new(":memory:"))
+            .expect("in-memory recovery store should init"),
+    );
+    let base = BaseReceptor {
+        receptor_id: "test-recovery".to_string(),
+        receptor_type: ReceptorType::LocalRecovery,
+        client_handler: Some(store as Arc<dyn Any + Send + Sync>),
+        properties: HashMap::new(),
+    };
+    Arc::new(Receptor::LocalRecovery(
+        LocalRecoveryReceptor::new(base).expect("receptor should create"),
+    ))
+}
+
+fn build_test_runtime_with_recovery() -> Runtime {
+    let space_manager = build_test_space_manager();
+    let recovery = build_test_recovery_receptor();
+    let session = Arc::new(RuntimeSession::new(space_manager, Some(recovery)));
+    Runtime::new(session)
+}
+
+/// Create a transient holon, stage it, and close an ExperienceUnit (`snapshot_after=true`).
+async fn stage_and_close(runtime: &Runtime, tx_id: &TxId, key: &str) {
+    let cmd = tx_cmd(
+        runtime,
+        tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from(key)) },
+    );
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("NewHolon should succeed");
+    let transient_ref = match result {
+        MapResult::Reference(HolonReference::Transient(t)) => t,
+        other => panic!("stage_and_close: expected Transient reference, got {:?}", other),
+    };
+
+    let cmd =
+        tx_cmd(runtime, tx_id, TransactionAction::StageNewHolon { source: transient_ref });
+    runtime
+        .execute_command(cmd, ExecutionPolicy { snapshot_after: true, ..Default::default() })
+        .await
+        .expect("StageNewHolon should succeed");
+}
+
+async fn staged_count(runtime: &Runtime, tx_id: &TxId) -> i64 {
+    let result = runtime
+        .execute_command(
+            tx_cmd(runtime, tx_id, TransactionAction::StagedCount),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("StagedCount should succeed");
+    match result {
+        MapResult::Value(BaseValue::IntegerValue(MapInteger(n))) => n,
+        other => panic!("expected IntegerValue, got {:?}", other),
+    }
+}
+
+// ── Undo/redo handler tests ─────────────────────────────────────────
+
+#[tokio::test]
+async fn snapshot_after_creates_undo_unit() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // Two EUs so the first undo has a prior snapshot to restore
+    stage_and_close(&runtime, &tx_id, "holon-a").await;
+    stage_and_close(&runtime, &tx_id, "holon-b").await;
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 2);
+
+    // UndoLast succeeds — proves snapshot_after=true created an EU
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed after snapshot_after=true");
+}
+
+#[tokio::test]
+async fn intermediate_command_no_undo_unit() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // NewHolon without snapshot_after — no EU is closed
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("no-unit")) },
+    );
+    runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("NewHolon should succeed");
+
+    // UndoLast must fail — undo stack is empty
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(result.is_err(), "UndoLast should fail when no ExperienceUnit has been closed");
+}
+
+#[tokio::test]
+async fn undo_restores_prior_state() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "holon-a").await; // EU_1 — count=1
+    stage_and_close(&runtime, &tx_id, "holon-b").await; // EU_2 — count=2
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 2);
+
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1, "undo should restore EU_1 state");
+}
+
+#[tokio::test]
+async fn redo_after_undo() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "holon-a").await; // EU_1 — count=1
+    stage_and_close(&runtime, &tx_id, "holon-b").await; // EU_2 — count=2
+
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::RedoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("RedoLast should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 2, "redo should restore EU_2 state");
+}
+
+#[tokio::test]
+async fn new_command_invalidates_redo() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "holon-a").await; // EU_1
+    stage_and_close(&runtime, &tx_id, "holon-b").await; // EU_2
+
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    // New EU after undo clears the redo stack
+    stage_and_close(&runtime, &tx_id, "holon-c").await; // EU_3 — redo cleared
+
+    let redo_result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::RedoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(redo_result.is_err(), "RedoLast should fail after new EU was created post-undo");
+}
+
+#[tokio::test]
+async fn disable_undo_prevents_future_units() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // Stage a holon and close the EU with disable_undo=true — permanently disables checkpointing
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("disable-key")) },
+    );
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("NewHolon should succeed");
+    let transient_ref = match result {
+        MapResult::Reference(HolonReference::Transient(t)) => t,
+        other => panic!("expected Transient reference, got {:?}", other),
+    };
+    let cmd =
+        tx_cmd(&runtime, &tx_id, TransactionAction::StageNewHolon { source: transient_ref });
+    runtime
+        .execute_command(
+            cmd,
+            ExecutionPolicy { snapshot_after: true, disable_undo: true, ..Default::default() },
+        )
+        .await
+        .expect("StageNewHolon with disable_undo should succeed");
+
+    // Even with snapshot_after=true, no EU should be created now
+    stage_and_close(&runtime, &tx_id, "after-disable").await;
+
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "UndoLast should fail after disable_undo permanently disabled checkpointing"
+    );
 }

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -730,3 +730,121 @@ async fn marker_binding_at_close() {
 
     assert_eq!(staged_count(&runtime, &tx_id).await, 1, "restored to the EU before the marker");
 }
+
+// ── disable_undo hardening tests ────────────────────────────────────
+
+#[tokio::test]
+async fn disable_undo_midstream_prior_eus_remain_undoable() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // Two EUs created normally before disable fires.
+    stage_and_close(&runtime, &tx_id, "before-0").await; // EU_0, count=1
+    stage_and_close(&runtime, &tx_id, "before-1").await; // EU_1, count=2
+    assert_eq!(staged_count(&runtime, &tx_id).await, 2);
+
+    // Intermediate command with disable_undo=true — permanently disables checkpointing
+    // but does not touch the existing undo stack.
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("after-disable")) },
+    );
+    runtime
+        .execute_command(cmd, ExecutionPolicy { disable_undo: true, ..Default::default() })
+        .await
+        .expect("NewHolon with disable_undo should succeed");
+
+    // EU_1 is still on the undo stack — UndoLast must succeed.
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should still work on EUs created before disable_undo");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        1,
+        "EU_1 should have been undone; count drops to 1"
+    );
+}
+
+#[tokio::test]
+async fn disable_undo_without_snapshot_after_still_sets_flag() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // Fire any command with disable_undo=true and snapshot_after=false — the flag
+    // is written to the DB regardless of snapshot_after.
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("flag-setter")) },
+    );
+    runtime
+        .execute_command(
+            cmd,
+            ExecutionPolicy { disable_undo: true, snapshot_after: false, ..Default::default() },
+        )
+        .await
+        .expect("NewHolon with disable_undo=true should succeed");
+
+    // Close an EU — snapshot_after=true — but the flag is already set so no EU is created.
+    stage_and_close(&runtime, &tx_id, "after-flag").await;
+
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "UndoLast should fail: disable_undo set the flag before any EU was created"
+    );
+}
+
+#[tokio::test]
+async fn disable_undo_after_markers_marker_still_navigable() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // EU_0 (no marker, count=1) provides a snapshot to restore to — same pattern
+    // used by every other marker test (undo_to_marker restores to the EU *below* the marker).
+    stage_and_close(&runtime, &tx_id, "base").await;
+    // EU_1 with marker "m1" (count=2), EU_2 above (count=3).
+    stage_and_close_marked(&runtime, &tx_id, "marked", "m1").await;
+    stage_and_close(&runtime, &tx_id, "above").await;
+
+    // Disable checkpointing — existing EUs stay on the undo stack.
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("disabler")) },
+    );
+    runtime
+        .execute_command(cmd, ExecutionPolicy { disable_undo: true, ..Default::default() })
+        .await
+        .expect("NewHolon with disable_undo should succeed");
+
+    // undo_to_marker("m1") pops EU_2 and EU_1; restores to EU_0's snapshot (count=1).
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "m1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should still navigate to markers created before disable_undo");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        1,
+        "restored to EU_0's state — count drops from 3 to 1"
+    );
+}

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -546,3 +546,187 @@ async fn disable_undo_prevents_future_units() {
         "UndoLast should fail after disable_undo permanently disabled checkpointing"
     );
 }
+
+// ── Marker navigation tests ─────────────────────────────────────────
+
+/// Stage a holon and close an EU with an explicit marker_id.
+async fn stage_and_close_marked(runtime: &Runtime, tx_id: &TxId, key: &str, marker: &str) {
+    let cmd =
+        tx_cmd(runtime, tx_id, TransactionAction::NewHolon { key: Some(MapString::from(key)) });
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("NewHolon should succeed");
+    let transient_ref = match result {
+        MapResult::Reference(HolonReference::Transient(t)) => t,
+        other => panic!("stage_and_close_marked: expected Transient, got {:?}", other),
+    };
+
+    let cmd = tx_cmd(runtime, tx_id, TransactionAction::StageNewHolon { source: transient_ref });
+    runtime
+        .execute_command(
+            cmd,
+            ExecutionPolicy {
+                snapshot_after: true,
+                marker_id: Some(marker.to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("StageNewHolon with marker should succeed");
+}
+
+#[tokio::test]
+async fn undo_to_marker_jumps_to_marked_unit() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // EU_0 (unmarked, count=1) — establishes a snapshot before the marker
+    stage_and_close(&runtime, &tx_id, "holon-0").await;
+    // EU_1 marked "step-1" (count=2)
+    stage_and_close_marked(&runtime, &tx_id, "holon-1", "step-1").await;
+    // EU_2 (count=3) and EU_3 (count=4) above the marker
+    stage_and_close(&runtime, &tx_id, "holon-2").await;
+    stage_and_close(&runtime, &tx_id, "holon-3").await;
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 4);
+
+    // UndoToMarker should pop EU_3, EU_2, EU_1 and restore to EU_0 state
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "step-1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should succeed");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        1,
+        "UndoToMarker should restore state to just before the marked EU"
+    );
+}
+
+#[tokio::test]
+async fn redo_to_marker_jumps_forward() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "holon-0").await; // EU_0, count=1
+    stage_and_close_marked(&runtime, &tx_id, "holon-1", "step-1").await; // EU_1, count=2
+    stage_and_close(&runtime, &tx_id, "holon-2").await; // EU_2, count=3
+    stage_and_close(&runtime, &tx_id, "holon-3").await; // EU_3, count=4
+
+    // Undo to the marker — now count=1, redo stack has [EU_1, EU_2, EU_3]
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "step-1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    // RedoToMarker("step-1") should restore EU_1's state — count=2
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::RedoToMarker { marker_id: "step-1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("RedoToMarker should succeed");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        2,
+        "RedoToMarker should restore state to after the marked EU was applied"
+    );
+}
+
+#[tokio::test]
+async fn undo_to_marker_fails_if_marker_not_reachable() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "holon-a").await;
+    stage_and_close(&runtime, &tx_id, "holon-b").await;
+
+    // "ghost" is not on the undo stack — should return InvalidParameter
+    let result = runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "ghost".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(result.is_err(), "UndoToMarker should fail for a nonexistent marker");
+
+    // Move EU to redo, then try to UndoToMarker it — no longer on undo stack
+    stage_and_close_marked(&runtime, &tx_id, "holon-c", "now-in-redo").await;
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    let result2 = runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "now-in-redo".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(
+        result2.is_err(),
+        "UndoToMarker should fail when the marker is in the redo stack, not undo"
+    );
+}
+
+#[tokio::test]
+async fn marker_binding_at_close() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    // EU_0 establishes a prior snapshot so UndoToMarker has something to restore
+    stage_and_close(&runtime, &tx_id, "base").await; // count=1
+                                                     // EU_1 bound to marker "m1"
+    stage_and_close_marked(&runtime, &tx_id, "marked", "m1").await; // count=2
+                                                                    // EU_2 above the marker
+    stage_and_close(&runtime, &tx_id, "above").await; // count=3
+
+    // If the marker was stored, UndoToMarker("m1") finds EU_1 and succeeds
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "m1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should find the marker — proving it was bound at EU close");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1, "restored to the EU before the marker");
+}

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -989,3 +989,66 @@ async fn undo_to_marker_at_first_eu_restores_to_baseline() {
         "UndoToMarker at first EU should restore to baseline"
     );
 }
+
+#[tokio::test]
+async fn undo_to_marker_after_redo_to_marker_uses_correct_stack_order() {
+    // Regression for redo_to_marker stack_pos inversion bug.
+    // After redo_to_marker moves multiple EUs back to undo, the marker must be
+    // at the top of the undo stack so undo_to_marker("m1") pops only that one EU.
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "eu-0").await; // EU_0, count=1
+    stage_and_close_marked(&runtime, &tx_id, "eu-1", "m1").await; // EU_1 (marked), count=2
+    stage_and_close(&runtime, &tx_id, "eu-2").await; // EU_2, count=3
+
+    // Undo all three — redo stack now holds [EU_2, EU_1, EU_0] (EU_2 most recently undone)
+    for _ in 0..3 {
+        runtime
+            .execute_command(
+                tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+                ExecutionPolicy::default(),
+            )
+            .await
+            .expect("UndoLast should succeed");
+    }
+    assert_eq!(staged_count(&runtime, &tx_id).await, 0);
+
+    // redo_to_marker("m1") moves EU_2 (newest on redo) and EU_1 (marker) back to undo.
+    // After this: undo=[EU_0, EU_1], redo=[EU_2], count=2.
+    // EU_1 must be at the TOP of the undo stack (highest stack_pos).
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::RedoToMarker { marker_id: "m1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("RedoToMarker should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 2);
+
+    // undo_to_marker("m1") must pop only EU_1 (the top of the undo stack) → count=1.
+    // With the stack_pos inversion bug, load_eu_stack would put EU_0 at the top
+    // and drain both EU_0 and EU_1, giving count=0 instead.
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "m1".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should find m1 at the top of the undo stack");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        1,
+        "undo_to_marker after redo_to_marker must pop only the marker EU, not the ones below it"
+    );
+}

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -848,3 +848,144 @@ async fn disable_undo_after_markers_marker_still_navigable() {
         "restored to EU_0's state — count drops from 3 to 1"
     );
 }
+
+// ── Redo invalidation by forward mutations ──────────────────────────
+
+#[tokio::test]
+async fn intermediate_mutation_after_undo_invalidates_redo() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "eu-0").await; // EU_0, count=1
+    stage_and_close(&runtime, &tx_id, "eu-1").await; // EU_1, count=2
+
+    // Undo EU_1 — it moves to the redo stack.
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    // Intermediate forward mutation (no snapshot_after) — must invalidate redo.
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("forward")) },
+    );
+    runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("intermediate NewHolon should succeed");
+
+    // RedoLast must now fail — the redo timeline was cleared.
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::RedoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(result.is_err(), "RedoLast should fail: intermediate mutation cleared the redo stack");
+}
+
+#[tokio::test]
+async fn disable_undo_mutation_after_undo_invalidates_redo() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "eu-0").await; // EU_0, count=1
+    stage_and_close(&runtime, &tx_id, "eu-1").await; // EU_1, count=2
+
+    // Undo EU_1 — it moves to the redo stack.
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    // disable_undo mutation — must also invalidate redo.
+    let cmd = tx_cmd(
+        &runtime,
+        &tx_id,
+        TransactionAction::NewHolon { key: Some(MapString::from("forward")) },
+    );
+    runtime
+        .execute_command(cmd, ExecutionPolicy { disable_undo: true, ..Default::default() })
+        .await
+        .expect("disable_undo NewHolon should succeed");
+
+    // RedoLast must now fail — the redo timeline was cleared.
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::RedoLast),
+            ExecutionPolicy::default(),
+        )
+        .await;
+    assert!(result.is_err(), "RedoLast should fail: disable_undo mutation cleared the redo stack");
+}
+
+#[tokio::test]
+async fn undo_first_eu_restores_to_baseline() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close(&runtime, &tx_id, "eu-0").await; // EU_0, count=1
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    // Undo the only EU — store returns None (no prior snapshot), must restore to baseline.
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::UndoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoLast should succeed even when undoing the first EU");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 0, "baseline should have no staged holons");
+
+    // EU_0 is now on the redo stack — RedoLast must restore it.
+    runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::RedoLast),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("RedoLast should restore EU_0");
+
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1, "redo should restore EU_0 state");
+}
+
+#[tokio::test]
+async fn undo_to_marker_at_first_eu_restores_to_baseline() {
+    let runtime = build_test_runtime_with_recovery();
+    let tx_id = begin_tx(&runtime).await;
+
+    stage_and_close_marked(&runtime, &tx_id, "eu-0", "m0").await; // EU_0 with marker, count=1
+    assert_eq!(staged_count(&runtime, &tx_id).await, 1);
+
+    // UndoToMarker targeting the first (only) EU — store returns None (no prior snapshot).
+    runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::UndoToMarker { marker_id: "m0".to_string() },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("UndoToMarker should succeed when marker is the first EU");
+
+    assert_eq!(
+        staged_count(&runtime, &tx_id).await,
+        0,
+        "UndoToMarker at first EU should restore to baseline"
+    );
+}

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -116,7 +116,10 @@ fn build_test_runtime() -> Runtime {
 /// Helper: begin a transaction and return the tx_id.
 async fn begin_tx(runtime: &Runtime) -> TxId {
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction), ExecutionPolicy::default())
+        .execute_command(
+            MapCommand::Space(SpaceCommand::BeginTransaction),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
     match result {
@@ -138,7 +141,10 @@ async fn begin_transaction_returns_valid_tx_id() {
     let runtime = build_test_runtime();
 
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction), ExecutionPolicy::default())
+        .execute_command(
+            MapCommand::Space(SpaceCommand::BeginTransaction),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
 
@@ -157,7 +163,10 @@ async fn begin_transaction_ids_are_unique() {
     let mut tx_ids = Vec::new();
     for _ in 0..3 {
         let result = runtime
-            .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction),ExecutionPolicy::default())
+            .execute_command(
+                MapCommand::Space(SpaceCommand::BeginTransaction),
+                ExecutionPolicy::default(),
+            )
             .await
             .expect("execute_command should succeed");
         match result {
@@ -196,7 +205,10 @@ async fn staged_count_returns_zero_for_new_tx() {
     let tx_id = begin_tx(&runtime).await;
 
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),ExecutionPolicy::default())
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
 
@@ -212,7 +224,10 @@ async fn transient_count_returns_zero_for_new_tx() {
     let tx_id = begin_tx(&runtime).await;
 
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount), ExecutionPolicy::default())
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
 
@@ -235,7 +250,10 @@ async fn new_holon_then_transient_count() {
         &tx_id,
         TransactionAction::NewHolon { key: Some(MapString::from("test-key")) },
     );
-    let result = runtime.execute_command(cmd, ExecutionPolicy::default()).await.expect("execute_command should succeed");
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("execute_command should succeed");
     match &result {
         MapResult::Reference(HolonReference::Transient(_)) => {}
         other => panic!("expected Transient reference, got {:?}", other),
@@ -243,7 +261,10 @@ async fn new_holon_then_transient_count() {
 
     // Transient count should be 1
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount), ExecutionPolicy::default())
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
     match result {
@@ -263,7 +284,10 @@ async fn new_holon_stage_then_staged_count() {
         &tx_id,
         TransactionAction::NewHolon { key: Some(MapString::from("stage-test")) },
     );
-    let result = runtime.execute_command(cmd,ExecutionPolicy::default()).await.expect("execute_command should succeed");
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("execute_command should succeed");
     let transient_ref = match result {
         MapResult::Reference(HolonReference::Transient(t)) => t,
         other => panic!("expected Transient reference, got {:?}", other),
@@ -271,7 +295,10 @@ async fn new_holon_stage_then_staged_count() {
 
     // StageNewHolon using the transient ref directly
     let cmd = tx_cmd(&runtime, &tx_id, TransactionAction::StageNewHolon { source: transient_ref });
-    let result = runtime.execute_command(cmd, ExecutionPolicy::default()).await.expect("execute_command should succeed");
+    let result = runtime
+        .execute_command(cmd, ExecutionPolicy::default())
+        .await
+        .expect("execute_command should succeed");
     match &result {
         MapResult::Reference(HolonReference::Staged(_)) => {}
         other => panic!("expected Staged reference, got {:?}", other),
@@ -279,7 +306,10 @@ async fn new_holon_stage_then_staged_count() {
 
     // StagedCount should be 1
     let result = runtime
-        .execute_command(tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount), ExecutionPolicy::default())
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("execute_command should succeed");
     match result {
@@ -315,11 +345,8 @@ fn build_test_runtime_with_recovery() -> Runtime {
 
 /// Create a transient holon, stage it, and close an ExperienceUnit (`snapshot_after=true`).
 async fn stage_and_close(runtime: &Runtime, tx_id: &TxId, key: &str) {
-    let cmd = tx_cmd(
-        runtime,
-        tx_id,
-        TransactionAction::NewHolon { key: Some(MapString::from(key)) },
-    );
+    let cmd =
+        tx_cmd(runtime, tx_id, TransactionAction::NewHolon { key: Some(MapString::from(key)) });
     let result = runtime
         .execute_command(cmd, ExecutionPolicy::default())
         .await
@@ -329,8 +356,7 @@ async fn stage_and_close(runtime: &Runtime, tx_id: &TxId, key: &str) {
         other => panic!("stage_and_close: expected Transient reference, got {:?}", other),
     };
 
-    let cmd =
-        tx_cmd(runtime, tx_id, TransactionAction::StageNewHolon { source: transient_ref });
+    let cmd = tx_cmd(runtime, tx_id, TransactionAction::StageNewHolon { source: transient_ref });
     runtime
         .execute_command(cmd, ExecutionPolicy { snapshot_after: true, ..Default::default() })
         .await
@@ -497,8 +523,7 @@ async fn disable_undo_prevents_future_units() {
         MapResult::Reference(HolonReference::Transient(t)) => t,
         other => panic!("expected Transient reference, got {:?}", other),
     };
-    let cmd =
-        tx_cmd(&runtime, &tx_id, TransactionAction::StageNewHolon { source: transient_ref });
+    let cmd = tx_cmd(&runtime, &tx_id, TransactionAction::StageNewHolon { source: transient_ref });
     runtime
         .execute_command(
             cmd,

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -26,6 +26,14 @@ pub async fn handle_transaction(
             session.redo_last(&command.context.tx_id()).await?;
             Ok(MapResult::RedoComplete)
         }
+        TransactionAction::UndoToMarker { marker_id } => {
+            session.undo_to_marker(&command.context.tx_id(), &marker_id).await?;
+            Ok(MapResult::UndoToMarkerComplete)
+        }
+        TransactionAction::RedoToMarker { marker_id } => {
+            session.redo_to_marker(&command.context.tx_id(), &marker_id).await?;
+            Ok(MapResult::RedoToMarkerComplete)
+        }
         TransactionAction::Dance(request) => {
             let response = context.initiate_ingress_dance(request, false).await?;
             Ok(MapResult::DanceResponse(response))

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -14,13 +14,18 @@ pub async fn handle_transaction(
     let context = &command.context;
 
     match command.action {
-        // ── Commit ───────────────────────────────────────────────────
         TransactionAction::Commit => {
             let transient_ref = session.commit_transaction(&command.context.tx_id()).await?;
             Ok(MapResult::Reference(HolonReference::Transient(transient_ref)))
         }
-
-        // ── Dance / Query / LoadHolons ───────────────────────────────
+        TransactionAction::UndoLast => {
+            session.undo_last(&command.context.tx_id()).await?;
+            Ok(MapResult::UndoComplete)
+        }
+        TransactionAction::RedoLast => {
+            session.redo_last(&command.context.tx_id()).await?;
+            Ok(MapResult::RedoComplete)
+        }
         TransactionAction::Dance(request) => {
             let response = context.initiate_ingress_dance(request, false).await?;
             Ok(MapResult::DanceResponse(response))
@@ -33,8 +38,6 @@ pub async fn handle_transaction(
                 holons_loader_client::load_holons_from_files(context.clone(), content_set).await?;
             Ok(MapResult::Reference(HolonReference::Transient(response)))
         }
-
-        // ── Lookup actions (LookupFacade) ────────────────────────────
         TransactionAction::GetAllHolons => {
             let collection = context.lookup().get_all_holons()?;
             Ok(MapResult::Collection(collection))
@@ -67,8 +70,6 @@ pub async fn handle_transaction(
             let count = context.lookup().transient_count()?;
             Ok(MapResult::Value(BaseValue::IntegerValue(MapInteger(count))))
         }
-
-        // ── Mutation actions (MutationFacade) ────────────────────────
         TransactionAction::NewHolon { key } => {
             let transient = context.mutation().new_holon(key)?;
             Ok(MapResult::Reference(HolonReference::Transient(transient)))
@@ -92,6 +93,5 @@ pub async fn handle_transaction(
         TransactionAction::DeleteHolon { local_id } => {
             context.mutation().delete_holon(local_id)?;
             Ok(MapResult::None)
-        }
-    }
+        }}
 }

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -93,5 +93,6 @@ pub async fn handle_transaction(
         TransactionAction::DeleteHolon { local_id } => {
             context.mutation().delete_holon(local_id)?;
             Ok(MapResult::None)
-        }}
+        }
+    }
 }

--- a/host/crates/map_commands_wire/src/ipc_envelope.rs
+++ b/host/crates/map_commands_wire/src/ipc_envelope.rs
@@ -21,19 +21,21 @@ impl RequestId {
     }
 }
 
-/// Identifies a user gesture for undo/redo grouping.
+/// Identifies a user marker for undo/redo grouping.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GestureId(pub MapString);
+pub struct MarkerId(pub MapString);
 
 /// Per-request options controlling dispatch behavior.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RequestOptions {
-    /// Groups this command into a gesture for undo/redo.
-    pub gesture_id: Option<GestureId>,
-    /// Human-readable label for the gesture (shown in undo UI).
-    pub gesture_label: Option<String>,
+    /// Groups this command into a marker for undo/redo.
+    pub marker_id: Option<MarkerId>,
+    /// Human-readable label for the marker (shown in undo UI).
+    pub marker_label: Option<String>,
     /// When true, snapshot pool state after mutation (no-op until Phase 2.3).
     pub snapshot_after: bool,
+    /// When true, disables undo for this request.
+    pub disable_undo: bool,
 }
 
 /// Canonical IPC request envelope for MAP Commands.

--- a/host/crates/map_commands_wire/src/result_wire.rs
+++ b/host/crates/map_commands_wire/src/result_wire.rs
@@ -18,6 +18,12 @@ pub enum MapResultWire {
     /// Command completed with no return value.
     None,
 
+    /// Command completed an undo operation.
+    UndoComplete,
+
+    /// Command completed a redo operation.
+    RedoComplete,
+
     /// Returns a new transaction id (from BeginTransaction).
     TransactionCreated { tx_id: TxId },
 
@@ -50,6 +56,8 @@ impl From<MapResult> for MapResultWire {
     fn from(result: MapResult) -> Self {
         match result {
             MapResult::None => MapResultWire::None,
+            MapResult::UndoComplete => MapResultWire::UndoComplete,
+            MapResult::RedoComplete => MapResultWire::RedoComplete,
             MapResult::TransactionCreated { tx_id } => MapResultWire::TransactionCreated { tx_id },
             MapResult::Reference(r) => MapResultWire::Reference(HolonReferenceWire::from(&r)),
             MapResult::References(refs) => {

--- a/host/crates/map_commands_wire/src/result_wire.rs
+++ b/host/crates/map_commands_wire/src/result_wire.rs
@@ -24,6 +24,12 @@ pub enum MapResultWire {
     /// Command completed a redo operation.
     RedoComplete,
 
+    /// Command completed an undo to marker operation.
+    UndoToMarkerComplete,
+
+    /// Command completed a redo to marker operation.
+    RedoToMarkerComplete,
+
     /// Returns a new transaction id (from BeginTransaction).
     TransactionCreated { tx_id: TxId },
 
@@ -58,6 +64,8 @@ impl From<MapResult> for MapResultWire {
             MapResult::None => MapResultWire::None,
             MapResult::UndoComplete => MapResultWire::UndoComplete,
             MapResult::RedoComplete => MapResultWire::RedoComplete,
+            MapResult::UndoToMarkerComplete => MapResultWire::UndoToMarkerComplete,
+            MapResult::RedoToMarkerComplete => MapResultWire::RedoToMarkerComplete,
             MapResult::TransactionCreated { tx_id } => MapResultWire::TransactionCreated { tx_id },
             MapResult::Reference(r) => MapResultWire::Reference(HolonReferenceWire::from(&r)),
             MapResult::References(refs) => {

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -29,6 +29,12 @@ pub enum TransactionActionWire {
     /// Commits the transaction.
     Commit,
 
+    /// Undoes the last mutation in this transaction.
+    UndoLast,
+    
+    /// Redoes the last undone mutation in this transaction.
+    RedoLast,
+
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
@@ -100,6 +106,8 @@ impl TransactionActionWire {
     fn bind(self, context: &Arc<TransactionContext>) -> Result<TransactionAction, HolonError> {
         match self {
             TransactionActionWire::Commit => Ok(TransactionAction::Commit),
+            TransactionActionWire::UndoLast => Ok(TransactionAction::UndoLast),
+            TransactionActionWire::RedoLast => Ok(TransactionAction::RedoLast),
             TransactionActionWire::LoadHolons { content_set } => {
                 Ok(TransactionAction::LoadHolons { content_set })
             }

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -31,7 +31,7 @@ pub enum TransactionActionWire {
 
     /// Undoes the last mutation in this transaction.
     UndoLast,
-    
+
     /// Redoes the last undone mutation in this transaction.
     RedoLast,
 

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -35,6 +35,12 @@ pub enum TransactionActionWire {
     /// Redoes the last undone mutation in this transaction.
     RedoLast,
 
+    /// Undoes mutations up to the specified marker.
+    UndoToMarker { marker_id: String },
+
+    /// Redoes mutations up to the specified marker.
+    RedoToMarker { marker_id: String },
+
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
@@ -108,6 +114,12 @@ impl TransactionActionWire {
             TransactionActionWire::Commit => Ok(TransactionAction::Commit),
             TransactionActionWire::UndoLast => Ok(TransactionAction::UndoLast),
             TransactionActionWire::RedoLast => Ok(TransactionAction::RedoLast),
+            TransactionActionWire::UndoToMarker { marker_id } => {
+                Ok(TransactionAction::UndoToMarker { marker_id })
+            }
+            TransactionActionWire::RedoToMarker { marker_id } => {
+                Ok(TransactionAction::RedoToMarker { marker_id })
+            }
             TransactionActionWire::LoadHolons { content_set } => {
                 Ok(TransactionAction::LoadHolons { content_set })
             }
@@ -115,7 +127,6 @@ impl TransactionActionWire {
                 Ok(TransactionAction::Dance(request_wire.bind(context)?))
             }
             TransactionActionWire::Query(query) => Ok(TransactionAction::Query(query)),
-
             // Lookup actions — no context binding needed
             TransactionActionWire::GetAllHolons => Ok(TransactionAction::GetAllHolons),
             TransactionActionWire::GetStagedHolonByBaseKey { key } => {

--- a/host/crates/map_commands_wire/tests/generate_fixtures.rs
+++ b/host/crates/map_commands_wire/tests/generate_fixtures.rs
@@ -18,7 +18,7 @@ use holons_core::dances::ResponseStatusCode;
 use holons_core::query_layer::QueryExpression;
 use holons_core::CollectionState;
 use map_commands_wire::{
-    GestureId, HolonActionWire, HolonCommandWire, MapCommandWire, MapIpcRequest, MapIpcResponse,
+    MarkerId, HolonActionWire, HolonCommandWire, MapCommandWire, MapIpcRequest, MapIpcResponse,
     MapResultWire, ReadableHolonActionWire, RequestId, RequestOptions, SpaceCommandWire,
     TransactionActionWire, TransactionCommandWire, WritableHolonActionWire,
 };
@@ -472,14 +472,15 @@ fn holon_command(tx: u64, target: HolonReferenceWire, action: HolonActionWire) -
 }
 
 fn default_options() -> RequestOptions {
-    RequestOptions { gesture_id: None, gesture_label: None, snapshot_after: false }
+    RequestOptions { marker_id: None, marker_label: None, snapshot_after: false, disable_undo: false }
 }
 
 fn mutation_options(label: &str) -> RequestOptions {
     RequestOptions {
-        gesture_id: Some(GestureId(map_string("gesture-123"))),
-        gesture_label: Some(label.to_string()),
+        marker_id: Some(MarkerId(map_string("marker-123"))),
+        marker_label: Some(label.to_string()),
         snapshot_after: true,
+        disable_undo: false,
     }
 }
 

--- a/host/crates/map_commands_wire/tests/generate_fixtures.rs
+++ b/host/crates/map_commands_wire/tests/generate_fixtures.rs
@@ -18,8 +18,8 @@ use holons_core::dances::ResponseStatusCode;
 use holons_core::query_layer::QueryExpression;
 use holons_core::CollectionState;
 use map_commands_wire::{
-    MarkerId, HolonActionWire, HolonCommandWire, MapCommandWire, MapIpcRequest, MapIpcResponse,
-    MapResultWire, ReadableHolonActionWire, RequestId, RequestOptions, SpaceCommandWire,
+    HolonActionWire, HolonCommandWire, MapCommandWire, MapIpcRequest, MapIpcResponse,
+    MapResultWire, MarkerId, ReadableHolonActionWire, RequestId, RequestOptions, SpaceCommandWire,
     TransactionActionWire, TransactionCommandWire, WritableHolonActionWire,
 };
 use serde::Serialize;
@@ -472,7 +472,12 @@ fn holon_command(tx: u64, target: HolonReferenceWire, action: HolonActionWire) -
 }
 
 fn default_options() -> RequestOptions {
-    RequestOptions { marker_id: None, marker_label: None, snapshot_after: false, disable_undo: false }
+    RequestOptions {
+        marker_id: None,
+        marker_label: None,
+        snapshot_after: false,
+        disable_undo: false,
+    }
 }
 
 fn mutation_options(label: &str) -> RequestOptions {

--- a/host/crates/recovery_receptor/src/local_recovery_receptor.rs
+++ b/host/crates/recovery_receptor/src/local_recovery_receptor.rs
@@ -92,6 +92,34 @@ impl LocalRecoveryReceptor {
             .map_err(|e| HolonError::Misc(format!("redo join error: {e}")))?
     }
 
+    pub async fn undo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError> {
+        let store = Arc::clone(&self.recovery_store);
+        let tx_id = tx_id.to_string();
+        let marker_id = marker_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.undo_to_marker(&tx_id, &marker_id))
+            .await
+            .map_err(|e| HolonError::Misc(format!("undo_to_marker join error: {e}")))?
+    }
+
+    pub async fn redo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError> {
+        let store = Arc::clone(&self.recovery_store);
+        let tx_id = tx_id.to_string();
+        let marker_id = marker_id.to_string();
+
+        tokio::task::spawn_blocking(move || store.redo_to_marker(&tx_id, &marker_id))
+            .await
+            .map_err(|e| HolonError::Misc(format!("redo_to_marker join error: {e}")))?
+    }
+
     pub fn can_undo(&self, tx_id: &str) -> Result<bool, HolonError> {
         self.recovery_store.can_undo(tx_id)
     }

--- a/host/crates/recovery_receptor/src/local_recovery_receptor.rs
+++ b/host/crates/recovery_receptor/src/local_recovery_receptor.rs
@@ -52,14 +52,26 @@ impl LocalRecoveryReceptor {
         context: &Arc<TransactionContext>,
         description: &str,
         disable_undo: bool,
+        snapshot_after: bool,
+        marker_id: Option<String>,
+        marker_label: Option<String>,
     ) -> Result<(), HolonError> {
         let store = Arc::clone(&self.recovery_store);
         let context = Arc::clone(context);
         let description = description.to_string();
 
-        tokio::task::spawn_blocking(move || store.persist(&context, &description, disable_undo))
-            .await
-            .map_err(|e| HolonError::Misc(format!("persist join error: {e}")))?
+        tokio::task::spawn_blocking(move || {
+            store.persist(
+                &context,
+                &description,
+                disable_undo,
+                snapshot_after,
+                marker_id.as_deref(),
+                marker_label.as_deref(),
+            )
+        })
+        .await
+        .map_err(|e| HolonError::Misc(format!("persist join error: {e}")))?
     }
 
     pub async fn undo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {

--- a/host/crates/recovery_receptor/src/storage/recovery_store.rs
+++ b/host/crates/recovery_receptor/src/storage/recovery_store.rs
@@ -17,6 +17,9 @@ pub trait RecoveryStore: Send + Sync {
         context: &Arc<TransactionContext>,
         description: &str,
         disable_undo: bool,
+        snapshot_after: bool,
+        marker_id: Option<&str>,
+        marker_label: Option<&str>,
     ) -> Result<(), HolonError>;
 
     fn undo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError>;

--- a/host/crates/recovery_receptor/src/storage/recovery_store.rs
+++ b/host/crates/recovery_receptor/src/storage/recovery_store.rs
@@ -24,6 +24,16 @@ pub trait RecoveryStore: Send + Sync {
 
     fn undo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError>;
     fn redo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError>;
+    fn undo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError>;
+    fn redo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError>;
     fn recover_latest(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError>;
     fn cleanup(&self, tx_id: &str) -> Result<(), HolonError>;
 

--- a/host/crates/recovery_receptor/src/storage/transaction_snapshot.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_snapshot.rs
@@ -40,11 +40,11 @@ pub struct UndoCheckpoint {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperienceUnit {
-    pub unit_id: String,           // UUID
+    pub unit_id: String, // UUID
     pub tx_id: String,
     pub marker_id: Option<String>, // bound at close; None until Phase 2
     pub label: Option<String>,
-    pub checkpoint_id: String,     // the restore target snapshot
+    pub checkpoint_id: String, // the restore target snapshot
     pub created_at_ms: i64,
 }
 

--- a/host/crates/recovery_receptor/src/storage/transaction_snapshot.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_snapshot.rs
@@ -38,6 +38,16 @@ pub struct UndoCheckpoint {
     pub timestamp: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperienceUnit {
+    pub unit_id: String,           // UUID
+    pub tx_id: String,
+    pub marker_id: Option<String>, // bound at close; None until Phase 2
+    pub label: Option<String>,
+    pub checkpoint_id: String,     // the restore target snapshot
+    pub created_at_ms: i64,
+}
+
 /// Complete transaction graph state — the unit persisted per checkpoint.
 ///
 /// This is what gets serialized into `snapshot_blob` in `recovery_checkpoint`,

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -358,6 +358,149 @@ impl RecoveryStore for TransactionRecoveryStore {
         Ok(Some(snapshot))
     }
 
+    /// Pop ExperienceUnits from the undo stack until the unit with `marker_id` is popped
+    /// (inclusive). All popped units are moved to the redo stack. Returns the snapshot
+    /// representing the state just before the marked unit, or `None` for baseline.
+    /// Returns `Err(InvalidParameter)` if the marker is not reachable on the undo stack.
+    fn undo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError> {
+        let mut guard = lock(self)?;
+        let now = now_ms();
+        let (mut undo_stack, mut redo_stack) = load_stacks(&guard, tx_id)?;
+
+        // Load EU list newest-first; all reads happen before the write transaction opens.
+        let mut undo_units = load_eu_stack(&guard, tx_id, "undo")?;
+        // undo_units[0] = top of stack (newest), same order as undo_stack reversed.
+
+        let marker_pos = undo_units
+            .iter()
+            .position(|(_, _, mid)| mid.as_deref() == Some(marker_id))
+            .ok_or_else(|| {
+                HolonError::InvalidParameter(format!(
+                    "marker_id '{marker_id}' not found on undo stack for tx={tx_id}"
+                ))
+            })?;
+
+        // Units to pop: indices 0..=marker_pos (newest-first, inclusive of the marker).
+        let to_pop: Vec<(String, String, Option<String>)> =
+            undo_units.drain(..=marker_pos).collect();
+
+        // Restore target = checkpoint of the new undo top (the unit just below the marker).
+        let (restore_snapshot, latest_cp) = match undo_units.first() {
+            Some((_, cp_id, _)) => {
+                let snap = load_snapshot(&guard, cp_id)?;
+                (Some(snap), Some(cp_id.clone()))
+            }
+            None => (None, None),
+        };
+
+        let initial_redo_len = redo_stack.len() as i64;
+        for (uid, _, _) in &to_pop {
+            undo_stack.pop();
+            redo_stack.push(uid.clone());
+        }
+
+        let tx = guard
+            .transaction()
+            .map_err(|e| HolonError::Misc(format!("undo_to_marker begin tx: {e}")))?;
+
+        for (i, (uid, cp_id, _)) in to_pop.iter().enumerate() {
+            let redo_pos = initial_redo_len + i as i64;
+            tx.execute(
+                "UPDATE experience_unit SET stack_kind = 'redo', stack_pos = ?1 WHERE unit_id = ?2",
+                params![redo_pos, uid],
+            )
+            .map_err(|e| HolonError::Misc(format!("undo_to_marker: move EU to redo: {e}")))?;
+            tx.execute(
+                "UPDATE recovery_checkpoint SET stack_kind = 'redo', stack_pos = ?1 WHERE checkpoint_id = ?2",
+                params![redo_pos, cp_id],
+            )
+            .map_err(|e| HolonError::Misc(format!("undo_to_marker: sync checkpoint to redo: {e}")))?;
+        }
+
+        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, latest_cp.as_deref(), now)?;
+        tx.commit().map_err(|e| HolonError::Misc(format!("undo_to_marker commit: {e}")))?;
+
+        tracing::info!(
+            "[RECOVERY STORE] undo_to_marker: popped {} units to reach marker='{marker_id}' for tx={tx_id}",
+            to_pop.len()
+        );
+        Ok(restore_snapshot)
+    }
+
+    /// Pop ExperienceUnits from the redo stack until the unit with `marker_id` is popped
+    /// (inclusive). All popped units are moved back to the undo stack. Returns the snapshot
+    /// captured by the marked unit (the state after it was applied).
+    /// Returns `Err(InvalidParameter)` if the marker is not reachable on the redo stack.
+    fn redo_to_marker(
+        &self,
+        tx_id: &str,
+        marker_id: &str,
+    ) -> Result<Option<TransactionSnapshot>, HolonError> {
+        let mut guard = lock(self)?;
+        let now = now_ms();
+        let (mut undo_stack, mut redo_stack) = load_stacks(&guard, tx_id)?;
+
+        // Load redo EUs newest-first (highest stack_pos first).
+        let mut redo_units = load_eu_stack(&guard, tx_id, "redo")?;
+
+        let marker_pos = redo_units
+            .iter()
+            .position(|(_, _, mid)| mid.as_deref() == Some(marker_id))
+            .ok_or_else(|| {
+                HolonError::InvalidParameter(format!(
+                    "marker_id '{marker_id}' not found on redo stack for tx={tx_id}"
+                ))
+            })?;
+
+        // Drain newest-first up to and including the marker.
+        let to_redo: Vec<(String, String, Option<String>)> =
+            redo_units.drain(..=marker_pos).collect();
+
+        // The marker is the last entry in to_redo (oldest of those being redone).
+        // Its checkpoint represents the state we want to restore.
+        let (_, marker_cp, _) = &to_redo[marker_pos];
+        let restore_snapshot = load_snapshot(&guard, marker_cp)?;
+        let latest_cp = marker_cp.clone();
+
+        let initial_undo_len = undo_stack.len() as i64;
+        for (uid, _, _) in &to_redo {
+            redo_stack.pop();
+            undo_stack.push(uid.clone());
+        }
+
+        let tx = guard
+            .transaction()
+            .map_err(|e| HolonError::Misc(format!("redo_to_marker begin tx: {e}")))?;
+
+        for (i, (uid, cp_id, _)) in to_redo.iter().enumerate() {
+            // Newest unit gets the highest undo position; marker gets initial_undo_len.
+            let undo_pos = initial_undo_len + (to_redo.len() - 1 - i) as i64;
+            tx.execute(
+                "UPDATE experience_unit SET stack_kind = 'undo', stack_pos = ?1 WHERE unit_id = ?2",
+                params![undo_pos, uid],
+            )
+            .map_err(|e| HolonError::Misc(format!("redo_to_marker: move EU to undo: {e}")))?;
+            tx.execute(
+                "UPDATE recovery_checkpoint SET stack_kind = 'undo', stack_pos = ?1 WHERE checkpoint_id = ?2",
+                params![undo_pos, cp_id],
+            )
+            .map_err(|e| HolonError::Misc(format!("redo_to_marker: sync checkpoint to undo: {e}")))?;
+        }
+
+        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, Some(&latest_cp), now)?;
+        tx.commit().map_err(|e| HolonError::Misc(format!("redo_to_marker commit: {e}")))?;
+
+        tracing::info!(
+            "[RECOVERY STORE] redo_to_marker: restored {} units to reach marker='{marker_id}' for tx={tx_id}",
+            to_redo.len()
+        );
+        Ok(Some(restore_snapshot))
+    }
+
     // -----------------------------------------------------------------------
     // Startup recovery
     // -----------------------------------------------------------------------
@@ -549,6 +692,32 @@ fn load_checkpoint_for_unit(conn: &Connection, unit_id: &str) -> Result<String, 
         |r| r.get(0),
     )
     .map_err(|e| HolonError::Misc(format!("Load checkpoint for unit '{unit_id}': {e}")))
+}
+
+/// Load all ExperienceUnit rows for a given stack (newest-first) as `(unit_id, checkpoint_id, marker_id)`.
+fn load_eu_stack(
+    conn: &Connection,
+    tx_id: &str,
+    stack_kind: &str,
+) -> Result<Vec<(String, String, Option<String>)>, HolonError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT unit_id, checkpoint_id, marker_id
+             FROM experience_unit
+             WHERE tx_id = ?1 AND stack_kind = ?2
+             ORDER BY stack_pos DESC",
+        )
+        .map_err(|e| HolonError::Misc(format!("load_eu_stack prepare: {e}")))?;
+
+    let rows = stmt
+        .query_map(params![tx_id, stack_kind], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, Option<String>>(2)?))
+        })
+        .map_err(|e| HolonError::Misc(format!("load_eu_stack query: {e}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| HolonError::Misc(format!("load_eu_stack collect: {e}")))?;
+
+    Ok(rows)
 }
 
 fn load_snapshot(

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -136,7 +136,7 @@ impl RecoveryStore for TransactionRecoveryStore {
 
         // Read undo_checkpointing_enabled + stacks before opening the write tx.
         let checkpointing_enabled = load_checkpointing_enabled(&guard, &tx_id)?;
-        let (mut undo_stack, _redo_stack) = load_stacks(&guard, &tx_id)?;
+        let (mut undo_stack, mut redo_stack) = load_stacks(&guard, &tx_id)?;
 
         let tx =
             guard.transaction().map_err(|e| HolonError::Misc(format!("Begin transaction: {e}")))?;
@@ -177,6 +177,32 @@ impl RecoveryStore for TransactionRecoveryStore {
         .map_err(|e| HolonError::Misc(format!("Insert checkpoint: {e}")))?;
 
         // ── Step 3: apply undo semantics ──
+
+        // Any forward mutation diverges from the redo timeline. Clear redo unconditionally —
+        // applies to EU-closing, intermediate, and disable_undo mutations alike.
+        if !redo_stack.is_empty() {
+            tx.execute(
+                "DELETE FROM experience_unit WHERE tx_id = ?1 AND stack_kind = 'redo'",
+                params![tx_id],
+            )
+            .map_err(|e| HolonError::Misc(format!("Clear redo EUs on forward mutation: {e}")))?;
+            tx.execute(
+                "DELETE FROM recovery_checkpoint WHERE tx_id = ?1 AND stack_kind = 'redo'",
+                params![tx_id],
+            )
+            .map_err(|e| {
+                HolonError::Misc(format!("Clear redo checkpoints on forward mutation: {e}"))
+            })?;
+            tx.execute(
+                "UPDATE recovery_session SET redo_stack_json = '[]' WHERE tx_id = ?1",
+                params![tx_id],
+            )
+            .map_err(|e| {
+                HolonError::Misc(format!("Clear redo stack json on forward mutation: {e}"))
+            })?;
+            redo_stack.clear();
+        }
+
         if disable_undo {
             // Permanently disable future undo checkpoint creation for this tx.
             tx.execute(
@@ -188,7 +214,7 @@ impl RecoveryStore for TransactionRecoveryStore {
             tracing::debug!("[RECOVERY STORE] disable_undo: checkpointing disabled for tx={tx_id}");
         } else if snapshot_after && checkpointing_enabled {
             // Close the current Experience Unit: create a checkpoint + EU row,
-            // push unit_id onto undo stack, invalidate redo history.
+            // push unit_id onto undo stack.
             let unit_id = Uuid::new_v4().to_string();
             let stack_pos = undo_stack.len() as i64;
 
@@ -209,25 +235,8 @@ impl RecoveryStore for TransactionRecoveryStore {
             )
             .map_err(|e| HolonError::Misc(format!("Insert experience_unit: {e}")))?;
 
-            // Invalidate redo history: delete all redo experience_unit rows.
-            tx.execute(
-                "DELETE FROM experience_unit WHERE tx_id = ?1 AND stack_kind = 'redo'",
-                params![tx_id],
-            )
-            .map_err(|e| HolonError::Misc(format!("Clear redo experience_units: {e}")))?;
-
-            // Push unit_id onto undo stack and clear redo stack.
             undo_stack.push(unit_id.clone());
-            let undo_json = serde_json::to_string(&undo_stack)
-                .map_err(|e| HolonError::Misc(format!("Serialize undo stack: {e}")))?;
-
-            tx.execute(
-                "UPDATE recovery_session
-                 SET undo_stack_json = ?1, redo_stack_json = '[]'
-                 WHERE tx_id = ?2",
-                params![undo_json, tx_id],
-            )
-            .map_err(|e| HolonError::Misc(format!("Update stacks: {e}")))?;
+            save_stacks(&tx, &tx_id, &undo_stack, &redo_stack, Some(&checkpoint_id), now)?;
 
             tracing::debug!(
                 "[RECOVERY STORE] Closed ExperienceUnit unit_id={unit_id} \

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -185,9 +185,7 @@ impl RecoveryStore for TransactionRecoveryStore {
             )
             .map_err(|e| HolonError::Misc(format!("Disable checkpointing: {e}")))?;
 
-            tracing::debug!(
-                "[RECOVERY STORE] disable_undo: checkpointing disabled for tx={tx_id}"
-            );
+            tracing::debug!("[RECOVERY STORE] disable_undo: checkpointing disabled for tx={tx_id}");
         } else if snapshot_after && checkpointing_enabled {
             // Close the current Experience Unit: create a checkpoint + EU row,
             // push unit_id onto undo stack, invalidate redo history.
@@ -304,9 +302,7 @@ impl RecoveryStore for TransactionRecoveryStore {
 
         tx.commit().map_err(|e| HolonError::Misc(format!("Undo commit: {e}")))?;
 
-        tracing::info!(
-            "[RECOVERY STORE] Undo: popped unit={popped_unit_id} for tx={tx_id}"
-        );
+        tracing::info!("[RECOVERY STORE] Undo: popped unit={popped_unit_id} for tx={tx_id}");
         Ok(snapshot)
     }
 

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -37,6 +37,7 @@ const SCHEMA_SQL: &'static str = "
             latest_checkpoint_id  TEXT,
             undo_stack_json       TEXT NOT NULL DEFAULT '[]',
             redo_stack_json       TEXT NOT NULL DEFAULT '[]',
+            undo_checkpointing_enabled INTEGER NOT NULL DEFAULT 1,
             format_version        INTEGER NOT NULL DEFAULT 1,
             updated_at_ms         INTEGER NOT NULL
         );
@@ -55,6 +56,22 @@ const SCHEMA_SQL: &'static str = "
                 REFERENCES recovery_session(tx_id)
                 ON DELETE CASCADE
         );
+
+        CREATE TABLE IF NOT EXISTS experience_unit (
+            unit_id         TEXT    PRIMARY KEY,
+            tx_id           TEXT    NOT NULL,
+            marker_id       TEXT,
+            marker_label    TEXT,
+            checkpoint_id   TEXT    NOT NULL,
+            stack_kind      TEXT    NOT NULL CHECK (stack_kind IN ('undo', 'redo')),
+            stack_pos       INTEGER NOT NULL,
+            created_at_ms   INTEGER NOT NULL,
+            FOREIGN KEY (tx_id)         REFERENCES recovery_session(tx_id) ON DELETE CASCADE,
+            FOREIGN KEY (checkpoint_id) REFERENCES recovery_checkpoint(checkpoint_id)
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_eu_stack_pos
+            ON experience_unit(tx_id, stack_kind, stack_pos);
 
         CREATE UNIQUE INDEX IF NOT EXISTS idx_checkpoint_stack_pos
             ON recovery_checkpoint(tx_id, stack_kind, stack_pos);
@@ -87,17 +104,25 @@ impl RecoveryStore for TransactionRecoveryStore {
 
     /// Capture the current context state and persist a new checkpoint.
     ///
-    /// - Builds a `TransactionSnapshot` from the context.
-    /// - If `disable_undo` is false: inserts a new undo checkpoint row,
-    ///   clears the redo stack, and pushes the checkpoint_id onto the undo stack.
-    /// - If `disable_undo` is true: updates the latest recoverable state
-    ///   without adding to the undo stack.
-    /// - All writes are in a single SQLite transaction (atomic).
+    /// Always writes a crash-recovery snapshot (`latest_checkpoint_id`).
+    ///
+    /// - `disable_undo=true`: marks `undo_checkpointing_enabled=0` for the
+    ///   transaction so no future undo units are created; persists crash-recovery
+    ///   row only (`stack_pos=-1`).
+    /// - `snapshot_after=true` (and checkpointing still enabled): closes the
+    ///   current Experience Unit — inserts a checkpoint + experience_unit row,
+    ///   pushes the unit_id onto the undo stack, clears redo history.
+    /// - Otherwise (intermediate command): updates `latest_checkpoint_id` only.
+    ///
+    /// All writes are in a single SQLite transaction (atomic).
     fn persist(
         &self,
         context: &Arc<TransactionContext>,
         description: &str,
         disable_undo: bool,
+        snapshot_after: bool,
+        marker_id: Option<&str>,
+        marker_label: Option<&str>,
     ) -> Result<(), HolonError> {
         let snapshot = TransactionSnapshot::from_context(context)?;
         let tx_id = snapshot.tx_id.clone();
@@ -109,77 +134,109 @@ impl RecoveryStore for TransactionRecoveryStore {
 
         let mut guard = lock(self)?;
 
-        // Load stacks before opening the write transaction (read-only query).
-        let (mut undo_stack, mut redo_stack) = load_stacks(&guard, &tx_id)?;
+        // Read undo_checkpointing_enabled + stacks before opening the write tx.
+        let checkpointing_enabled = load_checkpointing_enabled(&guard, &tx_id)?;
+        let (mut undo_stack, _redo_stack) = load_stacks(&guard, &tx_id)?;
 
-        // Use conn.transaction() so that any error automatically rolls back,
-        // preventing a dangling open transaction on the next call.
         let tx =
             guard.transaction().map_err(|e| HolonError::Misc(format!("Begin transaction: {e}")))?;
 
-        if !disable_undo {
-            // New undoable command invalidates all redo history.
-            tx.execute(
-                "DELETE FROM recovery_checkpoint WHERE tx_id = ?1 AND stack_kind = 'redo'",
-                params![tx_id],
-            )
-            .map_err(|e| HolonError::Misc(format!("Clear redo checkpoints: {e}")))?;
-            redo_stack.clear();
-            undo_stack.push(checkpoint_id.clone());
-        }
-
-        // Compute the final stack JSON and latest pointer before any INSERTs.
-        let undo_json = serde_json::to_string(&undo_stack)
-            .map_err(|e| HolonError::Misc(format!("Serialize undo stack: {e}")))?;
-        let redo_json = serde_json::to_string(&redo_stack)
-            .map_err(|e| HolonError::Misc(format!("Serialize redo stack: {e}")))?;
-
-        // ── Step 1: upsert session row FIRST so the FK on recovery_checkpoint is satisfied ──
+        // ── Step 1: upsert session row (crash-recovery pointer always updated) ──
+        // undo_checkpointing_enabled starts as a no-update; we patch it below if needed.
         tx.execute(
             "INSERT INTO recovery_session
                  (tx_id, lifecycle_state, latest_checkpoint_id,
-                  undo_stack_json, redo_stack_json, format_version, updated_at_ms)
-             VALUES (?1, 'Open', ?2, ?3, ?4, 1, ?5)
+                  undo_stack_json, redo_stack_json,
+                  undo_checkpointing_enabled, format_version, updated_at_ms)
+             VALUES (?1, 'Open', ?2, '[]', '[]', 1, 1, ?3)
              ON CONFLICT(tx_id) DO UPDATE SET
                  latest_checkpoint_id = excluded.latest_checkpoint_id,
-                 undo_stack_json      = excluded.undo_stack_json,
-                 redo_stack_json      = excluded.redo_stack_json,
                  updated_at_ms        = excluded.updated_at_ms",
-            params![tx_id, checkpoint_id, undo_json, redo_json, now],
+            params![tx_id, checkpoint_id, now],
         )
         .map_err(|e| HolonError::Misc(format!("Upsert session: {e}")))?;
 
-        // ── Step 2: insert the checkpoint row (FK now satisfied) ──
+        // ── Step 2: insert the checkpoint blob (FK now satisfied) ──
+        // INSERT OR REPLACE so the crash-recovery sentinel (stack_pos=-1) is always
+        // replaced by the latest snapshot rather than causing a UNIQUE conflict.
+        tx.execute(
+            "INSERT OR REPLACE INTO recovery_checkpoint
+                (checkpoint_id, tx_id, stack_kind, stack_pos,
+                 snapshot_blob, snapshot_hash, description, disable_undo, created_at_ms)
+             VALUES (?1, ?2, 'undo', -1, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                checkpoint_id,
+                tx_id,
+                snapshot_blob,
+                snapshot.hash,
+                description,
+                disable_undo as i64,
+                now,
+            ],
+        )
+        .map_err(|e| HolonError::Misc(format!("Insert checkpoint: {e}")))?;
+
+        // ── Step 3: apply undo semantics ──
         if disable_undo {
-            // Detached "latest" snapshot — not on the undo stack, used only for
-            // crash recovery of the most recent committed state.
+            // Permanently disable future undo checkpoint creation for this tx.
             tx.execute(
-                "INSERT INTO recovery_checkpoint
-                    (checkpoint_id, tx_id, stack_kind, stack_pos,
-                     snapshot_blob, snapshot_hash, description, disable_undo, created_at_ms)
-                 VALUES (?1, ?2, 'undo', -1, ?3, ?4, ?5, 1, ?6)",
-                params![checkpoint_id, tx_id, snapshot_blob, snapshot.hash, description, now,],
+                "UPDATE recovery_session SET undo_checkpointing_enabled = 0 WHERE tx_id = ?1",
+                params![tx_id],
             )
-            .map_err(|e| HolonError::Misc(format!("Insert no-undo checkpoint: {e}")))?;
-        } else {
-            let stack_pos = (undo_stack.len() as i64) - 1; // already pushed above
+            .map_err(|e| HolonError::Misc(format!("Disable checkpointing: {e}")))?;
+
+            tracing::debug!(
+                "[RECOVERY STORE] disable_undo: checkpointing disabled for tx={tx_id}"
+            );
+        } else if snapshot_after && checkpointing_enabled {
+            // Close the current Experience Unit: create a checkpoint + EU row,
+            // push unit_id onto undo stack, invalidate redo history.
+            let unit_id = Uuid::new_v4().to_string();
+            let stack_pos = undo_stack.len() as i64;
+
+            // Update the checkpoint to reflect its undo stack position.
             tx.execute(
-                "INSERT INTO recovery_checkpoint
-                    (checkpoint_id, tx_id, stack_kind, stack_pos,
-                     snapshot_blob, snapshot_hash, description, disable_undo, created_at_ms)
-                 VALUES (?1, ?2, 'undo', ?3, ?4, ?5, ?6, 0, ?7)",
-                params![
-                    checkpoint_id,
-                    tx_id,
-                    stack_pos,
-                    snapshot_blob,
-                    snapshot.hash,
-                    description,
-                    now,
-                ],
+                "UPDATE recovery_checkpoint SET stack_pos = ?1 WHERE checkpoint_id = ?2",
+                params![stack_pos, checkpoint_id],
             )
-            .map_err(|e| HolonError::Misc(format!("Insert checkpoint: {e}")))?;
+            .map_err(|e| HolonError::Misc(format!("Update checkpoint stack_pos: {e}")))?;
+
+            // Insert the Experience Unit record.
+            tx.execute(
+                "INSERT INTO experience_unit
+                    (unit_id, tx_id, marker_id, marker_label,
+                     checkpoint_id, stack_kind, stack_pos, created_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'undo', ?6, ?7)",
+                params![unit_id, tx_id, marker_id, marker_label, checkpoint_id, stack_pos, now],
+            )
+            .map_err(|e| HolonError::Misc(format!("Insert experience_unit: {e}")))?;
+
+            // Invalidate redo history: delete all redo experience_unit rows.
+            tx.execute(
+                "DELETE FROM experience_unit WHERE tx_id = ?1 AND stack_kind = 'redo'",
+                params![tx_id],
+            )
+            .map_err(|e| HolonError::Misc(format!("Clear redo experience_units: {e}")))?;
+
+            // Push unit_id onto undo stack and clear redo stack.
+            undo_stack.push(unit_id.clone());
+            let undo_json = serde_json::to_string(&undo_stack)
+                .map_err(|e| HolonError::Misc(format!("Serialize undo stack: {e}")))?;
+
+            tx.execute(
+                "UPDATE recovery_session
+                 SET undo_stack_json = ?1, redo_stack_json = '[]'
+                 WHERE tx_id = ?2",
+                params![undo_json, tx_id],
+            )
+            .map_err(|e| HolonError::Misc(format!("Update stacks: {e}")))?;
+
+            tracing::debug!(
+                "[RECOVERY STORE] Closed ExperienceUnit unit_id={unit_id} \
+                 checkpoint={checkpoint_id} for tx={tx_id}"
+            );
         }
+        // Else: intermediate command — crash recovery only (session already updated in step 1).
 
         tx.commit().map_err(|e| HolonError::Misc(format!("Commit transaction: {e}")))?;
 
@@ -188,99 +245,120 @@ impl RecoveryStore for TransactionRecoveryStore {
     }
 
     // -----------------------------------------------------------------------
-    // Undo — pop from undo stack, restore previous checkpoint
+    // Undo — pop top ExperienceUnit, restore the checkpoint before it
     // -----------------------------------------------------------------------
 
-    /// Pop the top of the undo stack and return the snapshot to restore.
-    /// Moves the popped checkpoint to the redo stack.
-    /// Returns `None` if nothing to undo.
+    /// Pop the top ExperienceUnit from the undo stack and return the snapshot
+    /// that preceded it (i.e. the checkpoint of the unit now at the top after
+    /// the pop, or `None` for baseline).
+    /// Moves the popped unit to the redo stack.
+    /// Returns `None` if the undo stack is empty.
     fn undo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {
         let mut guard = lock(self)?;
         let now = now_ms();
         let (mut undo_stack, mut redo_stack) = load_stacks(&guard, tx_id)?;
 
-        let Some(popped_id) = undo_stack.pop() else {
+        let Some(popped_unit_id) = undo_stack.pop() else {
             tracing::debug!("[RECOVERY STORE] Nothing to undo for tx={tx_id}");
             return Ok(None);
         };
 
-        let restore_id = undo_stack.last().cloned();
-        let snapshot = match restore_id.as_ref() {
-            Some(id) => Some(load_snapshot(&guard, id)?),
-            None => None,
+        // Pre-compute restore target and latest checkpoint pointer before opening
+        // the write transaction — guard can't be borrowed immutably once tx is open.
+        let popped_checkpoint_id = load_checkpoint_for_unit(&guard, &popped_unit_id)?;
+        let (snapshot, latest_cp) = match undo_stack.last() {
+            Some(prior_unit_id) => {
+                let cp_id = load_checkpoint_for_unit(&guard, prior_unit_id)?;
+                let snap = load_snapshot(&guard, &cp_id)?;
+                (Some(snap), Some(cp_id))
+            }
+            None => (None, None),
         };
 
-        // Move checkpoint to redo stack
         let redo_pos = redo_stack.len() as i64;
-        redo_stack.push(popped_id.clone());
+        redo_stack.push(popped_unit_id.clone());
 
         let tx =
             guard.transaction().map_err(|e| HolonError::Misc(format!("Begin transaction: {e}")))?;
 
+        // Move the experience_unit to the redo stack.
+        tx.execute(
+            "UPDATE experience_unit
+             SET stack_kind = 'redo', stack_pos = ?1
+             WHERE unit_id = ?2",
+            params![redo_pos, popped_unit_id],
+        )
+        .map_err(|e| HolonError::Misc(format!("Undo: move EU to redo: {e}")))?;
+
+        // Keep recovery_checkpoint in sync so its (tx_id, stack_kind, stack_pos)
+        // index stays consistent with the experience_unit position.
         tx.execute(
             "UPDATE recovery_checkpoint
              SET stack_kind = 'redo', stack_pos = ?1
              WHERE checkpoint_id = ?2",
-            params![redo_pos, popped_id],
+            params![redo_pos, popped_checkpoint_id],
         )
-        .map_err(|e| HolonError::Misc(format!("Undo: move to redo: {e}")))?;
+        .map_err(|e| HolonError::Misc(format!("Undo: sync checkpoint to redo: {e}")))?;
 
-        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, now)?;
+        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, latest_cp.as_deref(), now)?;
 
         tx.commit().map_err(|e| HolonError::Misc(format!("Undo commit: {e}")))?;
 
-        if let Some(restored_id) = restore_id {
-            tracing::info!(
-                "[RECOVERY STORE] Undo: restored checkpoint '{restored_id}' for tx={tx_id}"
-            );
-        } else {
-            tracing::info!(
-                "[RECOVERY STORE] Undo: restored baseline (no prior checkpoint) for tx={tx_id}"
-            );
-        }
+        tracing::info!(
+            "[RECOVERY STORE] Undo: popped unit={popped_unit_id} for tx={tx_id}"
+        );
         Ok(snapshot)
     }
 
     // -----------------------------------------------------------------------
-    // Redo — pop from redo stack, restore checkpoint
+    // Redo — pop top ExperienceUnit from redo, restore its checkpoint
     // -----------------------------------------------------------------------
 
-    /// Pop the top of the redo stack and return the snapshot to restore.
-    /// Moves the checkpoint back to the undo stack.
-    /// Returns `None` if nothing to redo.
+    /// Pop the top ExperienceUnit from the redo stack and return its snapshot.
+    /// Moves the unit back to the undo stack.
+    /// Returns `None` if the redo stack is empty.
     fn redo(&self, tx_id: &str) -> Result<Option<TransactionSnapshot>, HolonError> {
         let mut guard = lock(self)?;
         let now = now_ms();
         let (mut undo_stack, mut redo_stack) = load_stacks(&guard, tx_id)?;
 
-        let Some(checkpoint_id) = redo_stack.pop() else {
+        let Some(unit_id) = redo_stack.pop() else {
             tracing::debug!("[RECOVERY STORE] Nothing to redo for tx={tx_id}");
             return Ok(None);
         };
 
+        let checkpoint_id = load_checkpoint_for_unit(&guard, &unit_id)?;
         let snapshot = load_snapshot(&guard, &checkpoint_id)?;
 
         let undo_pos = undo_stack.len() as i64;
-        undo_stack.push(checkpoint_id.clone());
+        undo_stack.push(unit_id.clone());
 
         let tx =
             guard.transaction().map_err(|e| HolonError::Misc(format!("Begin transaction: {e}")))?;
 
+        // Move the experience_unit back to the undo stack.
+        tx.execute(
+            "UPDATE experience_unit
+             SET stack_kind = 'undo', stack_pos = ?1
+             WHERE unit_id = ?2",
+            params![undo_pos, unit_id],
+        )
+        .map_err(|e| HolonError::Misc(format!("Redo: move EU to undo: {e}")))?;
+
+        // Keep recovery_checkpoint in sync with the experience_unit position.
         tx.execute(
             "UPDATE recovery_checkpoint
              SET stack_kind = 'undo', stack_pos = ?1
              WHERE checkpoint_id = ?2",
             params![undo_pos, checkpoint_id],
         )
-        .map_err(|e| HolonError::Misc(format!("Redo: move to undo: {e}")))?;
+        .map_err(|e| HolonError::Misc(format!("Redo: sync checkpoint to undo: {e}")))?;
 
-        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, now)?;
+        save_stacks(&tx, tx_id, &undo_stack, &redo_stack, Some(&checkpoint_id), now)?;
 
         tx.commit().map_err(|e| HolonError::Misc(format!("Redo commit: {e}")))?;
 
-        tracing::info!(
-            "[RECOVERY STORE] Redo: restored checkpoint '{checkpoint_id}' for tx={tx_id}"
-        );
+        tracing::info!("[RECOVERY STORE] Redo: restored unit={unit_id} for tx={tx_id}");
         Ok(Some(snapshot))
     }
 
@@ -435,24 +513,46 @@ fn save_stacks(
     tx_id: &str,
     undo_stack: &[String],
     redo_stack: &[String],
+    latest_checkpoint_id: Option<&str>,
     now: i64,
 ) -> Result<(), HolonError> {
     let undo_json = serde_json::to_string(undo_stack)
         .map_err(|e| HolonError::Misc(format!("Serialize undo stack: {e}")))?;
     let redo_json = serde_json::to_string(redo_stack)
         .map_err(|e| HolonError::Misc(format!("Serialize redo stack: {e}")))?;
-    let latest = undo_stack.last().cloned();
 
     conn.execute(
         "UPDATE recovery_session
              SET undo_stack_json = ?1, redo_stack_json = ?2,
                  latest_checkpoint_id = ?3, updated_at_ms = ?4
              WHERE tx_id = ?5",
-        params![undo_json, redo_json, latest, now, tx_id],
+        params![undo_json, redo_json, latest_checkpoint_id, now, tx_id],
     )
     .map_err(|e| HolonError::Misc(format!("Save stacks for tx={tx_id}: {e}")))?;
 
     Ok(())
+}
+
+fn load_checkpointing_enabled(conn: &Connection, tx_id: &str) -> Result<bool, HolonError> {
+    let result: rusqlite::Result<i64> = conn.query_row(
+        "SELECT undo_checkpointing_enabled FROM recovery_session WHERE tx_id = ?1",
+        params![tx_id],
+        |r| r.get(0),
+    );
+    match result {
+        Ok(v) => Ok(v != 0),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(true), // default for new sessions
+        Err(e) => Err(HolonError::Misc(format!("Load checkpointing_enabled for tx={tx_id}: {e}"))),
+    }
+}
+
+fn load_checkpoint_for_unit(conn: &Connection, unit_id: &str) -> Result<String, HolonError> {
+    conn.query_row(
+        "SELECT checkpoint_id FROM experience_unit WHERE unit_id = ?1",
+        params![unit_id],
+        |r| r.get(0),
+    )
+    .map_err(|e| HolonError::Misc(format!("Load checkpoint for unit '{unit_id}': {e}")))
 }
 
 fn load_snapshot(

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -486,8 +486,9 @@ impl RecoveryStore for TransactionRecoveryStore {
             .map_err(|e| HolonError::Misc(format!("redo_to_marker begin tx: {e}")))?;
 
         for (i, (uid, cp_id, _)) in to_redo.iter().enumerate() {
-            // Newest unit gets the highest undo position; marker gets initial_undo_len.
-            let undo_pos = initial_undo_len + (to_redo.len() - 1 - i) as i64;
+            // to_redo[0] = newest-on-redo (redone first), to_redo[last] = marker (redone last).
+            // Marker gets the highest stack_pos = top of undo stack, matching undo_stack_json.
+            let undo_pos = initial_undo_len + i as i64;
             tx.execute(
                 "UPDATE experience_unit SET stack_kind = 'undo', stack_pos = ?1 WHERE unit_id = ?2",
                 params![undo_pos, uid],

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -6,9 +6,11 @@ import {
   expectNodeCollection,
   expectNone,
   expectRedoComplete,
+  expectRedoToMarkerComplete,
   expectReference,
   expectReferences,
   expectUndoComplete,
+  expectUndoToMarkerComplete,
   expectValue,
 } from '../result-decoders';
 import { invokeMapCommand, unwrapMapResponse } from '../transport';
@@ -76,6 +78,10 @@ export function commit(
   return runTransactionCommand(txId, 'Commit', expectReference, options);
 }
 
+/**
+ * Experiential unit functions for undo/redo operations.
+ */
+
 export function undoLast(
   txId: TxId,
 ): Promise<void> {
@@ -86,6 +92,20 @@ export function redoLast(
   txId: TxId,
 ): Promise<void> {
   return runTransactionCommand(txId, 'RedoLast', expectRedoComplete);
+}
+
+export function undoToMarker(
+  txId: TxId,
+  markerId: string,
+): Promise<void> {
+  return runTransactionCommand(txId, { UndoToMarker: { marker_id: markerId } }, expectUndoToMarkerComplete);
+}
+
+export function redoToMarker(
+  txId: TxId,
+  markerId: string,
+): Promise<void> {
+  return runTransactionCommand(txId, { RedoToMarker: { marker_id: markerId } }, expectRedoToMarkerComplete);
 }
 
 /**

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -5,8 +5,10 @@ import {
   expectDanceResponse,
   expectNodeCollection,
   expectNone,
+  expectRedoComplete,
   expectReference,
   expectReferences,
+  expectUndoComplete,
   expectValue,
 } from '../result-decoders';
 import { invokeMapCommand, unwrapMapResponse } from '../transport';
@@ -72,6 +74,18 @@ export function commit(
   options?: RequestOptionsOverrides,
 ): Promise<HolonReferenceWire> {
   return runTransactionCommand(txId, 'Commit', expectReference, options);
+}
+
+export function undoLast(
+  txId: TxId,
+): Promise<void> {
+  return runTransactionCommand(txId, 'UndoLast', expectUndoComplete);
+}
+
+export function redoLast(
+  txId: TxId,
+): Promise<void> {
+  return runTransactionCommand(txId, 'RedoLast', expectRedoComplete);
 }
 
 /**

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -73,9 +73,8 @@ async function runTransactionCommand<T>(
  */
 export function commit(
   txId: TxId,
-  options?: RequestOptionsOverrides,
 ): Promise<HolonReferenceWire> {
-  return runTransactionCommand(txId, 'Commit', expectReference, options);
+  return runTransactionCommand(txId, 'Commit', expectReference);
 }
 
 /**

--- a/host/map-sdk/src/internal/request-context.ts
+++ b/host/map-sdk/src/internal/request-context.ts
@@ -26,9 +26,10 @@ export function nextRequestId(): number {
  */
 export function defaultRequestOptions(): RequestOptions {
   return {
-    gesture_id: null,
-    gesture_label: null,
+    marker_id: null,
+    marker_label: null,
     snapshot_after: false,
+    disable_undo: false,
   };
 }
 

--- a/host/map-sdk/src/internal/result-decoders.ts
+++ b/host/map-sdk/src/internal/result-decoders.ts
@@ -49,6 +49,24 @@ export function expectNone(result: MapResultWire): void {
 }
 
 /**
+ * Decode a `MapResultWire::UndoComplete` payload.
+ */
+export function expectUndoComplete(result: MapResultWire): void {
+  if (result !== 'UndoComplete') {
+    throw unexpectedResultVariant('UndoComplete', result);
+  }
+}
+
+/**
+ * Decode a `MapResultWire::RedoComplete` payload.
+ */
+export function expectRedoComplete(result: MapResultWire): void {
+  if (result !== 'RedoComplete') {
+    throw unexpectedResultVariant('RedoComplete', result);
+  }
+}
+
+/**
  * Decode a `MapResultWire::TransactionCreated` payload.
  */
 export function expectTransactionCreated(result: MapResultWire): TxId {

--- a/host/map-sdk/src/internal/result-decoders.ts
+++ b/host/map-sdk/src/internal/result-decoders.ts
@@ -67,6 +67,24 @@ export function expectRedoComplete(result: MapResultWire): void {
 }
 
 /**
+ * Decode a `MapResultWire::UndoToMarkerComplete` payload.
+ */
+export function expectUndoToMarkerComplete(result: MapResultWire): void {
+  if (result !== 'UndoToMarkerComplete') {
+    throw unexpectedResultVariant('UndoToMarkerComplete', result);
+  }
+}
+
+/**
+ * Decode a `MapResultWire::RedoToMarkerComplete` payload.
+ */
+export function expectRedoToMarkerComplete(result: MapResultWire): void {
+  if (result !== 'RedoToMarkerComplete') {
+    throw unexpectedResultVariant('RedoToMarkerComplete', result);
+  }
+}
+
+/**
  * Decode a `MapResultWire::TransactionCreated` payload.
  */
 export function expectTransactionCreated(result: MapResultWire): TxId {

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -63,6 +63,8 @@ export type TransactionActionWire =
   | 'Commit'
   | 'UndoLast'
   | 'RedoLast'
+  | { UndoToMarker: { marker_id: string } }
+  | { RedoToMarker: { marker_id: string } }
   | { LoadHolons: { content_set: ContentSet } }
   | { Dance: DanceRequestWire }
   | { Query: QueryExpression }
@@ -271,7 +273,11 @@ export function isTransactionActionWire(
       isHolonId(value.StageNewVersionFromId['holon_id'])) ||
     (hasSingleKey(value, 'DeleteHolon') &&
       isRecord(value.DeleteHolon) &&
-      isLocalId(value.DeleteHolon['local_id']))
+      isLocalId(value.DeleteHolon['local_id'])) ||
+    (hasSingleKey(value, 'UndoToMarker') &&
+      isStringFieldObject(value.UndoToMarker, 'marker_id')) ||
+    (hasSingleKey(value, 'RedoToMarker') &&
+      isStringFieldObject(value.RedoToMarker, 'marker_id'))
   );
 }
 

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -61,6 +61,8 @@ export interface ContentSet {
  */
 export type TransactionActionWire =
   | 'Commit'
+  | 'UndoLast'
+  | 'RedoLast'
   | { LoadHolons: { content_set: ContentSet } }
   | { Dance: DanceRequestWire }
   | { Query: QueryExpression }
@@ -78,6 +80,7 @@ export type TransactionActionWire =
   | { StageNewVersion: { current_version: SmartReferenceWire } }
   | { StageNewVersionFromId: { holon_id: HolonId } }
   | { DeleteHolon: { local_id: LocalId } };
+
 
 /**
  * Holon-scoped command envelope.
@@ -141,6 +144,8 @@ const READABLE_HOLON_UNIT_ACTIONS = new Set<ReadableHolonActionWire>([
 
 const TRANSACTION_UNIT_ACTIONS = new Set([
   'Commit',
+  'UndoLast',
+  'RedoLast',
   'GetAllHolons',
   'StagedCount',
   'TransientCount',

--- a/host/map-sdk/src/internal/wire-types/envelope.ts
+++ b/host/map-sdk/src/internal/wire-types/envelope.ts
@@ -18,9 +18,10 @@ export type RequestId = number;
  * Per-request dispatch options echoed by the Rust IPC envelope.
  */
 export interface RequestOptions {
-  gesture_id: string | null;
-  gesture_label: string | null;
+  marker_id: string | null;   // replaces gesture_id
+  marker_label: string | null;       // replaces gesture_label
   snapshot_after: boolean;
+  disable_undo: boolean;
 }
 
 /**
@@ -52,8 +53,8 @@ export interface MapIpcResponse {
 export function isRequestOptions(value: unknown): value is RequestOptions {
   return (
     isRecord(value) &&
-    (value['gesture_id'] === null || typeof value['gesture_id'] === 'string') &&
-    (value['gesture_label'] === null || typeof value['gesture_label'] === 'string') &&
+    (value['marker_id'] === null || typeof value['marker_id'] === 'string') &&
+    (value['marker_label'] === null || typeof value['marker_label'] === 'string') &&
     typeof value['snapshot_after'] === 'boolean'
   );
 }

--- a/host/map-sdk/src/internal/wire-types/envelope.ts
+++ b/host/map-sdk/src/internal/wire-types/envelope.ts
@@ -18,8 +18,8 @@ export type RequestId = number;
  * Per-request dispatch options echoed by the Rust IPC envelope.
  */
 export interface RequestOptions {
-  marker_id: string | null;   // replaces gesture_id
-  marker_label: string | null;       // replaces gesture_label
+  marker_id: string | null;
+  marker_label: string | null;
   snapshot_after: boolean;
   disable_undo: boolean;
 }

--- a/host/map-sdk/src/internal/wire-types/results.ts
+++ b/host/map-sdk/src/internal/wire-types/results.ts
@@ -42,6 +42,8 @@ export interface EssentialHolonContent {
  */
 export type MapResultWire =
   | 'None'
+  | 'UndoComplete'    
+  | 'RedoComplete'
   | { TransactionCreated: { tx_id: number } }
   | { Reference: HolonReferenceWire }
   | { References: HolonReferenceWire[] }
@@ -71,6 +73,8 @@ export function isEssentialHolonContent(
 export function isMapResultWire(value: unknown): value is MapResultWire {
   return (
     value === 'None' ||
+    value === 'UndoComplete' ||
+    value === 'RedoComplete' ||
     (hasSingleKey(value, 'TransactionCreated') &&
       isRecord(value.TransactionCreated) &&
       isNumber(value.TransactionCreated['tx_id'])) ||

--- a/host/map-sdk/src/internal/wire-types/results.ts
+++ b/host/map-sdk/src/internal/wire-types/results.ts
@@ -44,6 +44,8 @@ export type MapResultWire =
   | 'None'
   | 'UndoComplete'    
   | 'RedoComplete'
+  | 'UndoToMarkerComplete'
+  | 'RedoToMarkerComplete'
   | { TransactionCreated: { tx_id: number } }
   | { Reference: HolonReferenceWire }
   | { References: HolonReferenceWire[] }
@@ -75,6 +77,8 @@ export function isMapResultWire(value: unknown): value is MapResultWire {
     value === 'None' ||
     value === 'UndoComplete' ||
     value === 'RedoComplete' ||
+    value === 'UndoToMarkerComplete' ||
+    value === 'RedoToMarkerComplete' ||
     (hasSingleKey(value, 'TransactionCreated') &&
       isRecord(value.TransactionCreated) &&
       isNumber(value.TransactionCreated['tx_id'])) ||

--- a/host/map-sdk/tests/commands/disable-undo.test.ts
+++ b/host/map-sdk/tests/commands/disable-undo.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  newHolon,
+  stageNewHolon,
+  undoLast,
+} from '../../src/internal/commands/transaction';
+import { resetRequestIdCounter } from '../../src/internal/request-context';
+import type {
+  RequestOptions,
+  TransientReferenceWire,
+  HolonReferenceWire,
+  MapResultWire,
+} from '../../src/internal/wire-types';
+
+// ===========================================
+// Mock transport
+// ===========================================
+
+const { invokeMapCommandMock } = vi.hoisted(() => ({
+  invokeMapCommandMock: vi.fn(),
+}));
+
+vi.mock('../../src/internal/transport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/internal/transport')>();
+  return { ...actual, invokeMapCommand: invokeMapCommandMock };
+});
+
+// ===========================================
+// Shared fixtures
+// ===========================================
+
+const txId = 41;
+
+const defaultOptions: RequestOptions = {
+  marker_id: null,
+  marker_label: null,
+  snapshot_after: false,
+  disable_undo: false,
+};
+
+const transientWire: TransientReferenceWire = {
+  tx_id: txId,
+  id: '2f9dcd83-47ee-482e-8059-28dca43d8a64',
+};
+
+const stagedReference: HolonReferenceWire = {
+  Staged: {
+    tx_id: txId,
+    id: 'fcb56a31-c1cb-4066-b4c3-d185809c2864',
+  },
+};
+
+function okResponse(result: MapResultWire) {
+  return { request_id: 1, result: { Ok: result } };
+}
+
+// ===========================================
+// disable_undo wire-level tests
+// ===========================================
+
+describe('disable_undo option', () => {
+  beforeEach(() => {
+    invokeMapCommandMock.mockReset();
+    resetRequestIdCounter();
+  });
+
+  // ── Default value ───────────────────────────────────────────────────
+
+  describe('default RequestOptions', () => {
+    it('sends disable_undo: false by default', async () => {
+      invokeMapCommandMock.mockResolvedValue(
+        okResponse({ Reference: { Transient: transientWire } }),
+      );
+
+      await newHolon(txId, 'key');
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.disable_undo).toBe(false);
+    });
+
+    it('sends the full default options shape on any command', async () => {
+      invokeMapCommandMock.mockResolvedValue(
+        okResponse({ Reference: { Transient: transientWire } }),
+      );
+
+      await newHolon(txId);
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options).toEqual(defaultOptions);
+    });
+  });
+
+  // ── disable_undo: true passes through ──────────────────────────────
+
+  describe('disable_undo: true in RequestOptions', () => {
+    it('sends disable_undo: true when requested on stageNewHolon', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, { disable_undo: true });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.disable_undo).toBe(true);
+    });
+
+    it('sends disable_undo: true independently of snapshot_after=false', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, {
+        disable_undo: true,
+        snapshot_after: false,
+      });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.disable_undo).toBe(true);
+      expect(request.options.snapshot_after).toBe(false);
+    });
+
+    it('sends disable_undo: true alongside snapshot_after: true', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, {
+        disable_undo: true,
+        snapshot_after: true,
+      });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.disable_undo).toBe(true);
+      expect(request.options.snapshot_after).toBe(true);
+    });
+
+    it('does not affect other options fields when disable_undo is set', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, {
+        disable_undo: true,
+        marker_id: 'step-1',
+        marker_label: 'my step',
+        snapshot_after: true,
+      });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options).toEqual({
+        disable_undo: true,
+        marker_id: 'step-1',
+        marker_label: 'my step',
+        snapshot_after: true,
+      });
+    });
+  });
+
+  // ── undo/redo must never carry disable_undo ─────────────────────────
+  // UndoLast / RedoLast have no options parameter — they always use defaults.
+
+  describe('undo/redo commands use default options', () => {
+    it('undoLast sends disable_undo: false', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('UndoComplete'));
+
+      await undoLast(txId);
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.disable_undo).toBe(false);
+      expect(request.options.snapshot_after).toBe(false);
+    });
+  });
+});

--- a/host/map-sdk/tests/commands/holon.test.ts
+++ b/host/map-sdk/tests/commands/holon.test.ts
@@ -51,9 +51,10 @@ function okResponse(result: MapResultWire) {
 
 const txId = 41;
 const defaultOptions: RequestOptions = {
-  gesture_id: null,
-  gesture_label: null,
+  marker_id: null,
+  marker_label: null,
   snapshot_after: false,
+  disable_undo: false
 };
 
 const target: HolonReferenceWire = {
@@ -317,9 +318,10 @@ describe('holon command builders', () => {
     invokeMapCommandMock.mockResolvedValue(okResponse('None'));
 
     await withDescriptor(txId, target, descriptor, {
-      gesture_id: 'gesture-123',
-      gesture_label: 'descriptor-link',
+      marker_id: 'gesture-123',
+      marker_label: 'descriptor-link',
       snapshot_after: true,
+      disable_undo: false,
     });
 
     expectHolonRequest(
@@ -331,9 +333,10 @@ describe('holon command builders', () => {
         },
       },
       {
-        gesture_id: 'gesture-123',
-        gesture_label: 'descriptor-link',
+        marker_id: 'gesture-123',
+        marker_label: 'descriptor-link',
         snapshot_after: true,
+        disable_undo: false,
       },
     );
   });

--- a/host/map-sdk/tests/commands/marker.test.ts
+++ b/host/map-sdk/tests/commands/marker.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  newHolon,
+  redoLast,
+  redoToMarker,
+  stageNewHolon,
+  undoLast,
+  undoToMarker,
+} from '../../src/internal/commands/transaction';
+import { MalformedResponseError } from '../../src/internal/errors';
+import { resetRequestIdCounter } from '../../src/internal/request-context';
+import type {
+  HolonReferenceWire,
+  MapResultWire,
+  RequestOptions,
+  TransientReferenceWire,
+} from '../../src/internal/wire-types';
+
+// ===========================================
+// Mock transport
+// ===========================================
+
+const { invokeMapCommandMock } = vi.hoisted(() => ({
+  invokeMapCommandMock: vi.fn(),
+}));
+
+vi.mock('../../src/internal/transport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/internal/transport')>();
+  return { ...actual, invokeMapCommand: invokeMapCommandMock };
+});
+
+// ===========================================
+// Shared fixtures
+// ===========================================
+
+const txId = 41;
+
+const defaultOptions: RequestOptions = {
+  marker_id: null,
+  marker_label: null,
+  snapshot_after: false,
+  disable_undo: false,
+};
+
+const transientWire: TransientReferenceWire = {
+  tx_id: txId,
+  id: '2f9dcd83-47ee-482e-8059-28dca43d8a64',
+};
+
+const stagedReference: HolonReferenceWire = {
+  Staged: {
+    tx_id: txId,
+    id: 'fcb56a31-c1cb-4066-b4c3-d185809c2864',
+  },
+};
+
+function okResponse(result: MapResultWire) {
+  return { request_id: 1, result: { Ok: result } };
+}
+
+// ===========================================
+// Marker Navigation — Wire Shape Tests
+// ===========================================
+
+describe('marker navigation commands', () => {
+  beforeEach(() => {
+    invokeMapCommandMock.mockReset();
+    resetRequestIdCounter();
+  });
+
+  // ── undoToMarker ────────────────────────────────────────────────────
+
+  describe('undoToMarker', () => {
+    it('sends { UndoToMarker: { marker_id } } with default options and resolves void', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('UndoToMarkerComplete'));
+
+      await expect(undoToMarker(txId, 'step-1')).resolves.toBeUndefined();
+
+      expect(invokeMapCommandMock).toHaveBeenCalledWith({
+        request_id: 1,
+        command: {
+          Transaction: {
+            tx_id: txId,
+            action: { UndoToMarker: { marker_id: 'step-1' } },
+          },
+        },
+        options: defaultOptions,
+      });
+    });
+
+    it('sends the exact marker_id string unchanged', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('UndoToMarkerComplete'));
+
+      await undoToMarker(txId, 'release-2025-04-28');
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ command: { Transaction: { action: { UndoToMarker: { marker_id: string } } } } }];
+      expect(request.command.Transaction.action).toEqual({
+        UndoToMarker: { marker_id: 'release-2025-04-28' },
+      });
+    });
+
+    it('throws MalformedResponseError when the result is not UndoToMarkerComplete', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('None'));
+
+      await expect(undoToMarker(txId, 'step-1')).rejects.toBeInstanceOf(
+        MalformedResponseError,
+      );
+    });
+
+    it('does not accept snapshot_after (no options parameter)', () => {
+      // undoToMarker deliberately has no options parameter — undo/redo
+      // must never create a new ExperienceUnit themselves.
+      expect(undoToMarker.length).toBe(2); // txId + markerId only
+    });
+  });
+
+  // ── redoToMarker ────────────────────────────────────────────────────
+
+  describe('redoToMarker', () => {
+    it('sends { RedoToMarker: { marker_id } } with default options and resolves void', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('RedoToMarkerComplete'));
+
+      await expect(redoToMarker(txId, 'step-1')).resolves.toBeUndefined();
+
+      expect(invokeMapCommandMock).toHaveBeenCalledWith({
+        request_id: 1,
+        command: {
+          Transaction: {
+            tx_id: txId,
+            action: { RedoToMarker: { marker_id: 'step-1' } },
+          },
+        },
+        options: defaultOptions,
+      });
+    });
+
+    it('sends the exact marker_id string unchanged', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('RedoToMarkerComplete'));
+
+      await redoToMarker(txId, 'release-2025-04-28');
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ command: { Transaction: { action: { RedoToMarker: { marker_id: string } } } } }];
+      expect(request.command.Transaction.action).toEqual({
+        RedoToMarker: { marker_id: 'release-2025-04-28' },
+      });
+    });
+
+    it('throws MalformedResponseError when the result is not RedoToMarkerComplete', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse('UndoToMarkerComplete'));
+
+      await expect(redoToMarker(txId, 'step-1')).rejects.toBeInstanceOf(
+        MalformedResponseError,
+      );
+    });
+
+    it('does not accept snapshot_after (no options parameter)', () => {
+      expect(redoToMarker.length).toBe(2); // txId + markerId only
+    });
+  });
+
+  // ── Marker binding at close ─────────────────────────────────────────
+
+  describe('closing an ExperienceUnit with a marker', () => {
+    it('sends snapshot_after=true and marker_id when stageNewHolon closes a unit', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, {
+        snapshot_after: true,
+        marker_id: 'step-1',
+        marker_label: 'add first holon',
+      });
+
+      expect(invokeMapCommandMock).toHaveBeenCalledWith({
+        request_id: 1,
+        command: {
+          Transaction: {
+            tx_id: txId,
+            action: { StageNewHolon: { source: transientWire } },
+          },
+        },
+        options: {
+          marker_id: 'step-1',
+          marker_label: 'add first holon',
+          snapshot_after: true,
+          disable_undo: false,
+        },
+      });
+    });
+
+    it('sends marker_id without marker_label when label is omitted', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, {
+        snapshot_after: true,
+        marker_id: 'checkpoint-A',
+      });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.marker_id).toBe('checkpoint-A');
+      expect(request.options.marker_label).toBeNull();
+      expect(request.options.snapshot_after).toBe(true);
+    });
+
+    it('sends null marker_id when closing a unit without a named marker', async () => {
+      invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: stagedReference }));
+
+      await stageNewHolon(txId, transientWire, { snapshot_after: true });
+
+      const [request] = invokeMapCommandMock.mock.calls[0] as [{ options: RequestOptions }];
+      expect(request.options.marker_id).toBeNull();
+      expect(request.options.snapshot_after).toBe(true);
+    });
+  });
+
+  // ── Full undo/redo marker flow ──────────────────────────────────────
+  //
+  // This scenario traces the complete lifecycle:
+  //   newHolon                               (transient created)
+  //   stageNewHolon (snapshot_after, marker) (EU_1 closed with "step-1")
+  //   newHolon + stageNewHolon (snapshot)    (EU_2 closed, no marker)
+  //   undoToMarker("step-1")                 (jumps back over EU_2 and EU_1)
+  //   redoToMarker("step-1")                 (jumps forward to EU_1 state)
+
+  describe('full marker undo/redo flow (wire-level)', () => {
+    it('traces the expected wire sequence for a two-step transaction with a named marker', async () => {
+      // ── Step 1: create EU_1 with marker "step-1" ────────────────────
+      invokeMapCommandMock
+        .mockResolvedValueOnce(okResponse({ Reference: { Transient: transientWire } }))
+        .mockResolvedValueOnce(okResponse({ Reference: stagedReference }));
+
+      await newHolon(txId, 'holon-a');
+      await stageNewHolon(txId, transientWire, {
+        snapshot_after: true,
+        marker_id: 'step-1',
+        marker_label: 'first named checkpoint',
+      });
+
+      // Verify the close request carried the marker
+      const closeCall = invokeMapCommandMock.mock.calls[1][0] as { options: RequestOptions };
+      expect(closeCall.options).toEqual({
+        marker_id: 'step-1',
+        marker_label: 'first named checkpoint',
+        snapshot_after: true,
+        disable_undo: false,
+      });
+
+      invokeMapCommandMock.mockReset();
+      resetRequestIdCounter();
+
+      // ── Step 2: create EU_2 without a marker ────────────────────────
+      invokeMapCommandMock
+        .mockResolvedValueOnce(okResponse({ Reference: { Transient: transientWire } }))
+        .mockResolvedValueOnce(okResponse({ Reference: stagedReference }));
+
+      await newHolon(txId, 'holon-b');
+      await stageNewHolon(txId, transientWire, { snapshot_after: true });
+
+      invokeMapCommandMock.mockReset();
+      resetRequestIdCounter();
+
+      // ── Step 3: jump back to just before "step-1" ───────────────────
+      invokeMapCommandMock.mockResolvedValueOnce(okResponse('UndoToMarkerComplete'));
+
+      await expect(undoToMarker(txId, 'step-1')).resolves.toBeUndefined();
+
+      expect(invokeMapCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: {
+            Transaction: {
+              tx_id: txId,
+              action: { UndoToMarker: { marker_id: 'step-1' } },
+            },
+          },
+        }),
+      );
+
+      invokeMapCommandMock.mockReset();
+      resetRequestIdCounter();
+
+      // ── Step 4: redo forward to the "step-1" state ──────────────────
+      invokeMapCommandMock.mockResolvedValueOnce(okResponse('RedoToMarkerComplete'));
+
+      await expect(redoToMarker(txId, 'step-1')).resolves.toBeUndefined();
+
+      expect(invokeMapCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: {
+            Transaction: {
+              tx_id: txId,
+              action: { RedoToMarker: { marker_id: 'step-1' } },
+            },
+          },
+        }),
+      );
+    });
+
+    it('undoLast and redoLast still send no marker_id (plain string actions)', async () => {
+      invokeMapCommandMock
+        .mockResolvedValueOnce(okResponse('UndoComplete'))
+        .mockResolvedValueOnce(okResponse('RedoComplete'));
+
+      await undoLast(txId);
+      await redoLast(txId);
+
+      const undoAction = (invokeMapCommandMock.mock.calls[0][0] as { command: { Transaction: { action: unknown } } }).command.Transaction.action;
+      const redoAction = (invokeMapCommandMock.mock.calls[1][0] as { command: { Transaction: { action: unknown } } }).command.Transaction.action;
+
+      expect(undoAction).toBe('UndoLast');
+      expect(redoAction).toBe('RedoLast');
+    });
+  });
+});

--- a/host/map-sdk/tests/commands/space.test.ts
+++ b/host/map-sdk/tests/commands/space.test.ts
@@ -45,9 +45,10 @@ describe('space command builders', () => {
         Space: 'BeginTransaction',
       },
       options: {
-        gesture_id: null,
-        gesture_label: null,
+        marker_id: null,
+        marker_label: null,
         snapshot_after: false,
+        disable_undo: false,
       },
     });
   });
@@ -65,9 +66,10 @@ describe('space command builders', () => {
     });
 
     await beginTransaction({
-      gesture_id: 'gesture-123',
-      gesture_label: 'space-start',
+      marker_id: 'gesture-123',
+      marker_label: 'space-start',
       snapshot_after: true,
+      disable_undo: false,
     });
 
     expect(invokeMapCommandMock).toHaveBeenCalledWith({
@@ -76,9 +78,10 @@ describe('space command builders', () => {
         Space: 'BeginTransaction',
       },
       options: {
-        gesture_id: 'gesture-123',
-        gesture_label: 'space-start',
+        marker_id: 'gesture-123',
+        marker_label: 'space-start',
         snapshot_after: true,
+        disable_undo: false,
       },
     });
   });

--- a/host/map-sdk/tests/commands/transaction.test.ts
+++ b/host/map-sdk/tests/commands/transaction.test.ts
@@ -13,12 +13,14 @@ import {
   loadHolons,
   newHolon,
   query,
+  redoLast,
   stageNewFromClone,
   stageNewHolon,
   stageNewVersion,
   stageNewVersionFromId,
   stagedCount,
   transientCount,
+  undoLast,
 } from '../../src/internal/commands/transaction';
 import { MalformedResponseError } from '../../src/internal/errors';
 import { resetRequestIdCounter } from '../../src/internal/request-context';
@@ -62,9 +64,10 @@ function okResponse(result: MapResultWire) {
 
 const txId = 41;
 const defaultOptions: RequestOptions = {
-  gesture_id: null,
-  gesture_label: null,
+  marker_id: null,
+  marker_label: null,
   snapshot_after: false,
+  disable_undo: false
 };
 
 const transientWire: TransientReferenceWire = {
@@ -322,6 +325,22 @@ const transactionCases: TransactionCase<unknown>[] = [
     expected: nodeCollection,
     wrongResult: { Collection: holonCollection },
   },
+  {
+    name: 'undoLast',
+    run: () => undoLast(txId),
+    action: 'UndoLast',
+    okResult: 'UndoComplete',
+    expected: undefined,
+    wrongResult: 'None',
+  },
+  {
+    name: 'redoLast',
+    run: () => redoLast(txId),
+    action: 'RedoLast',
+    okResult: 'RedoComplete',
+    expected: undefined,
+    wrongResult: 'None',
+  },
 ];
 
 // ===========================================
@@ -369,15 +388,29 @@ describe('transaction command builders', () => {
     invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: transientReference }));
 
     await commit(txId, {
-      gesture_id: 'gesture-123',
-      gesture_label: 'commit',
+      marker_id: 'gesture-123',
+      marker_label: 'commit',
       snapshot_after: true,
+      disable_undo: false,
     });
 
     expectTransactionRequest('Commit', {
-      gesture_id: 'gesture-123',
-      gesture_label: 'commit',
+      marker_id: 'gesture-123',
+      marker_label: 'commit',
       snapshot_after: true,
+      disable_undo: false,
     });
+  });
+
+  it('undoLast sends default options with snapshot_after false', async () => {
+    invokeMapCommandMock.mockResolvedValue(okResponse('UndoComplete'));
+    await undoLast(txId);
+    expectTransactionRequest('UndoLast', defaultOptions);
+  });
+    
+  it('redoLast sends default options with snapshot_after false', async () => {
+    invokeMapCommandMock.mockResolvedValue(okResponse('RedoComplete'));
+    await redoLast(txId);
+    expectTransactionRequest('RedoLast', defaultOptions);
   });
 });

--- a/host/map-sdk/tests/commands/transaction.test.ts
+++ b/host/map-sdk/tests/commands/transaction.test.ts
@@ -384,22 +384,18 @@ describe('transaction command builders', () => {
     });
   });
 
-  it('passes request option overrides through transaction builders', async () => {
+  it('commit sends default options (no snapshot_after, no marker)', async () => {
     invokeMapCommandMock.mockResolvedValue(okResponse({ Reference: transientReference }));
 
-    await commit(txId, {
-      marker_id: 'gesture-123',
-      marker_label: 'commit',
-      snapshot_after: true,
-      disable_undo: false,
-    });
+    await commit(txId);
 
-    expectTransactionRequest('Commit', {
-      marker_id: 'gesture-123',
-      marker_label: 'commit',
-      snapshot_after: true,
-      disable_undo: false,
-    });
+    expectTransactionRequest('Commit', defaultOptions);
+  });
+
+  it('commit does not accept options (txId only)', () => {
+    // commit() deliberately has no options parameter — lifecycle operations must
+    // never create an ExperienceUnit or carry marker metadata.
+    expect(commit.length).toBe(1);
   });
 
   it('undoLast sends default options with snapshot_after false', async () => {

--- a/host/map-sdk/tests/fixtures/request-holon-read-clone.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-clone.json
@@ -22,8 +22,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-read-essential.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-essential.json
@@ -15,8 +15,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-read-key.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-key.json
@@ -15,8 +15,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-read-property.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-property.json
@@ -19,8 +19,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-read-related.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-related.json
@@ -26,8 +26,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-read-summarize.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-summarize.json
@@ -22,8 +22,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-write-add-related.json
+++ b/host/map-sdk/tests/fixtures/request-holon-write-add-related.json
@@ -40,8 +40,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "add related",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "add related",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-write-descriptor.json
+++ b/host/map-sdk/tests/fixtures/request-holon-write-descriptor.json
@@ -38,8 +38,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "set descriptor",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "set descriptor",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-holon-write-property.json
+++ b/host/map-sdk/tests/fixtures/request-holon-write-property.json
@@ -22,8 +22,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "write property",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "write property",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-space-begin-transaction.json
+++ b/host/map-sdk/tests/fixtures/request-space-begin-transaction.json
@@ -4,8 +4,9 @@
     "Space": "BeginTransaction"
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-commit.json
+++ b/host/map-sdk/tests/fixtures/request-tx-commit.json
@@ -7,8 +7,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "commit transaction",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "commit transaction",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-dance.json
+++ b/host/map-sdk/tests/fixtures/request-tx-dance.json
@@ -69,8 +69,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "dance request",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "dance request",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-delete-holon.json
+++ b/host/map-sdk/tests/fixtures/request-tx-delete-holon.json
@@ -15,8 +15,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "delete holon",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "delete holon",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-get-all-holons.json
+++ b/host/map-sdk/tests/fixtures/request-tx-get-all-holons.json
@@ -7,8 +7,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-get-staged-by-base-key.json
+++ b/host/map-sdk/tests/fixtures/request-tx-get-staged-by-base-key.json
@@ -11,8 +11,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-load-holons.json
+++ b/host/map-sdk/tests/fixtures/request-tx-load-holons.json
@@ -22,8 +22,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "load holons",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "load holons",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-new-holon.json
+++ b/host/map-sdk/tests/fixtures/request-tx-new-holon.json
@@ -11,8 +11,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "new holon",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "new holon",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-query.json
+++ b/host/map-sdk/tests/fixtures/request-tx-query.json
@@ -11,8 +11,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-stage-new-from-clone.json
+++ b/host/map-sdk/tests/fixtures/request-tx-stage-new-from-clone.json
@@ -37,8 +37,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "stage clone",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "stage clone",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-stage-new-holon.json
+++ b/host/map-sdk/tests/fixtures/request-tx-stage-new-holon.json
@@ -14,8 +14,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "stage new holon",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "stage new holon",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-stage-new-version-from-id.json
+++ b/host/map-sdk/tests/fixtures/request-tx-stage-new-version-from-id.json
@@ -17,8 +17,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "stage version from id",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "stage version from id",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-stage-new-version.json
+++ b/host/map-sdk/tests/fixtures/request-tx-stage-new-version.json
@@ -41,8 +41,9 @@
     }
   },
   "options": {
-    "gesture_id": "gesture-123",
-    "gesture_label": "stage version",
-    "snapshot_after": true
+    "marker_id": "marker-123",
+    "marker_label": "stage version",
+    "snapshot_after": true,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-staged-count.json
+++ b/host/map-sdk/tests/fixtures/request-tx-staged-count.json
@@ -7,8 +7,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/fixtures/request-tx-transient-count.json
+++ b/host/map-sdk/tests/fixtures/request-tx-transient-count.json
@@ -7,8 +7,9 @@
     }
   },
   "options": {
-    "gesture_id": null,
-    "gesture_label": null,
-    "snapshot_after": false
+    "marker_id": null,
+    "marker_label": null,
+    "snapshot_after": false,
+    "disable_undo": false
   }
 }

--- a/host/map-sdk/tests/request-context.test.ts
+++ b/host/map-sdk/tests/request-context.test.ts
@@ -38,9 +38,10 @@ describe('request context', () => {
 
   it('returns the required default request options', () => {
     expect(defaultRequestOptions()).toEqual({
-      gesture_id: null,
-      gesture_label: null,
+      marker_id: null,
+      marker_label: null,
       snapshot_after: false,
+      disable_undo: false,
     });
   });
 
@@ -59,40 +60,44 @@ describe('request context', () => {
       request_id: 1,
       command: beginTransactionCommand,
       options: {
-        gesture_id: null,
-        gesture_label: null,
+        marker_id: null,
+        marker_label: null,
         snapshot_after: false,
+        disable_undo: false,
       },
     });
   });
 
   it('merges caller-provided request options over the defaults', () => {
     const request = buildRequest(beginTransactionCommand, {
-      gesture_id: 'gesture-123',
-      gesture_label: 'rename holon',
+      marker_id: 'gesture-123',
+      marker_label: 'rename holon',
       snapshot_after: true,
+      disable_undo: false,
     });
 
     expect(request).toEqual({
       request_id: 1,
       command: beginTransactionCommand,
       options: {
-        gesture_id: 'gesture-123',
-        gesture_label: 'rename holon',
+        marker_id: 'gesture-123',
+        marker_label: 'rename holon',
         snapshot_after: true,
+        disable_undo: false,
       },
     });
   });
 
   it('supports partial request option overrides', () => {
     const request = buildRequest(beginTransactionCommand, {
-      gesture_label: 'partial override',
+      marker_label: 'partial override',
     });
 
     expect(request.options).toEqual({
-      gesture_id: null,
-      gesture_label: 'partial override',
+      marker_id: null,
+      marker_label: 'partial override',
       snapshot_after: false,
+      disable_undo: false,
     });
   });
 

--- a/host/map-sdk/tests/transport.test.ts
+++ b/host/map-sdk/tests/transport.test.ts
@@ -22,9 +22,10 @@ const request: MapIpcRequest = {
     Space: 'BeginTransaction',
   },
   options: {
-    gesture_id: null,
-    gesture_label: null,
+    marker_id: null,
+    marker_label: null,
     snapshot_after: false,
+    disable_undo: false,
   },
 };
 

--- a/tests/sweetests/src/harness/execution_support/execution_state.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_state.rs
@@ -138,7 +138,7 @@ impl TestExecutionState {
         step_name: &str,
     ) -> Result<MapResult, HolonError> {
         debug!("Dispatching {}: {:?}", step_name, command);
-        let result = self.runtime.execute_command(command,ExecutionPolicy::default()).await;
+        let result = self.runtime.execute_command(command, ExecutionPolicy::default()).await;
         debug!("{} result: {:?}", step_name, &result);
         result
     }

--- a/tests/sweetests/src/harness/execution_support/execution_state.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_state.rs
@@ -23,7 +23,7 @@ use holons_prelude::prelude::*;
 
 use holons_core::core_shared_objects::transactions::TxId;
 use map_commands_contract::{MapCommand, MapResult, SpaceCommand};
-use map_commands_runtime::Runtime;
+use map_commands_runtime::{ExecutionPolicy, Runtime};
 use tracing::debug;
 
 #[derive(Clone, Debug)]
@@ -138,7 +138,7 @@ impl TestExecutionState {
         step_name: &str,
     ) -> Result<MapResult, HolonError> {
         debug!("Dispatching {}: {:?}", step_name, command);
-        let result = self.runtime.execute_command(command).await;
+        let result = self.runtime.execute_command(command,ExecutionPolicy::default()).await;
         debug!("{} result: {:?}", step_name, &result);
         result
     }

--- a/tests/sweetests/src/harness/helpers/test_context.rs
+++ b/tests/sweetests/src/harness/helpers/test_context.rs
@@ -77,7 +77,10 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
 
     // Step 5: Begin first transaction through the real command path
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction),ExecutionPolicy::default())
+        .execute_command(
+            MapCommand::Space(SpaceCommand::BeginTransaction),
+            ExecutionPolicy::default(),
+        )
         .await
         .expect("failed to begin initial transaction");
     let tx_id = match result {

--- a/tests/sweetests/src/harness/helpers/test_context.rs
+++ b/tests/sweetests/src/harness/helpers/test_context.rs
@@ -5,7 +5,7 @@ use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
 use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
 use holons_core::{HolonServiceApi, ServiceRoutingPolicy};
 use map_commands_contract::{MapCommand, MapResult, SpaceCommand};
-use map_commands_runtime::{Runtime, RuntimeSession};
+use map_commands_runtime::{ExecutionPolicy, Runtime, RuntimeSession};
 use std::sync::Arc;
 use tracing::info;
 
@@ -77,7 +77,7 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
 
     // Step 5: Begin first transaction through the real command path
     let result = runtime
-        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction))
+        .execute_command(MapCommand::Space(SpaceCommand::BeginTransaction),ExecutionPolicy::default())
         .await
         .expect("failed to begin initial transaction");
     let tx_id = match result {

--- a/tests/sweetests/tests/execution_steps/new_holon_executor.rs
+++ b/tests/sweetests/tests/execution_steps/new_holon_executor.rs
@@ -5,6 +5,7 @@ use map_commands_contract::{
     HolonAction, HolonCommand, MapCommand, MapResult, TransactionAction, TransactionCommand,
     WritableHolonAction,
 };
+use map_commands_runtime::ExecutionPolicy;
 use tracing::{debug, info};
 
 /// Creates a new transient holon via `TransactionAction::NewHolon`, applies properties
@@ -46,7 +47,7 @@ pub async fn execute_new_holon(
                         value,
                     }),
                 });
-                state.runtime().execute_command(prop_command).await.unwrap_or_else(|e| {
+                state.runtime().execute_command(prop_command, ExecutionPolicy::default()).await.unwrap_or_else(|e| {
                     panic!("failed to set property {:?} on new holon: {:?}", name, e)
                 });
             }

--- a/tests/sweetests/tests/execution_steps/new_holon_executor.rs
+++ b/tests/sweetests/tests/execution_steps/new_holon_executor.rs
@@ -47,9 +47,13 @@ pub async fn execute_new_holon(
                         value,
                     }),
                 });
-                state.runtime().execute_command(prop_command, ExecutionPolicy::default()).await.unwrap_or_else(|e| {
-                    panic!("failed to set property {:?} on new holon: {:?}", name, e)
-                });
+                state
+                    .runtime()
+                    .execute_command(prop_command, ExecutionPolicy::default())
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!("failed to set property {:?} on new holon: {:?}", name, e)
+                    });
             }
 
             // 4. RECORD


### PR DESCRIPTION
phase 1. 

design decisions:
refactor of RequestOptions inline with spec on marker functionality 

```typescript
export interface RequestOptions {
	marker_id: string | null; // replaces gesture_id
	marker_label: string | null; // replaces gesture_label
	snapshot_after: boolean;
	disable_undo: boolean;
}
```

added relevant undo redo command types

updated transaction store with experience_unit table:

```sql
CREATE TABLE IF NOT EXISTS experience_unit (
	unit_id TEXT PRIMARY KEY,
	tx_id TEXT NOT NULL,
	marker_id TEXT,
	marker_label TEXT,
	checkpoint_id TEXT NOT NULL,
	stack_kind TEXT NOT NULL CHECK (stack_kind IN ('undo', 'redo')),
	stack_pos INTEGER NOT NULL,
	created_at_ms INTEGER NOT NULL,
	FOREIGN KEY (tx_id) REFERENCES recovery_session(tx_id) ON DELETE CASCADE,
	FOREIGN KEY (checkpoint_id) REFERENCES recovery_checkpoint(checkpoint_id)
);
```

added tests for undo and redo