### PR TITLE
493 ai skills pr1    establish repo local agent skills structure and add map issue grounder

### DIFF
--- a/.agents/skills/map-issue-grounder/SKILL.md
+++ b/.agents/skills/map-issue-grounder/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: map-issue-grounder
+description: "Use this skill when the user wants a GitHub Enhancement Issue generated for a specific MAP or map-holons workplan task, track item, PR unit, or wave-plan unit. Trigger on requests to ground a workplan task into an issue, turn a roadmap/spec/implementation-plan item into a GitHub enhancement, or generate, refine, or review a repository-grounded enhancement issue for MAP implementation work. This skill performs Phase 4 repository-grounded issue generation: prompt for copied DevDocs roadmap/spec inputs, inspect the map-holons repository, use the repository's .github/ISSUE_TEMPLATE/enhancement.md template, and produce an implementation-ready Enhancement Issue grounded in existing code."
+---
+
+# MAP Issue Grounder
+
+Generate repository-grounded GitHub Enhancement Issues for MAP implementation work. Treat this as Phase 4 of the MAP development workflow: translate a stabilized DevDocs specification and bounded implementation-plan PR unit into a GitHub issue grounded in the actual `map-holons` repository.
+
+## Trigger phrases
+
+This skill should activate for requests like:
+
+- "ground this workplan task into an issue"
+- "turn this workplan item into a GitHub enhancement"
+- "generate an enhancement issue for this PR unit"
+- "create a repo-grounded issue for this roadmap task"
+- "refine this enhancement issue against the current repo"
+- "review this enhancement issue against the codebase"
+
+Prefer this skill when the user is asking for a GitHub enhancement issue tied to a specific workplan task, not for general issue triage or broad implementation planning.
+
+## Core posture
+
+Use DevDocs artifacts as architectural intent, but do not treat them as sufficient for implementation. Ground every issue in repository reality:
+
+- existing modules, types, APIs, tests, naming conventions, and architectural boundaries
+- current transaction, staging, versioning, validation, dance, command, query, and SDK patterns
+- current gaps between DevDocs intent and implemented substrate
+- the issue structure required by `.github/ISSUE_TEMPLATE/enhancement.md`
+
+Do not invent repository structures. If code context is missing, explicitly mark assumptions and ask for the relevant files or paths. Prefer extending existing patterns over introducing new abstractions.
+
+## Required source artifacts
+
+Before generating the issue, ensure the working context includes these artifacts in the `map-holons` repository:
+
+1. The latest overall workplan copied from `map-dev-docs`:
+   - source: `roadmap/desc-driven-impl-plan.md`
+   - destination: `map-holons/docs/roadmap/desc-driven-impl-plan.md`
+2. The target PR selection from that workplan:
+   - track name or identifier
+   - PR/unit identifier or title
+3. The latest track-specific design spec copied from `map-dev-docs` into an appropriate `map-holons/docs/...` location.
+4. The latest track-specific implementation plan copied from `map-dev-docs` into an appropriate `map-holons/docs/...` location.
+5. The enhancement issue template from the code repository:
+   - `.github/ISSUE_TEMPLATE/enhancement.md`
+
+If any required artifact is missing, prompt the user to copy or identify it before continuing. Do not substitute a generic issue format for the enhancement template.
+
+## Workflow
+
+### 1. Prompt for the latest overall workplan
+
+Ask the user to copy the latest overall workplan from `map-dev-docs` into `map-holons`:
+
+- Copy `map-dev-docs/roadmap/desc-driven-impl-plan.md`
+- To `map-holons/docs/roadmap/desc-driven-impl-plan.md`
+
+Then inspect `map-holons/docs/roadmap/desc-driven-impl-plan.md`.
+
+Use this file to understand:
+
+- available tracks
+- PR/unit identifiers
+- wave sequencing
+- dependency ordering
+- prerequisites and downstream dependents
+- the intended PR boundary for the target issue
+
+### 2. Prompt for target track and PR
+
+Ask the user to specify the target workplan unit:
+
+- track name or identifier
+- PR/unit identifier or title
+
+Then extract from the workplan:
+
+- PR purpose
+- scope boundary
+- dependencies
+- expected deliverables
+- sequencing/wave context
+- any stated non-goals
+
+Preserve the PR boundary. Do not silently expand scope beyond the selected workplan unit.
+
+### 3. Prompt for latest track-specific spec and implementation plan
+
+Based on the selected track, ask the user to copy the latest relevant DevDocs files into the `map-holons` repository.
+
+Ask for both:
+
+- the latest design/specification file for the selected track
+- the latest implementation-plan file for the selected track
+
+The exact destination may vary by repository convention, but prefer a location under `map-holons/docs/` that preserves enough path context to identify the source and track, such as:
+
+- `docs/specs/<track>/...`
+- `docs/roadmap/<track>/...`
+- `docs/devdocs-imports/<track>/...`
+
+After the user copies the files, inspect them and identify their paths in the issue's source/context sections according to the enhancement template.
+
+### 4. Load the enhancement issue template
+
+Read `.github/ISSUE_TEMPLATE/enhancement.md` from `map-holons`.
+
+Use its headings, field names, ordering, checkboxes, comments, and expected structure as the output format.
+
+Do not embed or rely on a default issue skeleton from this skill. The repository template is authoritative.
+
+If the template contains HTML comments, preserve or adapt them only if they are useful in the final issue. Remove instructional comments when producing a clean issue body unless repository convention expects them to remain.
+
+### 5. Restate design intent
+
+Using the selected PR, spec, and implementation plan:
+
+- summarize the capability or architectural change requested
+- identify relevant MAP concepts, such as Holons, Dances, Commands, Queries, Agent Spaces, Trust Channels, membranes, transactions, validation, or SDK surfaces
+- separate conceptual intent from implementation strategy
+- identify constraints, invariants, and non-goals stated in DevDocs
+
+### 6. Inspect repository reality
+
+Inspect the actual `map-holons` codebase for adjacent or affected implementation areas.
+
+Identify:
+
+- relevant modules, structs/classes, traits/interfaces, and functions
+- existing tests and fixtures
+- current API/SDK surfaces
+- related transaction, validation, query, dance, command, or type-system patterns
+- naming conventions and architectural boundaries
+- conflicts or gaps between DevDocs and current implementation
+
+Record only repository-grounded findings. If something is inferred rather than observed, mark it as an assumption.
+
+### 7. Map the PR intent to implementation substrate
+
+Translate the selected PR into concrete repository work:
+
+- affected files/modules if known
+- data structure changes
+- relationship or descriptor changes
+- validation changes
+- runtime behavior changes
+- SDK/API changes
+- test additions or updates
+- migration or compatibility considerations
+
+Distinguish:
+
+- required work for this issue
+- optional enhancements
+- deferred follow-up work
+- out-of-scope items
+
+### 8. Surface questions and reconciliation notes
+
+Identify unresolved questions that materially affect implementation.
+
+Categorize them as:
+
+- blocking
+- non-blocking
+- follow-up
+
+Also identify DevDocs reconciliation notes:
+
+- spec clarifications suggested by repository findings
+- implementation assumptions that DevDocs should validate
+- divergences between design intent and code reality
+- terminology drift or naming inconsistencies
+
+Do not hide design uncertainty inside vague acceptance criteria.
+
+### 9. Generate the Enhancement Issue
+
+Produce a complete issue body using `.github/ISSUE_TEMPLATE/enhancement.md` as the structure.
+
+The issue must be:
+
+- scoped to the selected track + PR unit
+- grounded in current repository reality
+- clear enough for a coding agent to create an implementation plan
+- explicit about source documents inspected
+- explicit about dependencies and sequencing
+- testable through concrete acceptance criteria
+
+Do not include code unless the user asks for implementation details in the issue.
+
+## Quality rules
+
+- Use the repository's enhancement template, not a generic format.
+- Preserve MAP terminology exactly when terms appear canonical.
+- Flag possible terminology drift rather than silently normalizing it.
+- Make acceptance criteria observable and testable.
+- Avoid vague criteria such as "works correctly" or "handles all cases".
+- Keep scope to one coherent PR unless the selected workplan unit is already too large.
+- Separate must-implement-now from should-defer.
+- Prefer current repository patterns over new abstractions.
+- Record assumptions when repository evidence is incomplete.
+
+## Split recommendation rule
+
+Recommend splitting the selected PR/unit only when repository grounding shows it is not a coherent single issue. Split when any of these are true:
+
+- it changes unrelated subsystems
+- it requires more than one independent migration path
+- it mixes foundational infrastructure with product-facing convenience APIs
+- tests would need unrelated fixtures or harnesses
+- acceptance criteria cannot be made coherent under one PR
+
+When recommending a split, provide the smallest coherent sequence of issues and explain dependencies, but still generate the best bounded issue possible for the requested unit.
+
+## Reconciliation emphasis
+
+The highest-value output is not a generic issue. The highest-value output records the discovered fit between:
+
+- what the copied DevDocs roadmap says this PR should do
+- what the copied track spec says should exist
+- what the copied implementation plan expects
+- what the `map-holons` codebase already supports
+- what must be added now
+- what should be deferred
+- what DevDocs may need to clarify

--- a/.agents/skills/map-issue-grounder/agents/openai.yaml
+++ b/.agents/skills/map-issue-grounder/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: MAP Issue Grounder
+  short_description: Ground MAP DevDocs PR units into map-holons Enhancement Issues.
+  icon: file-text
+  brand_color: '#4b5563'

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ settings.json
 
 # Legacy / deprecated directories
 /shared_crates/holons_core_old/
+
+# Local copied planning/spec docs
+docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md
+
+## Project purpose
+
+This repository includes repo-local Agent Skills that follow the Agent Skills standard. The skills live alongside the `map-holons` codebase so they can be versioned, reviewed, and evolved together with the implementation and design docs they depend on.
+
+The repository copy of each skill is the canonical shared source for all contributors, including contributors using Codex or Claude Code. Tool-specific metadata may live inside a skill directory, but the skill's core instructions should remain as tool-neutral as possible.
+
+## Repository layout
+
+- `.agents/skills/<skill-name>/` — canonical repo-local skill directory.
+- `.agents/skills/<skill-name>/SKILL.md` — required skill entrypoint.
+- `.agents/skills/<skill-name>/agents/openai.yaml` — optional OpenAI/Codex-specific metadata.
+- `.agents/skills/<skill-name>/references/` — optional supporting documentation.
+- `.agents/skills/<skill-name>/scripts/` — optional executable helpers.
+- `.agents/skills/<skill-name>/assets/` — optional templates, examples, or other static files.
+
+## Tool usage expectations
+
+- Keep the repo-local skill directory as the canonical shared definition.
+- Write `SKILL.md` so the main workflow and constraints are useful to both Codex and Claude Code.
+- Put tool-specific UI or metadata files under the skill directory without making the main instructions depend on them.
+- Do not assume any tool will automatically discover repo-local skills from `.agents/skills/`.
+
+For Codex specifically:
+
+- repo-local skills may be used when explicitly referenced by name or path
+- automatic first-class skill discovery generally requires installing or symlinking the skill into `~/.codex/skills/` and restarting Codex
+
+For Claude Code specifically:
+
+- keep the shared repo instructions readable and self-sufficient
+- avoid putting essential workflow rules only in Codex-specific metadata files
+
+## Skill authoring rules
+
+- Use lowercase, kebab-case skill directory names.
+- Every skill must include `SKILL.md`.
+- Keep `SKILL.md` concise and operational.
+- Put detailed background material in `references/`.
+- Put deterministic or fragile repeatable logic in `scripts/`.
+- Put reusable templates and static files in `assets/`.
+- Do not include generated build artifacts, dependency folders, secrets, or large binary files in skills.
+- Prefer examples that show exact expected inputs and outputs.
+
+## `SKILL.md` requirements
+
+Each `SKILL.md` must start with YAML frontmatter:
+
+```yaml
+---
+name: example-skill
+description: concise description of what the skill does and when to use it.
+---
+```
+
+Rules:
+
+- `name` must match the skill directory name.
+- `name` must be lowercase kebab-case.
+- `description` must explain when the skill should be used.
+- The body should describe the workflow, constraints, and any resources to consult.
+
+## Agent metadata
+
+If present, `agents/openai.yaml` should contain OpenAI-specific UI metadata, for example:
+
+```yaml
+interface:
+  display_name: Example Skill
+  short_description: Helps with a repeatable task.
+```
+
+## Validation checklist
+
+Before considering a skill complete:
+
+- Confirm the skill has `SKILL.md`.
+- Confirm frontmatter includes only `name` and `description`.
+- Confirm the skill name is lowercase kebab-case.
+- Confirm the description is specific enough to trigger the skill appropriately.
+- Remove unused placeholder files.
+- Run or inspect any scripts added under `scripts/`.
+- Ensure no secrets, credentials, private keys, or large generated files are committed.
+
+## Coding conventions
+
+- Keep scripts small, readable, and deterministic.
+- Prefer Python or shell scripts only when procedural reliability is needed.
+- Include clear usage comments at the top of scripts.
+- Fail loudly with actionable error messages.
+
+## Git conventions
+
+- Keep commits focused.
+- Do not mix unrelated skill changes in one commit.
+- When modifying a skill, update its supporting files and `SKILL.md` together if needed.
+- Do not rewrite history unless explicitly asked.
+
+## What not to do
+
+- Do not place multiple unrelated skills in one skill directory.
+- Do not put OpenAI metadata at the repository root.
+- Do not duplicate long reference material inside `SKILL.md`.
+- Do not make the core skill workflow understandable only to one tool when the repo skill is intended to be shared.
+- Do not assume a skill is complete if it has not been checked against the validation checklist.


### PR DESCRIPTION
## Summary

Establish a repo-local Agent Skills structure in `map-holons` and add `map-issue-grounder` as the first shared skill.

## What Changed

- added a canonical repo-local skills location under `.agents/skills/`
- added the first skill, `map-issue-grounder`
- added OpenAI/Codex metadata for that skill in `agents/openai.yaml`
- added `AGENTS.md` guidance for authoring and maintaining shared repo-local skills
- updated `.gitignore` to keep copied local planning/spec docs out of the repo

## Why

This creates a shared, versioned place for agent skills that can evolve alongside the codebase and support contributors using either Codex or Claude Code. It also provides a concrete first example skill for generating repository-grounded GitHub enhancement issues from MAP workplan artifacts.

## Scope

This PR is limited to:

- repo-local skill structure
- shared authoring guidance
- the initial `map-issue-grounder` skill

It does not introduce runtime code changes or implementation work outside the skill setup.

## Validation

- confirmed the repo-local skill structure is present and coherent
- confirmed `map-issue-grounder` includes a valid `SKILL.md`
- confirmed `agents/openai.yaml` is present for Codex/OpenAI metadata
- confirmed `AGENTS.md` now documents shared-tool usage expectations for both Codex and Claude Code
- confirmed copied local docs are excluded from tracking via `.gitignore`
