### PR TITLE
First draft of value constraint schema types is complete.

### DIFF
--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,14 +1,14 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-11T11:43:23",
+    "generated_at": "2026-05-11T17:23:28",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-abstract-value-types.csv"
     ],
     "load_with": [
       "MAP Schema Types-map-core-schema-value-constraint-types.json",
-      "MAP Schema Types-map-core-schema-operator-schema.json",
+      "MAP Schema Types-map-core-schema-operator-types.json",
       "MAP Schema Types-map-core-schema-root.json",
       "MAP Schema Types-map-core-schema-keyrules-schema.json"
     ]
@@ -131,7 +131,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(StringValueType)-[ConstrainedBy]->(StringValueConstraint)"
+            "$ref": "#(StringValueType)-[Constraints]->(StringValueConstraint)"
           }
         }
       ]
@@ -181,7 +181,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)"
+            "$ref": "#(IntegerValueType)-[Constraints]->(IntegerValueConstraint)"
           }
         }
       ]
@@ -259,7 +259,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)"
+            "$ref": "#(BytesValueType)-[Constraints]->(BytesValueConstraint)"
           }
         }
       ]
@@ -370,7 +370,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)"
+            "$ref": "#(ValueArrayValueType)-[Constraints]->(ValueArrayConstraint)"
           }
         }
       ]

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,12 +1,13 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-11T11:43:23",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-abstract-value-types.csv"
     ],
     "load_with": [
+      "MAP Schema Types-map-core-schema-value-constraint-types.json",
       "MAP Schema Types-map-core-schema-operator-schema.json",
       "MAP Schema Types-map-core-schema-root.json",
       "MAP Schema Types-map-core-schema-keyrules-schema.json"
@@ -126,6 +127,12 @@
           "target": {
             "$ref": "#TypeNameRule"
           }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(StringValueType)-[ConstrainedBy]->(StringValueConstraint)"
+          }
         }
       ]
     },
@@ -169,6 +176,12 @@
           "name": "UsesKeyRule",
           "target": {
             "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)"
           }
         }
       ]
@@ -241,6 +254,12 @@
           "name": "UsesKeyRule",
           "target": {
             "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)"
           }
         }
       ]
@@ -346,6 +365,12 @@
           "name": "UsesKeyRule",
           "target": {
             "$ref": "#TypeNameRule"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)"
           }
         }
       ]

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-11T11:43:23",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-root.csv"

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-11T11:52:06",
+    "generated_at": "2026-05-11T16:56:56",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-value-constraint-types.csv"
@@ -498,7 +498,45 @@
         {
           "name": "InstanceProperties",
           "target": {
-            "$ref": "#ConstraintUniqueItems.PropertyType"
+            "$ref": "#ConstraintEnabled.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "OrderedItems.ValueArrayConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "OrderedItems",
+        "type_name_plural": "OrderedItemsConstraints",
+        "display_name": "Ordered Items ",
+        "display_name_plural": "Ordered Items Constraints",
+        "instance_type_kind": "Holon",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintEnabled.PropertyType"
           }
         }
       ]
@@ -699,15 +737,15 @@
       ]
     },
     {
-      "key": "ConstraintUniqueItems.PropertyType",
+      "key": "ConstraintEnabled.PropertyType",
       "type": "#TypeDescriptor",
       "properties": {
-        "type_name": "ConstraintUniqueItems",
-        "type_name_plural": "ConstraintUniqueItems",
-        "display_name": "Constraint Unique Items",
-        "display_name_plural": "UniqueItems Constraints",
+        "type_name": "ConstraintEnabled",
+        "type_name_plural": "ConstraintsEnabled",
+        "display_name": "Constraint Enabled",
+        "display_name_plural": "Constraints Enabled",
         "instance_type_kind": "Property",
-        "description": "If all contained items must be unique.",
+        "description": "Boolean parameter indicating whether a boolean-style constraint rule is active.",
         "is_abstract_type": false
       },
       "relationships": [
@@ -738,13 +776,13 @@
       ]
     },
     {
-      "key": "(StringValueType)-[ConstrainedBy]->(StringValueConstraint)",
+      "key": "(StringValueType)-[Constraints]->(StringValueConstraint)",
       "type": "#TypeDescriptor",
       "properties": {
-        "type_name": "ConstrainedBy",
-        "type_name_plural": "ConstrainedBys",
-        "display_name": "ConstrainedBy Relationship",
-        "display_name_plural": "ConstrainedBy Relationship",
+        "type_name": "Constraints",
+        "type_name_plural": "Constraints",
+        "display_name": "Constraints Relationship",
+        "display_name_plural": "Constraints Relationships",
         "instance_type_kind": "Relationship",
         "description": "Attaches string-specific value constraints to a string value type.",
         "is_abstract_type": false,
@@ -788,13 +826,13 @@
       ]
     },
     {
-      "key": "(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)",
+      "key": "(IntegerValueType)-[Constraints]->(IntegerValueConstraint)",
       "type": "#TypeDescriptor",
       "properties": {
-        "type_name": "ConstrainedBy",
-        "type_name_plural": "ConstrainedBys",
-        "display_name": "ConstrainedBy Relationship",
-        "display_name_plural": "ConstrainedBy Relationship",
+        "type_name": "Constraints",
+        "type_name_plural": "Constraints",
+        "display_name": "Constraints Relationship",
+        "display_name_plural": "Constraints Relationships",
         "instance_type_kind": "Relationship",
         "description": "Attaches integer-specific value constraints to an integer value type.",
         "is_abstract_type": false,
@@ -838,13 +876,13 @@
       ]
     },
     {
-      "key": "(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)",
+      "key": "(BytesValueType)-[Constraints]->(BytesValueConstraint)",
       "type": "#TypeDescriptor",
       "properties": {
-        "type_name": "ConstrainedBy",
-        "type_name_plural": "ConstrainedBys",
-        "display_name": "ConstrainedBy Relationship",
-        "display_name_plural": "ConstrainedBy Relationship",
+        "type_name": "Constraints",
+        "type_name_plural": "Constraints",
+        "display_name": "Constraints Relationship",
+        "display_name_plural": "Constraints Relationships",
         "instance_type_kind": "Relationship",
         "description": "Attaches bytes-specific value constraints to a bytes value type.",
         "is_abstract_type": false,
@@ -888,13 +926,13 @@
       ]
     },
     {
-      "key": "(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)",
+      "key": "(ValueArrayValueType)-[Constraints]->(ValueArrayConstraint)",
       "type": "#TypeDescriptor",
       "properties": {
-        "type_name": "ConstrainedBy",
-        "type_name_plural": "ConstrainedBys",
-        "display_name": "ConstrainedBy Relationship",
-        "display_name_plural": "ConstrainedBy Relationship",
+        "type_name": "Constraints",
+        "type_name_plural": "Constraints",
+        "display_name": "Constraints Relationship",
+        "display_name_plural": "Constraints Relationships",
         "instance_type_kind": "Relationship",
         "description": "Attaches value-array-specific constraints to a value array type.",
         "is_abstract_type": false,
@@ -946,7 +984,7 @@
         "display_name": "Constrains Relationship",
         "display_name_plural": "Constrains Relationships",
         "instance_type_kind": "Relationship",
-        "description": "Inverse of ConstrainedBy, from a string value constraint to the string value type it constrains.",
+        "description": "Inverse of Constraints, from a string value constraint to the string value type it constrains.",
         "is_abstract_type": false,
         "is_definitional": false,
         "is_ordered": false,
@@ -976,7 +1014,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(StringValueType)-[ConstrainedBy]->(StringValueConstraint)"
+            "$ref": "#(StringValueType)-[Constraints]->(StringValueConstraint)"
           }
         },
         {
@@ -1002,7 +1040,7 @@
         "display_name": "Constrains Relationship",
         "display_name_plural": "Constrains Relationships",
         "instance_type_kind": "Relationship",
-        "description": "Inverse of ConstrainedBy, from an integer value constraint to the integer value type it constrains.",
+        "description": "Inverse of Constraints, from an integer value constraint to the integer value type it constrains.",
         "is_abstract_type": false,
         "is_definitional": false,
         "is_ordered": false,
@@ -1032,7 +1070,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)"
+            "$ref": "#(IntegerValueType)-[Constraints]->(IntegerValueConstraint)"
           }
         },
         {
@@ -1058,7 +1096,7 @@
         "display_name": "Constrains Relationship",
         "display_name_plural": "Constrains Relationships",
         "instance_type_kind": "Relationship",
-        "description": "Inverse of ConstrainedBy, from a bytes value constraint to the bytes value type it constrains.",
+        "description": "Inverse of Constraints, from a bytes value constraint to the bytes value type it constrains.",
         "is_abstract_type": false,
         "is_definitional": false,
         "is_ordered": false,
@@ -1088,7 +1126,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)"
+            "$ref": "#(BytesValueType)-[Constraints]->(BytesValueConstraint)"
           }
         },
         {
@@ -1114,7 +1152,7 @@
         "display_name": "Constrains Relationship",
         "display_name_plural": "Constrains Relationships",
         "instance_type_kind": "Relationship",
-        "description": "Inverse of ConstrainedBy, from a value array constraint to the value array type it constrains.",
+        "description": "Inverse of Constraints, from a value array constraint to the value array type it constrains.",
         "is_abstract_type": false,
         "is_definitional": false,
         "is_ordered": false,
@@ -1144,7 +1182,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)"
+            "$ref": "#(ValueArrayValueType)-[Constraints]->(ValueArrayConstraint)"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,0 +1,1165 @@
+{
+  "meta": {
+    "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
+    "generated_at": "2026-05-11T11:52:06",
+    "export_mode": "by-file",
+    "source_files": [
+      "MAP Schema Types-map-core-schema-value-constraint-types.csv"
+    ],
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+    ]
+  },
+  "holons": [
+    {
+      "key": "ValueConstraintType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ValueConstraintType",
+        "type_name_plural": "ValueConstraintTypes",
+        "display_name": "Value Constraint Type",
+        "display_name_plural": "Value Constraint Types",
+        "instance_type_kind": "Holon",
+        "description": "Abstract holon type for constraints that refine the accepted values of a ValueType.",
+        "is_abstract_type": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "StringValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "StringValueConstraint",
+        "type_name_plural": "StringValueConstraints",
+        "display_name": "String Value Constraint",
+        "display_name_plural": "String Value Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Abstract constraint-family anchor for string value constraints.",
+        "is_abstract_type": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueConstraintType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "IntegerValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "IntegerValueConstraint",
+        "type_name_plural": "IntegerValueConstraints",
+        "display_name": "Integer Value Constraint",
+        "display_name_plural": "Integer Value Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Abstract constraint-family anchor for integer value constraints.",
+        "is_abstract_type": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueConstraintType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "BytesValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "BytesValueConstraint",
+        "type_name_plural": "BytesValueConstraints",
+        "display_name": "Bytes Value Constraint",
+        "display_name_plural": "Bytes Value Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Abstract constraint-family anchor for byte sequence value constraints.",
+        "is_abstract_type": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueConstraintType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ValueArrayConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ValueArrayConstraint",
+        "type_name_plural": "ValueArrayConstraints",
+        "display_name": "Value Array Constraint",
+        "display_name_plural": "Value Array Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Abstract constraint-family anchor for value array constraints.",
+        "is_abstract_type": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueConstraintType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "MinimumLength.StringValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MinimumLength",
+        "type_name_plural": "MinimumLengths",
+        "display_name": "Minimum String Length",
+        "display_name_plural": "Minimum String Lengths",
+        "instance_type_kind": "Holon",
+        "description": "Requires string values to have at least the configured number of characters.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#StringValueConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintLength.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "MaximumLength.StringValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MaximumLength",
+        "type_name_plural": "MaximumLengths",
+        "display_name": "Maximum String Length",
+        "display_name_plural": "Maximum String Lengths",
+        "instance_type_kind": "Holon",
+        "description": "Requires string values to have at most the configured number of characters.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#StringValueConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintLength.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Pattern.StringValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Pattern",
+        "type_name_plural": "Patterns",
+        "display_name": "String Pattern Constraint",
+        "display_name_plural": "String Pattern Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Requires string values to match the configured regular expression pattern.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#StringValueConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#Pattern.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "MinimumValue.IntegerValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MinimumValue",
+        "type_name_plural": "MinimumValues",
+        "display_name": "Minimum Integer Value",
+        "display_name_plural": "Minimum Integer Values",
+        "instance_type_kind": "Holon",
+        "description": "Requires integer values to be greater than, or optionally equal to, the configured minimum.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#IntegerValueConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "#ConstraintIntegerValue.PropertyType"
+            },
+            {
+              "$ref": "#ConstraintIsInclusive.PropertyType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "MaximumValue.IntegerValueConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MaximumValue",
+        "type_name_plural": "MaximumValues",
+        "display_name": "Maximum Integer Value",
+        "display_name_plural": "Maximum Integer Values",
+        "instance_type_kind": "Holon",
+        "description": "Requires integer values to be less than, or optionally equal to, the configured maximum.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#IntegerValueConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "#ConstraintIntegerValue.PropertyType"
+            },
+            {
+              "$ref": "#ConstraintIsInclusive.PropertyType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "MinimumItems.ValueArrayConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MinimumItems",
+        "type_name_plural": "MinimumItemsConstraints",
+        "display_name": "Minimum Items",
+        "display_name_plural": "Minimum Items Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Requires value arrays to contain at least the configured number of elements.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintItemCount.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "MaximumItems.ValueArrayConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "MaximumItems",
+        "type_name_plural": "MaximumItemsConstraints",
+        "display_name": "Maximum Items",
+        "display_name_plural": "Maximum Items Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Requires value arrays to contain no more than the configured number of elements.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintItemCount.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "UniqueItems.ValueArrayConstraint",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "UniqueItems",
+        "type_name_plural": "UniqueItemsConstraints",
+        "display_name": "Unique Items",
+        "display_name_plural": "Unique Items Constraints",
+        "instance_type_kind": "Holon",
+        "description": "Requires value arrays to contain no duplicate elements.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "#ConstraintUniqueItems.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ConstraintLength.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstraintLength",
+        "type_name_plural": "ConstraintLengths",
+        "display_name": "Constraint Length",
+        "display_name_plural": "Constraint Lengths",
+        "instance_type_kind": "Property",
+        "description": "Limit of allowed character count for a string value.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapIntegerValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Pattern.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Pattern",
+        "type_name_plural": "Patterns",
+        "display_name": "Pattern",
+        "display_name_plural": "Patterns",
+        "instance_type_kind": "Property",
+        "description": "An allowed pattern for a string value.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapStringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ConstraintIntegerValue.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstraintIntegerValue",
+        "type_name_plural": "ConstraintIntegerValues",
+        "display_name": "Constraint Integer Value",
+        "display_name_plural": "Constraint Integer Values",
+        "instance_type_kind": "Property",
+        "description": "Limit of an integer value.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapIntegerValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ConstraintItemCount.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstraintItemCount",
+        "type_name_plural": "ConstraintItemCounts",
+        "display_name": "Constraint Item Count",
+        "display_name_plural": "Constraint Item Counts",
+        "instance_type_kind": "Property",
+        "description": "Limit on the number of items in an array.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapIntegerValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ConstraintIsInclusive.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstraintIsInclusive",
+        "type_name_plural": "ConstraintIsInclusives",
+        "display_name": "Constraint Is Inclusive",
+        "display_name_plural": "IsInclusive Constraints",
+        "instance_type_kind": "Property",
+        "description": "If the limit value included in the allowed range.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapBooleanValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ConstraintUniqueItems.PropertyType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstraintUniqueItems",
+        "type_name_plural": "ConstraintUniqueItems",
+        "display_name": "Constraint Unique Items",
+        "display_name_plural": "UniqueItems Constraints",
+        "instance_type_kind": "Property",
+        "description": "If all contained items must be unique.",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#PropertyType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "#MapBooleanValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(StringValueType)-[ConstrainedBy]->(StringValueConstraint)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstrainedBy",
+        "type_name_plural": "ConstrainedBys",
+        "display_name": "ConstrainedBy Relationship",
+        "display_name_plural": "ConstrainedBy Relationship",
+        "instance_type_kind": "Relationship",
+        "description": "Attaches string-specific value constraints to a string value type.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#StringValueType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#StringValueConstraint"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstrainedBy",
+        "type_name_plural": "ConstrainedBys",
+        "display_name": "ConstrainedBy Relationship",
+        "display_name_plural": "ConstrainedBy Relationship",
+        "instance_type_kind": "Relationship",
+        "description": "Attaches integer-specific value constraints to an integer value type.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#IntegerValueType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#IntegerValueConstraint"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstrainedBy",
+        "type_name_plural": "ConstrainedBys",
+        "display_name": "ConstrainedBy Relationship",
+        "display_name_plural": "ConstrainedBy Relationship",
+        "instance_type_kind": "Relationship",
+        "description": "Attaches bytes-specific value constraints to a bytes value type.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#BytesValueType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#BytesValueConstraint"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "ConstrainedBy",
+        "type_name_plural": "ConstrainedBys",
+        "display_name": "ConstrainedBy Relationship",
+        "display_name_plural": "ConstrainedBy Relationship",
+        "instance_type_kind": "Relationship",
+        "description": "Attaches value-array-specific constraints to a value array type.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#ValueArrayValueType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(StringValueConstraint)-[Constrains]->(StringValueType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Constrains",
+        "type_name_plural": "Constrains",
+        "display_name": "Constrains Relationship",
+        "display_name_plural": "Constrains Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Inverse of ConstrainedBy, from a string value constraint to the string value type it constrains.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(StringValueType)-[ConstrainedBy]->(StringValueConstraint)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#StringValueConstraint"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#StringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(IntegerValueConstraint)-[Constrains]->(IntegerValueType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Constrains",
+        "type_name_plural": "Constrains",
+        "display_name": "Constrains Relationship",
+        "display_name_plural": "Constrains Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Inverse of ConstrainedBy, from an integer value constraint to the integer value type it constrains.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(IntegerValueType)-[ConstrainedBy]->(IntegerValueConstraint)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#IntegerValueConstraint"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#IntegerValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(BytesValueConstraint)-[Constrains]->(BytesValueType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Constrains",
+        "type_name_plural": "Constrains",
+        "display_name": "Constrains Relationship",
+        "display_name_plural": "Constrains Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Inverse of ConstrainedBy, from a bytes value constraint to the bytes value type it constrains.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(BytesValueType)-[ConstrainedBy]->(BytesValueConstraint)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#BytesValueConstraint"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#BytesValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(ValueArrayConstraint)-[Constrains]->(ValueArrayValueType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Constrains",
+        "type_name_plural": "Constrains",
+        "display_name": "Constrains Relationship",
+        "display_name_plural": "Constrains Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Inverse of ConstrainedBy, from a value array constraint to the value array type it constrains.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.6"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(ValueArrayValueType)-[ConstrainedBy]->(ValueArrayConstraint)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#ValueArrayConstraint"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#ValueArrayValueType"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-11T16:56:56",
+    "generated_at": "2026-05-11T17:23:28",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-value-constraint-types.csv"
@@ -509,9 +509,10 @@
       "properties": {
         "type_name": "OrderedItems",
         "type_name_plural": "OrderedItemsConstraints",
-        "display_name": "Ordered Items ",
+        "display_name": "Ordered Items",
         "display_name_plural": "Ordered Items Constraints",
         "instance_type_kind": "Holon",
+        "description": "Requires value arrays to preserve item order as part of their semantic value.",
         "is_abstract_type": false
       },
       "relationships": [
@@ -741,9 +742,9 @@
       "type": "#TypeDescriptor",
       "properties": {
         "type_name": "ConstraintEnabled",
-        "type_name_plural": "ConstraintsEnabled",
+        "type_name_plural": "ConstraintEnabledValues",
         "display_name": "Constraint Enabled",
-        "display_name_plural": "Constraints Enabled",
+        "display_name_plural": "Constraint Enabled Values",
         "instance_type_kind": "Property",
         "description": "Boolean parameter indicating whether a boolean-style constraint rule is active.",
         "is_abstract_type": false

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -29,12 +29,12 @@ pub struct CoreSchemaLoadMetrics {
 }
 
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
-    staged: 209,
-    committed: 209,
-    links_created: 1123,
+    staged: 210,
+    committed: 210,
+    links_created: 1128,
     errors: 0,
     total_bundles: 9,
-    total_loader_holons: 209,
+    total_loader_holons: 210,
 };
 
 /// Absolute paths to all core schema import files used for loader-client testing.

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const CORE_SCHEMA_RELATIVE_PATHS: [&str; 8] = [
+const CORE_SCHEMA_RELATIVE_PATHS: [&str; 9] = [
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json",
@@ -15,6 +15,7 @@ const CORE_SCHEMA_RELATIVE_PATHS: [&str; 8] = [
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json",
+    "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json"
 ];
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -28,12 +29,12 @@ pub struct CoreSchemaLoadMetrics {
 }
 
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
-    staged: 182,
-    committed: 182,
-    links_created: 975,
+    staged: 209,
+    committed: 209,
+    links_created: 1123,
     errors: 0,
-    total_bundles: 8,
-    total_loader_holons: 182,
+    total_bundles: 9,
+    total_loader_holons: 209,
 };
 
 /// Absolute paths to all core schema import files used for loader-client testing.


### PR DESCRIPTION
## Summary

Implements PR3a schema/ontology support for first-class MAP value constraints.  Closes #489.

This adds a schema-only constraint layer for ValueTypes, including abstract constraint anchors, family-specific constraint types, strongly typed constraint relationships, and initial concrete constraint descriptors for integer, string, and value-array semantics.

## Changes

- Added abstract `ValueConstraintType`
- Added family constraint anchors:
  - `StringValueConstraint`
  - `IntegerValueConstraint`
  - `BytesValueConstraint`
  - `ValueArrayConstraint`
- Added family-typed `ConstrainedBy` / `Constrains` relationships for:
  - `StringValueType`
  - `IntegerValueType`
  - `BytesValueType`
  - `ValueArrayValueType`
- Added initial concrete constraints:
  - `MinimumValue`
  - `MaximumValue`
  - `MinimumLength`
  - `MaximumLength`
  - `Pattern`
  - `MinimumItems`
  - `MaximumItems`
  - `UniqueItems`
- Added semantic constraint parameter property types for length, integer bounds, item counts, inclusivity, uniqueness, and pattern values
- Updated abstract value type schema so value-family types expose the appropriate constraint relationship

## Notes

This PR is intentionally schema-only. Runtime validation execution, deterministic validation walks, family-specific runtime enums, tests for executable validation behavior, and error taxonomy updates are deferred to PR3b.

`OrderedItemsConstraint` is intentionally postponed because ordering semantics require additional core model work beyond this PR’s scope.