### PR TITLE
477 descriptors pr2a add schema backed descriptor sweetest coverage

### DIFF
--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-abstract-value-types.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-concrete-value-types.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-dance-schema.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json
@@ -1,14 +1,14 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-keyrules-schema.csv"
     ],
     "load_with": [
-      "MAP Schema Types-map-core-schema-root.json",
       "MAP Schema Types-map-core-schema-relationship-types.json",
+      "MAP Schema Types-map-core-schema-root.json",
       "MAP Schema Types-map-core-schema-property-types.json"
     ]
   },
@@ -28,12 +28,6 @@
         "allows_additional_relationships": false
       },
       "relationships": [
-        {
-          "name": "Extends",
-          "target": {
-            "$ref": "#HolonType"
-          }
-        },
         {
           "name": "UsesKeyRule",
           "target": {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-property-types.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:38:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-relationship-types.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T12:16:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-root.csv"
@@ -89,100 +89,6 @@
             },
             {
               "$ref": "#InstanceTypeKind.PropertyType"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "key": "SchemaType",
-      "type": "#TypeDescriptor",
-      "properties": {
-        "type_name": "SchemaType",
-        "type_name_plural": "SchemaTypes",
-        "display_name": "Schema Type",
-        "display_name_plural": "Schema Types",
-        "instance_type_kind": "Holon",
-        "description": "Describes schema holons - groupings of holons that represent a cohesive schema. Includes the ability to define inter-schema dependencies.",
-        "is_abstract_type": true
-      },
-      "relationships": [
-        {
-          "name": "ComponentOf",
-          "target": {
-            "$ref": "#MAP Core Schema-v0.0.4"
-          }
-        },
-        {
-          "name": "Extends",
-          "target": {
-            "$ref": "#MetaHolonType"
-          }
-        },
-        {
-          "name": "UsesKeyRule",
-          "target": {
-            "$ref": "#TypeNameRule"
-          }
-        },
-        {
-          "name": "InstanceProperties",
-          "target": [
-            {
-              "$ref": "#MapString.PropertyType"
-            },
-            {
-              "$ref": "#Description.PropertyType"
-            }
-          ]
-        },
-        {
-          "name": "InstanceRelationships",
-          "target": {
-            "$ref": "#(SchemaType)-[DependsOn]->(SchemaType)"
-          }
-        }
-      ]
-    },
-    {
-      "key": "HolonSpaceType",
-      "type": "#TypeDescriptor",
-      "properties": {
-        "type_name": "HolonSpaceType",
-        "type_name_plural": "HolonSpaceTypes",
-        "display_name": "Holon Space Holon Type",
-        "display_name_plural": "Holon Space Holon Types",
-        "instance_type_kind": "Holon",
-        "description": "Describes HolonSpace holons. A HolonSpace is a holon that, itself, is a container for holons. It maps 1:1 with a DHT. It also proxies inbound and outbound calls to other HolonSpaces of holons that represent a cohesive schema. Includes the ability to define inter-schema dependencies. With minimal InstanceProperties and no InstanceRelationships, a HolonSpace is very stable = i.e., owned holons and space proxies can be added to a space without requiring a new version of the HolonSpace.",
-        "is_abstract_type": true
-      },
-      "relationships": [
-        {
-          "name": "ComponentOf",
-          "target": {
-            "$ref": "#MAP Core Schema-v0.0.4"
-          }
-        },
-        {
-          "name": "Extends",
-          "target": {
-            "$ref": "#MetaHolonType"
-          }
-        },
-        {
-          "name": "UsesKeyRule",
-          "target": {
-            "$ref": "#TypeNameRule"
-          }
-        },
-        {
-          "name": "InstanceProperties",
-          "target": [
-            {
-              "$ref": "#SpaceName.PropertyType"
-            },
-            {
-              "$ref": "#Description.PropertyType"
             }
           ]
         }
@@ -817,6 +723,104 @@
       ]
     },
     {
+      "key": "SchemaType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "SchemaType",
+        "type_name_plural": "SchemaTypes",
+        "display_name": "Schema Type",
+        "display_name_plural": "Schema Types",
+        "instance_type_kind": "Holon",
+        "description": "Describes schema holons - groupings of holons that represent a cohesive schema. Includes the ability to define inter-schema dependencies.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "#MapString.PropertyType"
+            },
+            {
+              "$ref": "#Description.PropertyType"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(SchemaType)-[DependsOn]->(SchemaType)"
+          }
+        }
+      ]
+    },
+    {
+      "key": "HolonSpaceType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "HolonSpaceType",
+        "type_name_plural": "HolonSpaceTypes",
+        "display_name": "Holon Space Holon Type",
+        "display_name_plural": "Holon Space Holon Types",
+        "instance_type_kind": "Holon",
+        "description": "Describes HolonSpace holons. A HolonSpace is a holon that, itself, is a container for holons. It maps 1:1 with a DHT. It also proxies inbound and outbound calls to other HolonSpaces of holons that represent a cohesive schema. Includes the ability to define inter-schema dependencies. With minimal InstanceProperties and no InstanceRelationships, a HolonSpace is very stable = i.e., owned holons and space proxies can be added to a space without requiring a new version of the HolonSpace.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "#SpaceName.PropertyType"
+            },
+            {
+              "$ref": "#Description.PropertyType"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "key": "HolonErrorType",
       "type": "#TypeDescriptor",
       "properties": {
@@ -826,7 +830,7 @@
         "display_name_plural": "Holon Error Types",
         "instance_type_kind": "Holon",
         "description": "Describes the structure of error holons.",
-        "is_abstract_type": true,
+        "is_abstract_type": false,
         "allows_additional_properties": false,
         "allows_additional_relationships": false
       },

--- a/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
+++ b/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2025-12-08T13:09:06",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-holon-loader-schema.csv"
@@ -9,9 +9,10 @@
     "load_with": [
       "MAP Schema Types-map-core-schema-root.json",
       "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
       "MAP Schema Types-map-core-schema-property-types.json",
       "MAP Schema Types-map-core-schema-dance-schema.json",
-      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+      "MAP Schema Types-map-core-schema-abstract-value-types.json"
     ]
   },
   "holons": [
@@ -273,6 +274,9 @@
             },
             {
               "$ref": "#LinksCreated.PropertyType"
+            },
+            {
+              "$ref": "#LoadCommitStatus.PropertyType"
             }
           ]
         },
@@ -1029,6 +1033,150 @@
       ]
     },
     {
+      "key": "LoadCommitStatus",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "LoadCommitStatus",
+        "type_name_plural": "LoadCommitStatuses",
+        "display_name": "LoadCommitStatus",
+        "display_name_plural": "LoadCommitStatuses",
+        "instance_type_kind": "Value.Enum",
+        "description": "An enum representing the commit outcome of a holon load.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#MapEnumValueType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LoadCommitStatus.Complete",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Complete",
+        "display_name": "Complete",
+        "instance_type_kind": "EnumVariant",
+        "description": "An enum variant indicating a complete commit.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#EnumVariantValueType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#EnumVariantRule"
+          }
+        },
+        {
+          "name": "VariantOf",
+          "target": {
+            "$ref": "#LoadCommitStatus"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LoadCommitStatus.Incomplete",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Incomplete",
+        "display_name": "Incomplete",
+        "instance_type_kind": "EnumVariant",
+        "description": "An enum variant indicating a incomplete commit.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#EnumVariantValueType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#EnumVariantRule"
+          }
+        },
+        {
+          "name": "VariantOf",
+          "target": {
+            "$ref": "#LoadCommitStatus"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LoadCommitStatus.Skipped",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Skipped",
+        "display_name": "Skipped",
+        "instance_type_kind": "EnumVariant",
+        "description": "An enum variant indicating that commit was skipped.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#EnumVariantValueType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#EnumVariantRule"
+          }
+        },
+        {
+          "name": "VariantOf",
+          "target": {
+            "$ref": "#LoadCommitStatus"
+          }
+        }
+      ]
+    },
+    {
       "key": "Key.PropertyType",
       "type": "#TypeDescriptor",
       "properties": {
@@ -1531,6 +1679,45 @@
           "name": "ValueType",
           "target": {
             "$ref": "#MapIntegerValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LoadCommitStatus.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "LoadCommitStatus",
+        "type_name_plural": "LoadCommitStatuses",
+        "display_name": "load_commit_status",
+        "display_name_plural": "load_commit_statuses",
+        "instance_type_kind": "Property",
+        "description": "Represents the commit status for a holon loading operation.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.4"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#LoadCommitStatus"
           }
         }
       ]

--- a/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
+++ b/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
@@ -1109,7 +1109,7 @@
         "type_name": "Incomplete",
         "display_name": "Incomplete",
         "instance_type_kind": "EnumVariant",
-        "description": "An enum variant indicating a incomplete commit.",
+        "description": "An enum variant indicating an incomplete commit.",
         "is_abstract_type": false
       },
       "relationships": [

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -111,6 +111,10 @@ impl Iterator for ExtendsIter {
         }
 
         let current = self.next.take()?;
+        // Cycle detection relies on reference_id_string() being a stable,
+        // collision-resistant identity for each concrete holon reference. Do
+        // not implement reference_id_string() with lossy display fallbacks such
+        // as "<invalid utf-8>" for binary saved IDs.
         self.visited.insert(current.reference_id_string());
 
         // Resolve the next step after capturing the current item. This keeps

--- a/shared_crates/holons_core/src/reference_layer/smart_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/smart_reference.rs
@@ -116,7 +116,7 @@ impl SmartReference {
     }
 
     pub fn reference_id_string(&self) -> String {
-        format!("HolonId={}", self.holon_id)
+        format!("HolonId={:?}", self.holon_id)
     }
 }
 

--- a/shared_crates/type_system/integrity_core_types/src/id.rs
+++ b/shared_crates/type_system/integrity_core_types/src/id.rs
@@ -38,6 +38,9 @@ impl LocalId {
 
 impl fmt::Display for LocalId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display is for human-readable diagnostics only. Do not use it for
+        // identity, lookup keys, or hashing: non-UTF-8 IDs collapse to the
+        // same "<invalid utf-8>" placeholder.
         match short_hash(self, 6) {
             Ok(s) => write!(f, "{}", s),
             Err(_) => write!(f, "<invalid utf-8>"),

--- a/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
+++ b/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-04-28T11:41:19",
+    "generated_at": "2026-04-29T10:51:57",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-test-schema-book-person-inverse.csv"

--- a/tests/sweetests/src/harness/helpers/constants.rs
+++ b/tests/sweetests/src/harness/helpers/constants.rs
@@ -12,6 +12,12 @@ pub const EDITOR_FOR: &str = "EDITOR_FOR";
 pub const ENSURE_DB_EMPTY: &str = "Ensuring DB is 'empty' (only contains initial LocalHolonSpace).";
 pub const BOOK_DESCRIPTOR_KEY: &str = "Book.HolonType";
 pub const PERSON_DESCRIPTOR_KEY: &str = "Person.HolonType";
+pub const SCHEMA_TYPE_KEY: &str = "SchemaType";
+pub const HOLON_TYPE_KEY: &str = "HolonType";
+pub const CORE_INSTANCE_PROPERTIES_RELATIONSHIP_KEY: &str =
+    "(TypeDescriptor)-[InstanceProperties]->(PropertyType)";
+pub const CORE_INSTANCE_PROPERTY_FOR_RELATIONSHIP_KEY: &str =
+    "(PropertyType)-[InstancePropertyFor]->(TypeDescriptor)";
 pub const BOOK_TO_PERSON_RELATIONSHIP_KEY: &str =
     "(Book.HolonType)-[AuthoredBy]->(Person.HolonType)";
 pub const PERSON_TO_BOOK_REL_INVERSE: &str = "Authors";

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -29,7 +29,7 @@ pub struct CoreSchemaLoadMetrics {
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
     staged: 182,
     committed: 182,
-    links_created: 1042,
+    links_created: 1041,
     errors: 0,
     total_bundles: 7,
     total_loader_holons: 182,

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -170,6 +170,42 @@ impl DancesTestCase {
         Ok(())
     }
 
+    pub fn add_verify_book_person_descriptors_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description = description
+            .unwrap_or_else(|| "Verify Book/Person descriptors over loaded schema".to_string());
+        self.steps.push(DanceTestStep::VerifyBookPersonDescriptors { description });
+
+        Ok(())
+    }
+
+    pub fn add_verify_core_schema_descriptor_subtypes_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Verify core schema descriptor subtypes".to_string());
+        self.steps.push(DanceTestStep::VerifyCoreSchemaDescriptorSubtypes { description });
+
+        Ok(())
+    }
+
+    pub fn add_verify_core_schema_descriptors_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Verify core schema descriptors".to_string());
+        self.steps.push(DanceTestStep::VerifyCoreSchemaDescriptors { description });
+
+        Ok(())
+    }
+
     pub fn add_load_holons_internal_step(
         &mut self,
         set: TransientReference,

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -55,6 +55,15 @@ pub enum DanceTestStep {
     LoadBookPersonInverseTestSchema {
         description: String,
     },
+    VerifyBookPersonDescriptors {
+        description: String,
+    },
+    VerifyCoreSchemaDescriptorSubtypes {
+        description: String,
+    },
+    VerifyCoreSchemaDescriptors {
+        description: String,
+    },
     MatchSavedContent,
     NewHolon {
         step_token: TestReference,
@@ -163,6 +172,15 @@ impl core::fmt::Display for DanceTestStep {
                 write!(f, "{description}")
             }
             DanceTestStep::LoadBookPersonInverseTestSchema { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::VerifyBookPersonDescriptors { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::VerifyCoreSchemaDescriptorSubtypes { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::VerifyCoreSchemaDescriptors { description } => {
                 write!(f, "{description}")
             }
             DanceTestStep::MatchSavedContent => {

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -108,9 +108,9 @@ use holons_prelude::prelude::*;
 #[case::stage_new_from_clone_test(stage_new_from_clone_fixture())]
 #[case::stage_new_version_test(stage_new_version_fixture())]
 #[case::load_holons_internal_test(loader_incremental_fixture())]
+#[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
 #[case::load_core_schema_test(load_core_schema_fixture())]
 #[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
-#[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
 #[tokio::test(flavor = "multi_thread")]
 async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
     // Setup

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -35,6 +35,10 @@ use execution_steps::add_related_holons_executor::execute_add_related_holons;
 use execution_steps::begin_transaction_executor::execute_begin_transaction;
 use execution_steps::commit_executor::execute_commit;
 use execution_steps::delete_holon_executor::execute_delete_holon;
+use execution_steps::descriptor_verification_executor::{
+    execute_verify_book_person_descriptors, execute_verify_core_schema_descriptor_subtypes,
+    execute_verify_core_schema_descriptors,
+};
 use execution_steps::ensure_database_count_executor::execute_ensure_database_count;
 use execution_steps::load_book_person_inverse_test_schema_executor::execute_load_book_person_inverse_test_schema;
 use execution_steps::load_core_schema_executor::execute_load_core_schema;
@@ -198,6 +202,15 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
             }
             DanceTestStep::LoadBookPersonInverseTestSchema { .. } => {
                 execute_load_book_person_inverse_test_schema(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifyBookPersonDescriptors { .. } => {
+                execute_verify_book_person_descriptors(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifyCoreSchemaDescriptorSubtypes { .. } => {
+                execute_verify_core_schema_descriptor_subtypes(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifyCoreSchemaDescriptors { .. } => {
+                execute_verify_core_schema_descriptors(&mut test_execution_state).await
             }
             DanceTestStep::MatchSavedContent => {
                 execute_match_db_content(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -1,0 +1,355 @@
+use holons_core::descriptors::{HolonDescriptor, RelationshipDescriptor};
+use holons_prelude::prelude::*;
+use holons_test::harness::helpers::{
+    BOOK_DESCRIPTOR_KEY, BOOK_TO_PERSON_RELATIONSHIP_KEY, PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY,
+};
+use holons_test::TestExecutionState;
+use pretty_assertions::assert_eq;
+use tracing::info;
+
+const CORE_SCHEMA_KEY: &str = "MAP Core Schema-v0.0.4";
+const HOLON_TYPE_KEY: &str = "HolonType";
+const DECLARED_CORE_RELATIONSHIP_KEY: &str =
+    "(TypeDescriptor)-[InstanceProperties]->(PropertyType)";
+const INVERSE_CORE_RELATIONSHIP_KEY: &str =
+    "(PropertyType)-[InstancePropertyFor]->(TypeDescriptor)";
+
+/// Verifies representative foundational descriptor access over loaded MAP core schema data.
+pub async fn execute_verify_core_schema_descriptors(state: &mut TestExecutionState) {
+    let holons = loaded_holons(state, "verify_core_schema_descriptors").await;
+
+    let core_schema = find_holon_by_key(&holons, CORE_SCHEMA_KEY);
+    let core_schema_descriptor = HolonDescriptor::from_holon(core_schema);
+    assert_eq!(
+        core_schema_descriptor.header().type_name().expect("core schema type_name"),
+        MapString(CORE_SCHEMA_KEY.to_string())
+    );
+    assert!(!core_schema_descriptor
+        .allows_additional_properties()
+        .expect("core schema allows_additional_properties"));
+    assert!(!core_schema_descriptor
+        .allows_additional_relationships()
+        .expect("core schema allows_additional_relationships"));
+
+    let holon_type = find_holon_by_key(&holons, HOLON_TYPE_KEY);
+    let holon_type_descriptor = HolonDescriptor::from_holon(holon_type);
+    assert_eq!(
+        holon_type_descriptor.header().type_name().expect("HolonType type_name"),
+        MapString("HolonType".to_string())
+    );
+
+    let instance_property_names = type_names(holon_type_descriptor.instance_properties());
+    assert_contains(&instance_property_names, "AllowsAdditionalProperties");
+    assert_contains(&instance_property_names, "AllowsAdditionalRelationships");
+
+    let instance_relationship_names =
+        relationship_names(holon_type_descriptor.instance_relationships());
+    assert_contains(&instance_relationship_names, "Properties");
+    assert_contains(&instance_relationship_names, "DescribedBy");
+
+    let property = holon_type_descriptor
+        .get_property_by_name(PropertyName(MapString("AllowsAdditionalProperties".to_string())))
+        .expect("AllowsAdditionalProperties lookup");
+    assert_eq!(
+        property
+            .value_type()
+            .expect("AllowsAdditionalProperties value_type")
+            .header()
+            .type_name()
+            .expect("AllowsAdditionalProperties value type_name"),
+        MapString("MapBooleanValueType".to_string())
+    );
+
+    let relationship = holon_type_descriptor
+        .get_relationship_by_name(RelationshipName(MapString("Properties".to_string())))
+        .expect("Properties relationship lookup");
+    assert_relationship_shape(
+        &relationship,
+        "Properties",
+        "HolonType",
+        "PropertyType",
+        "(HolonType)-[Properties]->(PropertyType)",
+    );
+
+    info!("verified representative core schema descriptor access");
+}
+
+/// Verifies declared/inverse relationship subtype narrowing over loaded MAP core schema data.
+pub async fn execute_verify_core_schema_descriptor_subtypes(state: &mut TestExecutionState) {
+    let holons = loaded_holons(state, "verify_core_schema_descriptor_subtypes").await;
+
+    let declared = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        DECLARED_CORE_RELATIONSHIP_KEY,
+    ))
+    .try_into_declared_relationship_descriptor()
+    .expect("core declared relationship should narrow");
+    assert_relationship_shape(
+        &declared,
+        "InstanceProperties",
+        "TypeDescriptor",
+        "PropertyType",
+        "(TypeDescriptor)-[InstanceProperties]->(PropertyType)",
+    );
+
+    let inverse = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        INVERSE_CORE_RELATIONSHIP_KEY,
+    ))
+    .try_into_inverse_relationship_descriptor()
+    .expect("core inverse relationship should narrow");
+    assert_relationship_shape(
+        &inverse,
+        "InstancePropertyFor",
+        "PropertyType",
+        "TypeDescriptor",
+        "(PropertyType)-[InstancePropertyFor]->(TypeDescriptor)",
+    );
+    assert_eq!(
+        inverse
+            .inverse_of()
+            .expect("core inverse relationship inverse_of")
+            .base_relationship_name()
+            .expect("core inverse_of base name")
+            .to_string(),
+        "InstanceProperties"
+    );
+
+    info!("verified core schema descriptor subtype access");
+}
+
+/// Verifies representative descriptor access over the loaded Book/Person inverse schema.
+pub async fn execute_verify_book_person_descriptors(state: &mut TestExecutionState) {
+    let holons = loaded_holons(state, "verify_book_person_descriptors").await;
+
+    let book_descriptor =
+        HolonDescriptor::from_holon(find_holon_by_key(&holons, BOOK_DESCRIPTOR_KEY));
+    assert_eq!(
+        book_descriptor.header().type_name().expect("Book type_name"),
+        MapString("Book".to_string())
+    );
+    assert!(!book_descriptor
+        .allows_additional_properties()
+        .expect("Book allows_additional_properties"));
+    assert!(!book_descriptor
+        .allows_additional_relationships()
+        .expect("Book allows_additional_relationships"));
+
+    let instance_property_names = type_names(book_descriptor.instance_properties());
+    assert_contains(&instance_property_names, "Title");
+    assert_contains(&instance_property_names, "AllowsAdditionalProperties");
+
+    let instance_relationship_names = relationship_names(book_descriptor.instance_relationships());
+    assert_contains(&instance_relationship_names, "AuthoredBy");
+    assert_contains(&instance_relationship_names, "Properties");
+
+    let title = book_descriptor
+        .get_property_by_name(PropertyName(MapString("Title".to_string())))
+        .expect("Title property lookup");
+    assert_eq!(
+        title
+            .value_type()
+            .expect("Title value_type")
+            .header()
+            .type_name()
+            .expect("Title value type_name"),
+        MapString("MapStringValueType".to_string())
+    );
+
+    let authored_by = book_descriptor
+        .get_relationship_by_name(RelationshipName(MapString("AuthoredBy".to_string())))
+        .expect("AuthoredBy relationship lookup");
+    assert_relationship_shape(
+        &authored_by,
+        "AuthoredBy",
+        "Book",
+        "Person",
+        "(Book)-[AuthoredBy]->(Person)",
+    );
+
+    let inverse = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY,
+    ))
+    .try_into_inverse_relationship_descriptor()
+    .expect("Book/Person inverse relationship should narrow");
+    assert_eq!(
+        inverse
+            .inverse_of()
+            .expect("Book/Person inverse_of")
+            .base_relationship_name()
+            .expect("Book/Person inverse_of base name")
+            .to_string(),
+        "AuthoredBy"
+    );
+
+    let declared = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        BOOK_TO_PERSON_RELATIONSHIP_KEY,
+    ))
+    .try_into_declared_relationship_descriptor()
+    .expect("Book/Person declared relationship should narrow");
+    assert_relationship_shape(
+        &declared,
+        "AuthoredBy",
+        "Book",
+        "Person",
+        "(Book)-[AuthoredBy]->(Person)",
+    );
+
+    info!("verified representative Book/Person descriptor access");
+}
+
+async fn loaded_holons(state: &mut TestExecutionState, step_name: &str) -> HolonCollection {
+    let context = state.open_assertion_context(step_name).await.unwrap_or_else(|error| {
+        panic!("{step_name}: failed to open assertion transaction: {error:?}")
+    });
+
+    context
+        .lookup()
+        .get_all_holons()
+        .unwrap_or_else(|error| panic!("{step_name}: get_all_holons failed: {error:?}"))
+}
+
+fn find_holon_by_key(holons: &HolonCollection, key: &str) -> HolonReference {
+    holons
+        .get_members()
+        .iter()
+        .find(|holon| {
+            holon
+                .key()
+                .unwrap_or_else(|error| {
+                    panic!("failed to read holon key while finding {key}: {error:?}")
+                })
+                .map(|actual| actual.0 == key)
+                .unwrap_or(false)
+        })
+        .unwrap_or_else(|| panic!("expected loaded holon with key {key}"))
+        .clone()
+}
+
+fn type_names(
+    descriptors: Result<Vec<holons_core::descriptors::PropertyDescriptor>, HolonError>,
+) -> Vec<String> {
+    descriptors
+        .expect("property descriptor list")
+        .into_iter()
+        .map(|descriptor| descriptor.header().type_name().expect("property descriptor type_name").0)
+        .collect()
+}
+
+fn relationship_names(descriptors: Result<Vec<RelationshipDescriptor>, HolonError>) -> Vec<String> {
+    descriptors
+        .expect("relationship descriptor list")
+        .into_iter()
+        .map(|descriptor| {
+            descriptor
+                .base_relationship_name()
+                .expect("relationship descriptor base name")
+                .to_string()
+        })
+        .collect()
+}
+
+fn assert_contains(values: &[String], expected: &str) {
+    assert!(
+        values.iter().any(|actual| actual == expected),
+        "expected {values:?} to contain {expected}"
+    );
+}
+
+fn assert_relationship_shape(
+    relationship: &impl RelationshipAssertions,
+    expected_base_name: &str,
+    expected_source_type: &str,
+    expected_target_type: &str,
+    expected_full_name: &str,
+) {
+    assert_eq!(
+        relationship.base_relationship_name().expect("base relationship name").to_string(),
+        expected_base_name
+    );
+    assert_eq!(
+        relationship
+            .source_type()
+            .expect("source_type")
+            .header()
+            .type_name()
+            .expect("source type_name"),
+        MapString(expected_source_type.to_string())
+    );
+    assert_eq!(
+        relationship
+            .target_type()
+            .expect("target_type")
+            .header()
+            .type_name()
+            .expect("target type_name"),
+        MapString(expected_target_type.to_string())
+    );
+    assert_eq!(
+        relationship.full_relationship_name().expect("full relationship name"),
+        MapString(expected_full_name.to_string())
+    );
+}
+
+trait RelationshipAssertions {
+    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError>;
+    fn source_type(&self) -> Result<HolonDescriptor, HolonError>;
+    fn target_type(&self) -> Result<HolonDescriptor, HolonError>;
+    fn full_relationship_name(&self) -> Result<MapString, HolonError>;
+}
+
+impl RelationshipAssertions for RelationshipDescriptor {
+    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
+        RelationshipDescriptor::base_relationship_name(self)
+    }
+
+    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
+        RelationshipDescriptor::source_type(self)
+    }
+
+    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
+        RelationshipDescriptor::target_type(self)
+    }
+
+    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
+        RelationshipDescriptor::full_relationship_name(self)
+    }
+}
+
+impl RelationshipAssertions for holons_core::descriptors::DeclaredRelationshipDescriptor {
+    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
+        self.base_relationship_name()
+    }
+
+    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
+        self.source_type()
+    }
+
+    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
+        self.target_type()
+    }
+
+    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
+        self.full_relationship_name()
+    }
+}
+
+impl RelationshipAssertions for holons_core::descriptors::InverseRelationshipDescriptor {
+    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
+        self.base_relationship_name()
+    }
+
+    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
+        self.source_type()
+    }
+
+    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
+        self.target_type()
+    }
+
+    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
+        self.full_relationship_name()
+    }
+}

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -1,35 +1,31 @@
 use holons_core::descriptors::{HolonDescriptor, RelationshipDescriptor};
 use holons_prelude::prelude::*;
 use holons_test::harness::helpers::{
-    BOOK_DESCRIPTOR_KEY, BOOK_TO_PERSON_RELATIONSHIP_KEY, PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY,
+    BOOK_DESCRIPTOR_KEY, BOOK_TO_PERSON_RELATIONSHIP_KEY,
+    CORE_INSTANCE_PROPERTIES_RELATIONSHIP_KEY, CORE_INSTANCE_PROPERTY_FOR_RELATIONSHIP_KEY,
+    HOLON_TYPE_KEY, PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY, SCHEMA_TYPE_KEY,
 };
 use holons_test::TestExecutionState;
+use map_commands_contract::{MapCommand, MapResult, TransactionAction, TransactionCommand};
 use pretty_assertions::assert_eq;
 use tracing::info;
-
-const CORE_SCHEMA_KEY: &str = "MAP Core Schema-v0.0.4";
-const HOLON_TYPE_KEY: &str = "HolonType";
-const DECLARED_CORE_RELATIONSHIP_KEY: &str =
-    "(TypeDescriptor)-[InstanceProperties]->(PropertyType)";
-const INVERSE_CORE_RELATIONSHIP_KEY: &str =
-    "(PropertyType)-[InstancePropertyFor]->(TypeDescriptor)";
 
 /// Verifies representative foundational descriptor access over loaded MAP core schema data.
 pub async fn execute_verify_core_schema_descriptors(state: &mut TestExecutionState) {
     let holons = loaded_holons(state, "verify_core_schema_descriptors").await;
 
-    let core_schema = find_holon_by_key(&holons, CORE_SCHEMA_KEY);
-    let core_schema_descriptor = HolonDescriptor::from_holon(core_schema);
+    let schema_type = find_holon_by_key(&holons, SCHEMA_TYPE_KEY);
+    let schema_type_descriptor = HolonDescriptor::from_holon(schema_type);
     assert_eq!(
-        core_schema_descriptor.header().type_name().expect("core schema type_name"),
-        MapString(CORE_SCHEMA_KEY.to_string())
+        schema_type_descriptor.header().type_name().expect("SchemaType type_name"),
+        MapString(SCHEMA_TYPE_KEY.to_string())
     );
-    assert!(!core_schema_descriptor
+    assert!(!schema_type_descriptor
         .allows_additional_properties()
-        .expect("core schema allows_additional_properties"));
-    assert!(!core_schema_descriptor
+        .expect("SchemaType allows_additional_properties"));
+    assert!(!schema_type_descriptor
         .allows_additional_relationships()
-        .expect("core schema allows_additional_relationships"));
+        .expect("SchemaType allows_additional_relationships"));
 
     let holon_type = find_holon_by_key(&holons, HOLON_TYPE_KEY);
     let holon_type_descriptor = HolonDescriptor::from_holon(holon_type);
@@ -80,7 +76,7 @@ pub async fn execute_verify_core_schema_descriptor_subtypes(state: &mut TestExec
 
     let declared = RelationshipDescriptor::from_holon(find_holon_by_key(
         &holons,
-        DECLARED_CORE_RELATIONSHIP_KEY,
+        CORE_INSTANCE_PROPERTIES_RELATIONSHIP_KEY,
     ))
     .try_into_declared_relationship_descriptor()
     .expect("core declared relationship should narrow");
@@ -94,7 +90,7 @@ pub async fn execute_verify_core_schema_descriptor_subtypes(state: &mut TestExec
 
     let inverse = RelationshipDescriptor::from_holon(find_holon_by_key(
         &holons,
-        INVERSE_CORE_RELATIONSHIP_KEY,
+        CORE_INSTANCE_PROPERTY_FOR_RELATIONSHIP_KEY,
     ))
     .try_into_inverse_relationship_descriptor()
     .expect("core inverse relationship should narrow");
@@ -205,10 +201,19 @@ async fn loaded_holons(state: &mut TestExecutionState, step_name: &str) -> Holon
         panic!("{step_name}: failed to open assertion transaction: {error:?}")
     });
 
-    context
-        .lookup()
-        .get_all_holons()
-        .unwrap_or_else(|error| panic!("{step_name}: get_all_holons failed: {error:?}"))
+    let command = MapCommand::Transaction(TransactionCommand {
+        context: context.clone(),
+        action: TransactionAction::GetAllHolons,
+    });
+    let result = state
+        .dispatch_command(command, step_name)
+        .await
+        .unwrap_or_else(|error| panic!("{step_name}: get_all_holons failed: {error:?}"));
+
+    match result {
+        MapResult::Collection(collection) => collection,
+        other => panic!("{step_name}: expected Collection, got {other:?}"),
+    }
 }
 
 fn find_holon_by_key(holons: &HolonCollection, key: &str) -> HolonReference {

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -34,17 +34,17 @@ pub async fn execute_verify_core_schema_descriptors(state: &mut TestExecutionSta
         MapString("HolonType".to_string())
     );
 
-    let instance_property_names = type_names(holon_type_descriptor.instance_properties());
+    let instance_property_names = property_type_names(holon_type_descriptor.instance_properties());
     assert_contains(&instance_property_names, "AllowsAdditionalProperties");
     assert_contains(&instance_property_names, "AllowsAdditionalRelationships");
 
     let instance_relationship_names =
-        relationship_names(holon_type_descriptor.instance_relationships());
+        relationship_base_names(holon_type_descriptor.instance_relationships());
     assert_contains(&instance_relationship_names, "Properties");
     assert_contains(&instance_relationship_names, "DescribedBy");
 
     let property = holon_type_descriptor
-        .get_property_by_name(PropertyName(MapString("AllowsAdditionalProperties".to_string())))
+        .get_property_by_name(PropertyName(MapString::from("AllowsAdditionalProperties")))
         .expect("AllowsAdditionalProperties lookup");
     assert_eq!(
         property
@@ -57,10 +57,13 @@ pub async fn execute_verify_core_schema_descriptors(state: &mut TestExecutionSta
     );
 
     let relationship = holon_type_descriptor
-        .get_relationship_by_name(RelationshipName(MapString("Properties".to_string())))
+        .get_relationship_by_name(RelationshipName(MapString::from("Properties")))
         .expect("Properties relationship lookup");
     assert_relationship_shape(
-        &relationship,
+        relationship.base_relationship_name(),
+        relationship.source_type(),
+        relationship.target_type(),
+        relationship.full_relationship_name(),
         "Properties",
         "HolonType",
         "PropertyType",
@@ -81,7 +84,10 @@ pub async fn execute_verify_core_schema_descriptor_subtypes(state: &mut TestExec
     .try_into_declared_relationship_descriptor()
     .expect("core declared relationship should narrow");
     assert_relationship_shape(
-        &declared,
+        declared.base_relationship_name(),
+        declared.source_type(),
+        declared.target_type(),
+        declared.full_relationship_name(),
         "InstanceProperties",
         "TypeDescriptor",
         "PropertyType",
@@ -95,7 +101,10 @@ pub async fn execute_verify_core_schema_descriptor_subtypes(state: &mut TestExec
     .try_into_inverse_relationship_descriptor()
     .expect("core inverse relationship should narrow");
     assert_relationship_shape(
-        &inverse,
+        inverse.base_relationship_name(),
+        inverse.source_type(),
+        inverse.target_type(),
+        inverse.full_relationship_name(),
         "InstancePropertyFor",
         "PropertyType",
         "TypeDescriptor",
@@ -131,16 +140,17 @@ pub async fn execute_verify_book_person_descriptors(state: &mut TestExecutionSta
         .allows_additional_relationships()
         .expect("Book allows_additional_relationships"));
 
-    let instance_property_names = type_names(book_descriptor.instance_properties());
+    let instance_property_names = property_type_names(book_descriptor.instance_properties());
     assert_contains(&instance_property_names, "Title");
     assert_contains(&instance_property_names, "AllowsAdditionalProperties");
 
-    let instance_relationship_names = relationship_names(book_descriptor.instance_relationships());
+    let instance_relationship_names =
+        relationship_base_names(book_descriptor.instance_relationships());
     assert_contains(&instance_relationship_names, "AuthoredBy");
     assert_contains(&instance_relationship_names, "Properties");
 
     let title = book_descriptor
-        .get_property_by_name(PropertyName(MapString("Title".to_string())))
+        .get_property_by_name(PropertyName(MapString::from("Title")))
         .expect("Title property lookup");
     assert_eq!(
         title
@@ -153,10 +163,13 @@ pub async fn execute_verify_book_person_descriptors(state: &mut TestExecutionSta
     );
 
     let authored_by = book_descriptor
-        .get_relationship_by_name(RelationshipName(MapString("AuthoredBy".to_string())))
+        .get_relationship_by_name(RelationshipName(MapString::from("AuthoredBy")))
         .expect("AuthoredBy relationship lookup");
     assert_relationship_shape(
-        &authored_by,
+        authored_by.base_relationship_name(),
+        authored_by.source_type(),
+        authored_by.target_type(),
+        authored_by.full_relationship_name(),
         "AuthoredBy",
         "Book",
         "Person",
@@ -186,7 +199,10 @@ pub async fn execute_verify_book_person_descriptors(state: &mut TestExecutionSta
     .try_into_declared_relationship_descriptor()
     .expect("Book/Person declared relationship should narrow");
     assert_relationship_shape(
-        &declared,
+        declared.base_relationship_name(),
+        declared.source_type(),
+        declared.target_type(),
+        declared.full_relationship_name(),
         "AuthoredBy",
         "Book",
         "Person",
@@ -218,22 +234,12 @@ async fn loaded_holons(state: &mut TestExecutionState, step_name: &str) -> Holon
 
 fn find_holon_by_key(holons: &HolonCollection, key: &str) -> HolonReference {
     holons
-        .get_members()
-        .iter()
-        .find(|holon| {
-            holon
-                .key()
-                .unwrap_or_else(|error| {
-                    panic!("failed to read holon key while finding {key}: {error:?}")
-                })
-                .map(|actual| actual.0 == key)
-                .unwrap_or(false)
-        })
+        .get_by_key(&MapString::from(key))
+        .unwrap_or_else(|error| panic!("key lookup for {key} failed: {error:?}"))
         .unwrap_or_else(|| panic!("expected loaded holon with key {key}"))
-        .clone()
 }
 
-fn type_names(
+fn property_type_names(
     descriptors: Result<Vec<holons_core::descriptors::PropertyDescriptor>, HolonError>,
 ) -> Vec<String> {
     descriptors
@@ -243,7 +249,9 @@ fn type_names(
         .collect()
 }
 
-fn relationship_names(descriptors: Result<Vec<RelationshipDescriptor>, HolonError>) -> Vec<String> {
+fn relationship_base_names(
+    descriptors: Result<Vec<RelationshipDescriptor>, HolonError>,
+) -> Vec<String> {
     descriptors
         .expect("relationship descriptor list")
         .into_iter()
@@ -264,97 +272,29 @@ fn assert_contains(values: &[String], expected: &str) {
 }
 
 fn assert_relationship_shape(
-    relationship: &impl RelationshipAssertions,
+    base_relationship_name: Result<RelationshipName, HolonError>,
+    source_type: Result<HolonDescriptor, HolonError>,
+    target_type: Result<HolonDescriptor, HolonError>,
+    full_relationship_name: Result<MapString, HolonError>,
     expected_base_name: &str,
     expected_source_type: &str,
     expected_target_type: &str,
     expected_full_name: &str,
 ) {
     assert_eq!(
-        relationship.base_relationship_name().expect("base relationship name").to_string(),
+        base_relationship_name.expect("base relationship name").to_string(),
         expected_base_name
     );
     assert_eq!(
-        relationship
-            .source_type()
-            .expect("source_type")
-            .header()
-            .type_name()
-            .expect("source type_name"),
+        source_type.expect("source_type").header().type_name().expect("source type_name"),
         MapString(expected_source_type.to_string())
     );
     assert_eq!(
-        relationship
-            .target_type()
-            .expect("target_type")
-            .header()
-            .type_name()
-            .expect("target type_name"),
+        target_type.expect("target_type").header().type_name().expect("target type_name"),
         MapString(expected_target_type.to_string())
     );
     assert_eq!(
-        relationship.full_relationship_name().expect("full relationship name"),
+        full_relationship_name.expect("full relationship name"),
         MapString(expected_full_name.to_string())
     );
-}
-
-trait RelationshipAssertions {
-    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError>;
-    fn source_type(&self) -> Result<HolonDescriptor, HolonError>;
-    fn target_type(&self) -> Result<HolonDescriptor, HolonError>;
-    fn full_relationship_name(&self) -> Result<MapString, HolonError>;
-}
-
-impl RelationshipAssertions for RelationshipDescriptor {
-    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
-        RelationshipDescriptor::base_relationship_name(self)
-    }
-
-    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
-        RelationshipDescriptor::source_type(self)
-    }
-
-    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
-        RelationshipDescriptor::target_type(self)
-    }
-
-    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
-        RelationshipDescriptor::full_relationship_name(self)
-    }
-}
-
-impl RelationshipAssertions for holons_core::descriptors::DeclaredRelationshipDescriptor {
-    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
-        self.base_relationship_name()
-    }
-
-    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
-        self.source_type()
-    }
-
-    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
-        self.target_type()
-    }
-
-    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
-        self.full_relationship_name()
-    }
-}
-
-impl RelationshipAssertions for holons_core::descriptors::InverseRelationshipDescriptor {
-    fn base_relationship_name(&self) -> Result<RelationshipName, HolonError> {
-        self.base_relationship_name()
-    }
-
-    fn source_type(&self) -> Result<HolonDescriptor, HolonError> {
-        self.source_type()
-    }
-
-    fn target_type(&self) -> Result<HolonDescriptor, HolonError> {
-        self.target_type()
-    }
-
-    fn full_relationship_name(&self) -> Result<MapString, HolonError> {
-        self.full_relationship_name()
-    }
 }

--- a/tests/sweetests/tests/execution_steps/mod.rs
+++ b/tests/sweetests/tests/execution_steps/mod.rs
@@ -3,6 +3,7 @@ pub mod add_related_holons_executor;
 pub mod begin_transaction_executor;
 pub mod commit_executor;
 pub mod delete_holon_executor;
+pub mod descriptor_verification_executor;
 pub mod ensure_database_count_executor;
 pub mod load_book_person_inverse_test_schema_executor;
 pub mod load_core_schema_executor;

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -16,6 +16,7 @@ pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, Holon
     test_case.add_load_core_schema_step(None)?;
     test_case.add_begin_transaction_step(None, None)?;
     test_case.add_load_book_person_inverse_test_schema_step(None)?;
+    test_case.add_verify_book_person_descriptors_step(None)?;
 
     test_case.finalize(&fixture_context)?;
 

--- a/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
@@ -12,6 +12,8 @@ pub fn load_core_schema_fixture() -> Result<DancesTestCase, HolonError> {
         TestCaseInit::new("load_core_schema", "Load MAP core schema via LoadCoreSchema step");
 
     test_case.add_load_core_schema_step(None)?;
+    test_case.add_verify_core_schema_descriptors_step(None)?;
+    test_case.add_verify_core_schema_descriptor_subtypes_step(None)?;
 
     test_case.finalize(&fixture_context)?;
 


### PR DESCRIPTION
## Summary

Closes #477 

Adds schema-backed descriptor sweetest coverage by extending the two existing schema-load test cases with new descriptor verification steps, and fixes a false `CyclicExtends` error that surfaced during test execution.

- **`load_core_schema`** now runs two new verification steps after schema load:
  - `verify_core_schema_descriptors` — validates foundational `HolonDescriptor` navigation, property/relationship lookup, and accessor behavior over representative loaded core schema elements (`SchemaType`, `HolonType`, `AllowsAdditionalProperties`, `Properties`)
  - `verify_core_schema_descriptor_subtypes` — validates declared/inverse subtype narrowing (`try_into_declared_relationship_descriptor` / `try_into_inverse_relationship_descriptor`) and the `inverse_of()` back-link over real loaded core schema data

- **`load_book_person_inverse_schema`** now runs a new verification step after schema load:
  - `verify_book_person_descriptors` — validates the intended descriptor caller path over representative domain schema elements (`Book`, `Title`, `AuthoredBy`, `Authors`)

## Bug fix: false `CyclicExtends` on loaded schema holons

Running the new steps exposed a latent bug in `SmartReference::reference_id_string`. It was formatting `HolonId` with `Display`, but `LocalId::Display` interprets raw Holochain hash bytes as UTF-8, and falls back to the literal string `"<invalid utf-8>"` for binary hashes. This caused every distinct saved descriptor holon to produce the same identity string, which `walk_extends_chain`'s `HashSet`-based cycle detector immediately mistook for a cycle.

**Fix:** Changed `reference_id_string` to use `{:?}` (Debug), which uses hex encoding and is always collision-resistant.

Also added warning comments at the call site in `walk_extends_chain` and at `LocalId::Display` noting that `Display` is for human-readable diagnostics only and must not be used as an identity or lookup key.

## Test plan

- [x] `npm run test:unit` — unit tests pass
- [x] `npm run test` (in `nix develop`) — full suite including new verification steps passes
- [x] No new schema-load test cases introduced; existing cases extended only
- [x] No exhaustive schema snapshot assertions; coverage is representative