### PR TITLE
473 descriptors    pr4    introduce commanddescriptor and schema backed command affordance anchoring

### DIFF
--- a/host/crates/map_commands_contract/src/command_lifecycle_policy.rs
+++ b/host/crates/map_commands_contract/src/command_lifecycle_policy.rs
@@ -7,16 +7,16 @@ pub enum MutationClassification {
     RuntimeDetected,
 }
 
-/// Static metadata describing a command's lifecycle requirements.
+/// Static policy describing a command's lifecycle requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CommandDescriptor {
+pub struct CommandLifecyclePolicy {
     pub mutation: MutationClassification,
     pub requires_open_tx: bool,
     pub requires_commit_guard: bool,
 }
 
-impl CommandDescriptor {
-    /// Read-only descriptor for transaction-scoped commands.
+impl CommandLifecyclePolicy {
+    /// Read-only policy for transaction-scoped commands.
     ///
     /// All transaction commands require an open transaction — even lookups —
     /// because a committed transaction must reject all further operations.
@@ -28,7 +28,7 @@ impl CommandDescriptor {
         }
     }
 
-    /// Read-only descriptor for holon-scoped commands.
+    /// Read-only policy for holon-scoped commands.
     ///
     /// Holon reads do not require an open transaction because references from
     /// committed transactions remain alive and accessible.

--- a/host/crates/map_commands_contract/src/holon_command.rs
+++ b/host/crates/map_commands_contract/src/holon_command.rs
@@ -5,7 +5,7 @@ use core_types::{PropertyName, RelationshipName};
 use holons_core::core_shared_objects::transactions::TransactionContext;
 use holons_core::reference_layer::HolonReference;
 
-use super::CommandDescriptor;
+use super::CommandLifecyclePolicy;
 
 /// Holon-scoped domain command.
 ///
@@ -28,11 +28,13 @@ pub enum HolonAction {
 }
 
 impl HolonAction {
-    pub fn descriptor(&self) -> CommandDescriptor {
+    pub fn policy(&self) -> CommandLifecyclePolicy {
         match self {
-            HolonAction::Read(ReadableHolonAction::CloneHolon) => CommandDescriptor::mutating(),
-            HolonAction::Read(_) => CommandDescriptor::holon_read_only(),
-            HolonAction::Write(_) => CommandDescriptor::mutating(),
+            HolonAction::Read(ReadableHolonAction::CloneHolon) => {
+                CommandLifecyclePolicy::mutating()
+            }
+            HolonAction::Read(_) => CommandLifecyclePolicy::holon_read_only(),
+            HolonAction::Write(_) => CommandLifecyclePolicy::mutating(),
         }
     }
 

--- a/host/crates/map_commands_contract/src/lib.rs
+++ b/host/crates/map_commands_contract/src/lib.rs
@@ -1,11 +1,11 @@
-mod command_descriptor;
+mod command_lifecycle_policy;
 mod holon_command;
 mod map_command;
 mod map_result;
 mod space_command;
 mod transaction_command;
 
-pub use command_descriptor::*;
+pub use command_lifecycle_policy::*;
 pub use holon_command::*;
 pub use map_command::*;
 pub use map_result::*;

--- a/host/crates/map_commands_contract/src/map_command.rs
+++ b/host/crates/map_commands_contract/src/map_command.rs
@@ -1,4 +1,4 @@
-use super::{CommandDescriptor, HolonCommand, SpaceCommand, TransactionCommand};
+use super::{CommandLifecyclePolicy, HolonCommand, SpaceCommand, TransactionCommand};
 
 /// Post-binding domain command.
 ///
@@ -12,11 +12,11 @@ pub enum MapCommand {
 }
 
 impl MapCommand {
-    pub fn descriptor(&self) -> CommandDescriptor {
+    pub fn policy(&self) -> CommandLifecyclePolicy {
         match self {
-            MapCommand::Space(cmd) => cmd.descriptor(),
-            MapCommand::Transaction(cmd) => cmd.action.descriptor(),
-            MapCommand::Holon(cmd) => cmd.action.descriptor(),
+            MapCommand::Space(cmd) => cmd.policy(),
+            MapCommand::Transaction(cmd) => cmd.action.policy(),
+            MapCommand::Holon(cmd) => cmd.action.policy(),
         }
     }
 

--- a/host/crates/map_commands_contract/src/space_command.rs
+++ b/host/crates/map_commands_contract/src/space_command.rs
@@ -1,4 +1,4 @@
-use super::{CommandDescriptor, MutationClassification};
+use super::{CommandLifecyclePolicy, MutationClassification};
 
 /// Space-scoped domain commands.
 ///
@@ -10,9 +10,9 @@ pub enum SpaceCommand {
 }
 
 impl SpaceCommand {
-    pub fn descriptor(&self) -> CommandDescriptor {
+    pub fn policy(&self) -> CommandLifecyclePolicy {
         match self {
-            SpaceCommand::BeginTransaction => CommandDescriptor {
+            SpaceCommand::BeginTransaction => CommandLifecyclePolicy {
                 mutation: MutationClassification::Mutating,
                 requires_open_tx: false,
                 requires_commit_guard: false,

--- a/host/crates/map_commands_contract/src/tests.rs
+++ b/host/crates/map_commands_contract/src/tests.rs
@@ -2,52 +2,52 @@ use base_types::{BaseValue, MapString};
 use core_types::{LocalId, PropertyName};
 
 use crate::{
-    CommandDescriptor, HolonAction, MutationClassification, ReadableHolonAction, SpaceCommand,
+    CommandLifecyclePolicy, HolonAction, MutationClassification, ReadableHolonAction, SpaceCommand,
     TransactionAction, WritableHolonAction,
 };
 
 #[test]
-fn space_begin_transaction_descriptor() {
-    let desc = SpaceCommand::BeginTransaction.descriptor();
-    assert_eq!(desc.mutation, MutationClassification::Mutating);
-    assert!(!desc.requires_open_tx);
-    assert!(!desc.requires_commit_guard);
+fn space_begin_transaction_policy() {
+    let policy = SpaceCommand::BeginTransaction.policy();
+    assert_eq!(policy.mutation, MutationClassification::Mutating);
+    assert!(!policy.requires_open_tx);
+    assert!(!policy.requires_commit_guard);
 }
 
 #[test]
-fn transaction_action_descriptors() {
-    assert_eq!(TransactionAction::Commit.descriptor(), CommandDescriptor::mutating_with_guard());
+fn transaction_action_policies() {
+    assert_eq!(TransactionAction::Commit.policy(), CommandLifecyclePolicy::mutating_with_guard());
     assert_eq!(
-        TransactionAction::StagedCount.descriptor(),
-        CommandDescriptor::transaction_read_only()
+        TransactionAction::StagedCount.policy(),
+        CommandLifecyclePolicy::transaction_read_only()
     );
     assert_eq!(
-        TransactionAction::TransientCount.descriptor(),
-        CommandDescriptor::transaction_read_only()
+        TransactionAction::TransientCount.policy(),
+        CommandLifecyclePolicy::transaction_read_only()
     );
     assert_eq!(
-        TransactionAction::GetAllHolons.descriptor(),
-        CommandDescriptor::transaction_read_only()
+        TransactionAction::GetAllHolons.policy(),
+        CommandLifecyclePolicy::transaction_read_only()
     );
     assert_eq!(
-        TransactionAction::NewHolon { key: None }.descriptor(),
-        CommandDescriptor::mutating()
+        TransactionAction::NewHolon { key: None }.policy(),
+        CommandLifecyclePolicy::mutating()
     );
     assert_eq!(
-        TransactionAction::DeleteHolon { local_id: LocalId(vec![]) }.descriptor(),
-        CommandDescriptor::mutating()
+        TransactionAction::DeleteHolon { local_id: LocalId(vec![]) }.policy(),
+        CommandLifecyclePolicy::mutating()
     );
 }
 
 #[test]
-fn holon_action_descriptors() {
+fn holon_action_policies() {
     assert_eq!(
-        HolonAction::Read(ReadableHolonAction::Key).descriptor(),
-        CommandDescriptor::holon_read_only()
+        HolonAction::Read(ReadableHolonAction::Key).policy(),
+        CommandLifecyclePolicy::holon_read_only()
     );
     assert_eq!(
-        HolonAction::Read(ReadableHolonAction::CloneHolon).descriptor(),
-        CommandDescriptor::mutating(),
+        HolonAction::Read(ReadableHolonAction::CloneHolon).policy(),
+        CommandLifecyclePolicy::mutating(),
         "CloneHolon creates a transient — mutating despite being a ReadableHolonAction"
     );
     assert_eq!(
@@ -55,7 +55,7 @@ fn holon_action_descriptors() {
             name: PropertyName(MapString::from("x")),
             value: BaseValue::StringValue(MapString::from("v")),
         })
-        .descriptor(),
-        CommandDescriptor::mutating()
+        .policy(),
+        CommandLifecyclePolicy::mutating()
     );
 }

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -7,7 +7,7 @@ use holons_core::dances::DanceRequest;
 use holons_core::query_layer::QueryRequest;
 use holons_core::reference_layer::{HolonReference, SmartReference, TransientReference};
 
-use super::{CommandDescriptor, MutationClassification};
+use super::{CommandLifecyclePolicy, MutationClassification};
 
 /// Transaction-scoped domain command.
 ///
@@ -22,7 +22,7 @@ pub struct TransactionCommand {
 /// Domain-level transaction actions.
 ///
 /// Kept flat per the MAP Commands spec. Policy classification (mutating vs read-only)
-/// is enforced by `CommandDescriptor` at runtime, not by enum structure.
+/// is enforced by `CommandLifecyclePolicy` at runtime, not by enum structure.
 #[derive(Debug)]
 pub enum TransactionAction {
     /// Commits the transaction.
@@ -95,22 +95,22 @@ pub enum TransactionAction {
 }
 
 impl TransactionAction {
-    pub fn descriptor(&self) -> CommandDescriptor {
+    pub fn policy(&self) -> CommandLifecyclePolicy {
         match self {
-            TransactionAction::Commit => CommandDescriptor::mutating_with_guard(),
+            TransactionAction::Commit => CommandLifecyclePolicy::mutating_with_guard(),
             TransactionAction::UndoLast | TransactionAction::RedoLast => {
-                CommandDescriptor::transaction_read_only()
+                CommandLifecyclePolicy::transaction_read_only()
             }
             TransactionAction::UndoToMarker { .. } | TransactionAction::RedoToMarker { .. } => {
-                CommandDescriptor::transaction_read_only()
+                CommandLifecyclePolicy::transaction_read_only()
             }
-            TransactionAction::LoadHolons { .. } => CommandDescriptor::mutating_with_guard(),
-            TransactionAction::Dance(_) => CommandDescriptor {
+            TransactionAction::LoadHolons { .. } => CommandLifecyclePolicy::mutating_with_guard(),
+            TransactionAction::Dance(_) => CommandLifecyclePolicy {
                 mutation: MutationClassification::RuntimeDetected,
                 requires_open_tx: true,
                 requires_commit_guard: false,
             },
-            TransactionAction::Query(_) => CommandDescriptor::transaction_read_only(),
+            TransactionAction::Query(_) => CommandLifecyclePolicy::transaction_read_only(),
 
             // Lookups
             TransactionAction::GetAllHolons
@@ -120,7 +120,7 @@ impl TransactionAction {
             | TransactionAction::GetTransientHolonByBaseKey { .. }
             | TransactionAction::GetTransientHolonByVersionedKey { .. }
             | TransactionAction::StagedCount
-            | TransactionAction::TransientCount => CommandDescriptor::transaction_read_only(),
+            | TransactionAction::TransientCount => CommandLifecyclePolicy::transaction_read_only(),
 
             // Mutations
             TransactionAction::NewHolon { .. }
@@ -128,7 +128,7 @@ impl TransactionAction {
             | TransactionAction::StageNewFromClone { .. }
             | TransactionAction::StageNewVersion { .. }
             | TransactionAction::StageNewVersionFromId { .. }
-            | TransactionAction::DeleteHolon { .. } => CommandDescriptor::mutating(),
+            | TransactionAction::DeleteHolon { .. } => CommandLifecyclePolicy::mutating(),
         }
     }
 

--- a/host/crates/map_commands_runtime/src/runtime.rs
+++ b/host/crates/map_commands_runtime/src/runtime.rs
@@ -12,7 +12,7 @@ use super::{holon_handler, space_handler, transaction_handler};
 /// The MAP Commands execution boundary.
 ///
 /// All MAP command execution flows through `Runtime::execute_command`. It
-/// enforces lifecycle policy via `CommandDescriptor` and routes to
+/// enforces lifecycle policy via `CommandLifecyclePolicy` and routes to
 /// scope-specific handlers.
 ///
 /// Wire binding (IPC envelope → domain command) is handled by the caller
@@ -46,7 +46,7 @@ impl Runtime {
         command: MapCommand,
         policy: ExecutionPolicy,
     ) -> Result<MapResult, HolonError> {
-        let descriptor = command.descriptor();
+        let lifecycle_policy = command.policy();
         let command_label = command.label();
 
         let is_commit = match &command {
@@ -61,7 +61,7 @@ impl Runtime {
         };
 
         // Open-transaction check: reject commands that require an open transaction
-        if descriptor.requires_open_tx {
+        if lifecycle_policy.requires_open_tx {
             if let Some(ref ctx) = context {
                 if !ctx.is_open() {
                     let tx_id = ctx.tx_id().value();
@@ -79,7 +79,7 @@ impl Runtime {
         }
 
         // Commit guard: hold across handler execution for commit-guarded commands
-        let _commit_guard = if descriptor.requires_commit_guard {
+        let _commit_guard = if lifecycle_policy.requires_commit_guard {
             if let Some(ref ctx) = context {
                 Some(ctx.begin_host_commit_ingress_guard()?)
             } else {
@@ -90,8 +90,8 @@ impl Runtime {
         };
 
         // Mutation entry check: for non-commit-guarded mutating commands
-        if !descriptor.requires_commit_guard
-            && descriptor.mutation == MutationClassification::Mutating
+        if !lifecycle_policy.requires_commit_guard
+            && lifecycle_policy.mutation == MutationClassification::Mutating
         {
             if let Some(ref ctx) = context {
                 ctx.ensure_host_mutation_entry_allowed()?;
@@ -104,7 +104,7 @@ impl Runtime {
         // Persist after every mutable non-commit command so the store can clear
         // the redo stack unconditionally. EU creation only happens when
         // snapshot_after=true; crash-recovery state is always written.
-        if descriptor.mutation != MutationClassification::ReadOnly && !is_commit {
+        if lifecycle_policy.mutation != MutationClassification::ReadOnly && !is_commit {
             if let Some(tx_id) = tx_id_for_snapshot {
                 self.session.persist_success(&tx_id, command_label, policy).await?;
             }

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -23,7 +23,7 @@ pub struct TransactionCommandWire {
 /// Wire-level transaction actions.
 ///
 /// Flat enum per the MAP Commands spec. Policy classification is enforced by
-/// `CommandDescriptor` at runtime, not by enum structure.
+/// `CommandLifecyclePolicy` at runtime, not by enum structure.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionActionWire {
     /// Commits the transaction.

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-11T17:23:28",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-abstract-value-types.csv"
@@ -30,7 +30,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -63,7 +63,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -113,7 +113,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -163,7 +163,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -208,7 +208,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -241,7 +241,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -286,7 +286,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -319,7 +319,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -352,7 +352,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-command-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-command-types.json
@@ -1,0 +1,1452 @@
+{
+  "meta": {
+    "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
+    "generated_at": "2026-05-20T16:28:35",
+    "export_mode": "by-file",
+    "source_files": [
+      "MAP Schema Types-map-core-schema-command-types.csv"
+    ],
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+    ]
+  },
+  "holons": [
+    {
+      "key": "CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "CommandType",
+        "type_name_plural": "CommandTypes",
+        "display_name": "Command Type",
+        "display_name_plural": "Command Types",
+        "instance_type_kind": "Holon",
+        "description": "Abstract descriptor type for core MAP command affordances discoverable through descriptor-local command lookup.",
+        "is_abstract_type": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#TypeNameRule"
+          }
+        }
+      ]
+    },
+    {
+      "key": "BeginTransaction.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "BeginTransaction",
+        "type_name_plural": "BeginTransactionCommands",
+        "display_name": "Begin Transaction Command",
+        "display_name_plural": "Begin Transaction Commands",
+        "instance_type_kind": "Holon",
+        "description": "Opens a new transaction for a holon space.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "CloneHolon.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "CloneHolon",
+        "type_name_plural": "CloneHolonCommands",
+        "display_name": "Clone Holon Command",
+        "display_name_plural": "Clone Holon Commands",
+        "instance_type_kind": "Holon",
+        "description": "Creates a transient clone of the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetEssentialContent.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetEssentialContent",
+        "type_name_plural": "GetEssentialContentCommands",
+        "display_name": "Get Essential Content Command",
+        "display_name_plural": "Get Essential Content Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the target holon's essential content.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Summarize.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Summarize",
+        "type_name_plural": "SummarizeCommands",
+        "display_name": "Summarize Command",
+        "display_name_plural": "Summarize Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns a concise string summary of the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetHolonId.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetHolonId",
+        "type_name_plural": "GetHolonIdCommands",
+        "display_name": "Get Holon Id Command",
+        "display_name_plural": "Get Holon Id Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the target holon's saved holon identifier.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetPredecessor.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetPredecessor",
+        "type_name_plural": "GetPredecessorCommands",
+        "display_name": "Get Predecessor Command",
+        "display_name_plural": "Get Predecessor Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the target holon's predecessor reference, if present.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetKey",
+        "type_name_plural": "GetKeyCommands",
+        "display_name": "Get Key Command",
+        "display_name_plural": "Get Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the target holon's primary key value, if present.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetVersionedKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetVersionedKey",
+        "type_name_plural": "GetVersionedKeyCommands",
+        "display_name": "Get Versioned Key Command",
+        "display_name_plural": "Get Versioned Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the target holon's versioned key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetPropertyValue.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetPropertyValue",
+        "type_name_plural": "GetPropertyValueCommands",
+        "display_name": "Get Property Value Command",
+        "display_name_plural": "Get Property Value Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the value of a named property on the target holon, if present.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetRelatedHolons.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetRelatedHolons",
+        "type_name_plural": "GetRelatedHolonsCommands",
+        "display_name": "Get Related Holons Command",
+        "display_name_plural": "Get Related Holons Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns holons related to the target holon through a named relationship.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "WithPropertyValue.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "WithPropertyValue",
+        "type_name_plural": "WithPropertyValueCommands",
+        "display_name": "With Property Value Command",
+        "display_name_plural": "With Property Value Commands",
+        "instance_type_kind": "Holon",
+        "description": "Sets or updates a named property value on the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "RemovePropertyValue.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "RemovePropertyValue",
+        "type_name_plural": "RemovePropertyValueCommands",
+        "display_name": "Remove Property Value Command",
+        "display_name_plural": "Remove Property Value Commands",
+        "instance_type_kind": "Holon",
+        "description": "Removes a named property value from the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "AddRelatedHolons.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "AddRelatedHolons",
+        "type_name_plural": "AddRelatedHolonsCommands",
+        "display_name": "Add Related Holons Command",
+        "display_name_plural": "Add Related Holons Commands",
+        "instance_type_kind": "Holon",
+        "description": "Adds one or more related holons under a named relationship on the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "RemoveRelatedHolons.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "RemoveRelatedHolons",
+        "type_name_plural": "RemoveRelatedHolonsCommands",
+        "display_name": "Remove Related Holons Command",
+        "display_name_plural": "Remove Related Holons Commands",
+        "instance_type_kind": "Holon",
+        "description": "Removes one or more related holons from a named relationship on the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "WithDescriptor.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "WithDescriptor",
+        "type_name_plural": "WithDescriptorCommands",
+        "display_name": "With Descriptor Command",
+        "display_name_plural": "With Descriptor Commands",
+        "instance_type_kind": "Holon",
+        "description": "Attaches a type descriptor holon to the target holon.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Commit.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Commit",
+        "type_name_plural": "CommitCommands",
+        "display_name": "Commit Command",
+        "display_name_plural": "Commit Commands",
+        "instance_type_kind": "Holon",
+        "description": "Commits the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "UndoLast.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "UndoLast",
+        "type_name_plural": "UndoLastCommands",
+        "display_name": "Undo Last Command",
+        "display_name_plural": "Undo Last Commands",
+        "instance_type_kind": "Holon",
+        "description": "Undoes the last mutation in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "RedoLast.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "RedoLast",
+        "type_name_plural": "RedoLastCommands",
+        "display_name": "Redo Last Command",
+        "display_name_plural": "Redo Last Commands",
+        "instance_type_kind": "Holon",
+        "description": "Redoes the last undone mutation in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "UndoToMarker.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "UndoToMarker",
+        "type_name_plural": "UndoToMarkerCommands",
+        "display_name": "Undo To Marker Command",
+        "display_name_plural": "Undo To Marker Commands",
+        "instance_type_kind": "Holon",
+        "description": "Undoes mutations in the active transaction up to a specified marker.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "RedoToMarker.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "RedoToMarker",
+        "type_name_plural": "RedoToMarkerCommands",
+        "display_name": "Redo To Marker Command",
+        "display_name_plural": "Redo To Marker Commands",
+        "instance_type_kind": "Holon",
+        "description": "Redoes mutations in the active transaction up to a specified marker.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LoadHolons.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "LoadHolons",
+        "type_name_plural": "LoadHolonsCommands",
+        "display_name": "Load Holons Command",
+        "display_name_plural": "Load Holons Commands",
+        "instance_type_kind": "Holon",
+        "description": "Loads holons from uploaded or imported file content into the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Dance.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Dance",
+        "type_name_plural": "DanceCommands",
+        "display_name": "Dance Command",
+        "display_name_plural": "Dance Commands",
+        "instance_type_kind": "Holon",
+        "description": "Executes a dance request within the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Query.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "Query",
+        "type_name_plural": "QueryCommands",
+        "display_name": "Query Command",
+        "display_name_plural": "Query Commands",
+        "instance_type_kind": "Holon",
+        "description": "Executes a query request within the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetAllHolons.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetAllHolons",
+        "type_name_plural": "GetAllHolonsCommands",
+        "display_name": "Get All Holons Command",
+        "display_name_plural": "Get All Holons Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns all holons visible in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetStagedHolonByBaseKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetStagedHolonByBaseKey",
+        "type_name_plural": "GetStagedHolonByBaseKeyCommands",
+        "display_name": "Get Staged Holon By Base Key Command",
+        "display_name_plural": "Get Staged Holon By Base Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the staged holon matching a specified base key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetStagedHolonsByBaseKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetStagedHolonsByBaseKey",
+        "type_name_plural": "GetStagedHolonsByBaseKeyCommands",
+        "display_name": "Get Staged Holons By Base Key Command",
+        "display_name_plural": "Get Staged Holons By Base Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns all staged holons matching a specified base key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetStagedHolonByVersionedKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetStagedHolonByVersionedKey",
+        "type_name_plural": "GetStagedHolonByVersionedKeyCommands",
+        "display_name": "Get Staged Holon By Versioned Key Command",
+        "display_name_plural": "Get Staged Holon By Versioned Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the staged holon matching a specified versioned key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetTransientHolonByBaseKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetTransientHolonByBaseKey",
+        "type_name_plural": "GetTransientHolonByBaseKeyCommands",
+        "display_name": "Get Transient Holon By Base Key Command",
+        "display_name_plural": "Get Transient Holon By Base Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the transient holon matching a specified base key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetTransientHolonByVersionedKey.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetTransientHolonByVersionedKey",
+        "type_name_plural": "GetTransientHolonByVersionedKeyCommands",
+        "display_name": "Get Transient Holon By Versioned Key Command",
+        "display_name_plural": "Get Transient Holon By Versioned Key Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the transient holon matching a specified versioned key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetStagedCount.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetStagedCount",
+        "type_name_plural": "GetStagedCountCommands",
+        "display_name": "Get Staged Count Command",
+        "display_name_plural": "Get Staged Count Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the number of staged holons in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "GetTransientCount.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "GetTransientCount",
+        "type_name_plural": "GetTransientCountCommands",
+        "display_name": "Get Transient Count Command",
+        "display_name_plural": "Get Transient Count Commands",
+        "instance_type_kind": "Holon",
+        "description": "Returns the number of transient holons in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "NewHolon.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "NewHolon",
+        "type_name_plural": "NewHolonCommands",
+        "display_name": "New Holon Command",
+        "display_name_plural": "New Holon Commands",
+        "instance_type_kind": "Holon",
+        "description": "Creates a new transient holon, optionally with a key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "StageNewHolon.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "StageNewHolon",
+        "type_name_plural": "StageNewHolonCommands",
+        "display_name": "Stage New Holon Command",
+        "display_name_plural": "Stage New Holon Commands",
+        "instance_type_kind": "Holon",
+        "description": "Stages a transient holon as a new holon in the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "StageNewFromClone.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "StageNewFromClone",
+        "type_name_plural": "StageNewFromCloneCommands",
+        "display_name": "Stage New From Clone Command",
+        "display_name_plural": "Stage New From Clone Commands",
+        "instance_type_kind": "Holon",
+        "description": "Stages a new holon cloned from an existing holon reference with a new key.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "StageNewVersion.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "StageNewVersion",
+        "type_name_plural": "StageNewVersionCommands",
+        "display_name": "Stage New Version Command",
+        "display_name_plural": "Stage New Version Commands",
+        "instance_type_kind": "Holon",
+        "description": "Stages a new version of an existing smart reference.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "StageNewVersionFromId.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "StageNewVersionFromId",
+        "type_name_plural": "StageNewVersionFromIdCommands",
+        "display_name": "Stage New Version From Id Command",
+        "display_name_plural": "Stage New Version From Id Commands",
+        "instance_type_kind": "Holon",
+        "description": "Stages a new version of an existing holon identified by holon ID.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "DeleteHolon.CommandType",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "DeleteHolon",
+        "type_name_plural": "DeleteHolonCommands",
+        "display_name": "Delete Holon Command",
+        "display_name_plural": "Delete Holon Commands",
+        "instance_type_kind": "Holon",
+        "description": "Deletes a holon identified by local ID from the active transaction.",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#ExtendedTypeRule.KeyRuleType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(HolonType)-[AffordsCommand]->(CommandType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "AffordsCommand",
+        "type_name_plural": "AffordsCommandRelationships",
+        "display_name": "AffordsCommand Relationship",
+        "display_name_plural": "AffordsCommand Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Declares that a HolonType affords a CommandType, making the command discoverable through descriptor-local command affordance lookup.",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(CommandType)-[AffordedBy]->(HolonType)",
+      "type": "#TypeDescriptor",
+      "properties": {
+        "type_name": "AffordedBy",
+        "type_name_plural": "AffordedByRelationships",
+        "display_name": "AffordedBy Relationship",
+        "display_name_plural": "AffordedBy Relationships",
+        "instance_type_kind": "Relationship",
+        "description": "Inverse of AffordsCommand, relationship from CommandType to HolonType.",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "#MAP Core Schema-v0.0.7"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "#InverseRelationshipType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "#RelationshipRule.KeyRuleType"
+          }
+        },
+        {
+          "name": "InverseOf",
+          "target": {
+            "$ref": "#(HolonType)-[AffordsCommand]->(CommandType)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "#CommandType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "#HolonType"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-concrete-value-types.csv"
@@ -29,7 +29,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -62,7 +62,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -95,7 +95,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -128,7 +128,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -161,7 +161,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -194,7 +194,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -227,7 +227,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -260,7 +260,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -291,7 +291,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -328,7 +328,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -365,7 +365,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -404,7 +404,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -435,7 +435,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -472,7 +472,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -509,7 +509,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -546,7 +546,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -583,7 +583,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -620,7 +620,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -657,7 +657,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -694,7 +694,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -731,7 +731,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -768,7 +768,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -805,7 +805,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -842,7 +842,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -879,7 +879,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -916,7 +916,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -953,7 +953,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-dance-schema.csv"
@@ -29,7 +29,7 @@
         {
           "name": "DependsOn",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         }
       ]
@@ -246,7 +246,7 @@
       "properties": {
         "type_name": "Affords",
         "type_name_plural": "AffordsRelationships",
-        "display_name": "Affords",
+        "display_name": "Affords Relationship",
         "display_name_plural": "Affords Relationships",
         "instance_type_kind": "Relationship",
         "description": "Declares that a HolonType affords (supports) a DanceType (i.e., the verb is valid for instances of the type).",
@@ -297,7 +297,7 @@
       "properties": {
         "type_name": "AffordedBy",
         "type_name_plural": "AffordedByRelationships",
-        "display_name": "AffordedBy",
+        "display_name": "AffordedBy Relationship",
         "display_name_plural": "AffordedBy Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of Affords, from DanceType to HolonType.",
@@ -353,7 +353,7 @@
       "properties": {
         "type_name": "ImplementsDance",
         "type_name_plural": "ImplementsDanceRelationships",
-        "display_name": "ImplementsDance",
+        "display_name": "ImplementsDance Relationship",
         "display_name_plural": "ImplementsDance Relationships",
         "instance_type_kind": "Relationship",
         "description": "Binds a TypeDescriptor to a specific DanceImplementation that can be dispatched.",
@@ -401,7 +401,7 @@
       "properties": {
         "type_name": "ImplementedFor",
         "type_name_plural": "ImplementedForRelationships",
-        "display_name": "ImplementedFor",
+        "display_name": "ImplementedFor Relationship",
         "display_name_plural": "ImplementedFor Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of ImplementsDance, from DanceImplementation to TypeDescriptor.",
@@ -455,7 +455,7 @@
       "properties": {
         "type_name": "ForDance",
         "type_name_plural": "ForDanceRelationships",
-        "display_name": "ForDance",
+        "display_name": "ForDance Relationship",
         "display_name_plural": "ForDance Relationships",
         "instance_type_kind": "Relationship",
         "description": "Pins a DanceImplementation to exactly one DanceType interface it satisfies.",
@@ -505,7 +505,7 @@
       "properties": {
         "type_name": "HasImplementation",
         "type_name_plural": "HasImplementationRelationships",
-        "display_name": "HasImplementation",
+        "display_name": "HasImplementation Relationship",
         "display_name_plural": "HasImplementation Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of ForDance, from DanceType to DanceImplementation.",
@@ -561,7 +561,7 @@
       "properties": {
         "type_name": "Request",
         "type_name_plural": "RequestRelationships",
-        "display_name": "Request",
+        "display_name": "Request Relationship",
         "display_name_plural": "Request Relationships",
         "instance_type_kind": "Relationship",
         "description": "Links a DanceType to the HolonType used as its request body.",
@@ -611,7 +611,7 @@
       "properties": {
         "type_name": "RequestFor",
         "type_name_plural": "RequestForRelationships",
-        "display_name": "RequestFor",
+        "display_name": "RequestFor Relationship",
         "display_name_plural": "RequestFor Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of Request, from HolonType to DanceType.",
@@ -667,7 +667,7 @@
       "properties": {
         "type_name": "Response",
         "type_name_plural": "ResponseRelationships",
-        "display_name": "Response",
+        "display_name": "Response Relationship",
         "display_name_plural": "Response Relationships",
         "instance_type_kind": "Relationship",
         "description": "Links a DanceType to the DanceResponseType used to structure its response.",
@@ -717,7 +717,7 @@
       "properties": {
         "type_name": "ResponseFor",
         "type_name_plural": "ResponseForRelationships",
-        "display_name": "ResponseFor",
+        "display_name": "ResponseFor Relationship",
         "display_name_plural": "ResponseFor Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of Response, from DanceResponseType to DanceType.",
@@ -773,7 +773,7 @@
       "properties": {
         "type_name": "ResponseBody",
         "type_name_plural": "ResponseBody Relationships",
-        "display_name": "ResponseBody",
+        "display_name": "ResponseBody Relationship",
         "display_name_plural": "ResponseBody Relationships",
         "instance_type_kind": "Relationship",
         "description": "Links a DanceResponseType to the ResponseBodyType that will serve as the structured response body.",
@@ -823,7 +823,7 @@
       "properties": {
         "type_name": "ResponseBodyFor",
         "type_name_plural": "ResponseBodyForRelationships",
-        "display_name": "ResponseBodyFor",
+        "display_name": "ResponseBodyFor Relationship",
         "display_name_plural": "ResponseBodyFor Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of ResponseBody, from ResponseBodyType to DanceResponseType.",
@@ -2155,7 +2155,7 @@
       "properties": {
         "type_name": "SavedHolons",
         "type_name_plural": "SavedHolonsRelationships",
-        "display_name": "SavedHolons",
+        "display_name": "SavedHolons Relationship",
         "display_name_plural": "SavedHolons Relationships",
         "instance_type_kind": "Relationship",
         "description": "Declared relationship from a CommitResponse to each holon successfully saved by this commit.",
@@ -2206,7 +2206,7 @@
       "properties": {
         "type_name": "SavedByCommit",
         "type_name_plural": "SavedByCommitRelationships",
-        "display_name": "SavedByCommit",
+        "display_name": "SavedByCommit Relationship",
         "display_name_plural": "SavedByCommit Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of SavedHolons. Links a holon to a CommitResponse that successfully saved it.",
@@ -2263,7 +2263,7 @@
       "properties": {
         "type_name": "AbandonedHolons",
         "type_name_plural": "AbandonedHolonsRelationships",
-        "display_name": "AbandonedHolons",
+        "display_name": "AbandonedHolons Relationship",
         "display_name_plural": "AbandonedHolons Relationships",
         "instance_type_kind": "Relationship",
         "description": "Declared relationship from a CommitResponse to each holon that was not saved due to validation or commit errors.",
@@ -2314,7 +2314,7 @@
       "properties": {
         "type_name": "AbandonedByCommit",
         "type_name_plural": "AbandonedByCommitRelationships",
-        "display_name": "AbandonedByCommit",
+        "display_name": "AbandonedByCommit Relationship",
         "display_name_plural": "AbandonedByCommit Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of AbandonedHolons.  Links a holon to a CommitResponse that did not successfully save it.",

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-keyrules-schema.csv"
@@ -31,7 +31,7 @@
         {
           "name": "DependsOn",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         }
       ]

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-operator-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-operator-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-12T10:40:15",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-operator-types.csv"
@@ -30,7 +30,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -64,7 +64,7 @@
       "properties": {
         "type_name": "AffordsOperator",
         "type_name_plural": "AffordsOperatorRelationships",
-        "display_name": "AffordsOperator",
+        "display_name": "AffordsOperator Relationship",
         "display_name_plural": "AffordsOperator Relationships",
         "instance_type_kind": "Relationship",
         "description": "Links a ValueType to the OperatorTypes available for that value type, supporting validation and query construction.",
@@ -79,7 +79,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -114,7 +114,7 @@
       "properties": {
         "type_name": "AffordedBy",
         "type_name_plural": "AffordedByRelationships",
-        "display_name": "AffordedBy",
+        "display_name": "AffordedBy Relationship",
         "display_name_plural": "AffordedBy Relationships",
         "instance_type_kind": "Relationship",
         "description": "Inverse of AffordsOperator, relationship from OperatorType to ValueType.",
@@ -129,7 +129,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -180,7 +180,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -211,7 +211,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -248,7 +248,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -287,7 +287,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -326,7 +326,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -367,7 +367,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -402,7 +402,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-property-types.csv"
@@ -29,7 +29,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -68,7 +68,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -107,7 +107,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -146,7 +146,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -185,7 +185,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -224,7 +224,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -263,7 +263,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -302,7 +302,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -341,7 +341,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -380,7 +380,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -419,7 +419,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -458,7 +458,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -497,7 +497,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -536,7 +536,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -575,7 +575,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -614,7 +614,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -653,7 +653,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -692,7 +692,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -731,7 +731,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -770,7 +770,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -809,7 +809,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -848,7 +848,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -887,7 +887,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -926,7 +926,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:39:21",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-relationship-types.csv"
@@ -34,7 +34,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -85,7 +85,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -142,7 +142,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -192,7 +192,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -248,7 +248,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -298,7 +298,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -354,7 +354,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -404,7 +404,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -460,7 +460,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -510,7 +510,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -566,7 +566,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -616,7 +616,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -672,7 +672,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -722,7 +722,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -778,7 +778,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -828,7 +828,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -884,7 +884,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -934,7 +934,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -990,7 +990,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1040,7 +1040,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1096,7 +1096,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1146,7 +1146,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1202,7 +1202,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1252,7 +1252,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1308,7 +1308,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1358,7 +1358,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1414,7 +1414,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1464,7 +1464,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1520,7 +1520,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1570,7 +1570,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
@@ -1,15 +1,15 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-20T16:28:35",
+    "generated_at": "2026-05-20T21:02:43",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-root.csv"
     ],
     "load_with": [
       "MAP Schema Types-map-core-schema-property-types.json",
-      "MAP Schema Types-map-core-schema-relationship-types.json",
       "MAP Schema Types-map-core-schema-command-types.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json",
       "MAP Schema Types-map-core-schema-keyrules-schema.json"
     ]
   },
@@ -74,6 +74,53 @@
       },
       "relationships": [
         {
+          "name": "AffordsCommand",
+          "target": [
+            {
+              "$ref": "#CloneHolon.CommandType"
+            },
+            {
+              "$ref": "#GetEssentialContent.CommandType"
+            },
+            {
+              "$ref": "#Summarize.CommandType"
+            },
+            {
+              "$ref": "#GetHolonId.CommandType"
+            },
+            {
+              "$ref": "#GetPredecessor.CommandType"
+            },
+            {
+              "$ref": "#GetKey.CommandType"
+            },
+            {
+              "$ref": "#GetVersionedKey.CommandType"
+            },
+            {
+              "$ref": "#GetPropertyValue.CommandType"
+            },
+            {
+              "$ref": "#GetRelatedHolons.CommandType"
+            },
+            {
+              "$ref": "#WithPropertyValue.CommandType"
+            },
+            {
+              "$ref": "#RemovePropertyValue.CommandType"
+            },
+            {
+              "$ref": "#AddRelatedHolons.CommandType"
+            },
+            {
+              "$ref": "#RemoveRelatedHolons.CommandType"
+            },
+            {
+              "$ref": "#WithDescriptor.CommandType"
+            }
+          ]
+        },
+        {
           "name": "ComponentOf",
           "target": {
             "$ref": "#MAP Core Schema-v0.0.7"
@@ -101,12 +148,6 @@
               "$ref": "#AllowsAdditionalRelationships.PropertyType"
             }
           ]
-        },
-        {
-          "name": "InstanceRelationships",
-          "target": {
-            "$ref": "#(HolonType)-[AffordsCommand]->(CommandType)"
-          }
         }
       ]
     },
@@ -310,6 +351,9 @@
             },
             {
               "$ref": "#(HolonType)-[Properties]->(PropertyType)"
+            },
+            {
+              "$ref": "#(HolonType)-[AffordsCommand]->(CommandType)"
             }
           ]
         }
@@ -555,6 +599,12 @@
         "allows_additional_relationships": false
       },
       "relationships": [
+        {
+          "name": "AffordsCommand",
+          "target": {
+            "$ref": "#BeginTransaction.CommandType"
+          }
+        },
         {
           "name": "ComponentOf",
           "target": {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-root.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-11T11:43:23",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-root.csv"
@@ -9,16 +9,17 @@
     "load_with": [
       "MAP Schema Types-map-core-schema-property-types.json",
       "MAP Schema Types-map-core-schema-relationship-types.json",
+      "MAP Schema Types-map-core-schema-command-types.json",
       "MAP Schema Types-map-core-schema-keyrules-schema.json"
     ]
   },
   "holons": [
     {
-      "key": "MAP Core Schema-v0.0.6",
+      "key": "MAP Core Schema-v0.0.7",
       "type": "#SchemaType",
       "properties": {
-        "type_name": "MAP Core Schema-v0.0.6",
-        "display_name": "MAP Core Schema-v0.0.6",
+        "type_name": "MAP Core Schema-v0.0.7",
+        "display_name": "MAP Core Schema-v0.0.7",
         "instance_type_kind": "Holon",
         "description": "Schema containing all meta-level descriptors for MAP type definitions, including the TypeDescriptor itself.",
         "is_abstract_type": false,
@@ -42,7 +43,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -75,7 +76,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -100,6 +101,12 @@
               "$ref": "#AllowsAdditionalRelationships.PropertyType"
             }
           ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "#(HolonType)-[AffordsCommand]->(CommandType)"
+          }
         }
       ]
     },
@@ -119,7 +126,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -152,7 +159,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -185,7 +192,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -218,7 +225,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -277,7 +284,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -324,7 +331,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -369,7 +376,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -436,7 +443,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -469,7 +476,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -510,7 +517,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -551,7 +558,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -586,7 +593,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-12T15:58:12",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-value-constraint-types.csv"
@@ -32,7 +32,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -65,7 +65,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -98,7 +98,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -131,7 +131,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -164,7 +164,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -197,7 +197,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -236,7 +236,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -275,7 +275,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -319,7 +319,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -363,7 +363,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -402,7 +402,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -441,7 +441,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -480,7 +480,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -519,7 +519,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -558,7 +558,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -597,7 +597,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -636,7 +636,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -680,7 +680,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -730,7 +730,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -780,7 +780,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -830,7 +830,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -880,7 +880,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -936,7 +936,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -992,7 +992,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1048,7 +1048,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
+++ b/host/import_files/map-schema/holon-loader-schema/MAP Schema Types-map-holon-loader-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T10:00:31",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-holon-loader-schema.csv"
@@ -34,7 +34,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -86,7 +86,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -138,7 +138,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -190,7 +190,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -301,7 +301,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -356,7 +356,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -374,7 +374,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)"
+            "$ref": "#(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)"
           }
         }
       ]
@@ -401,7 +401,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -452,7 +452,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -509,7 +509,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -560,7 +560,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -617,7 +617,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -668,7 +668,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -725,7 +725,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -776,7 +776,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -833,7 +833,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -884,7 +884,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -920,7 +920,7 @@
       ]
     },
     {
-      "key": "(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)",
+      "key": "(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)",
       "type": "#TypeDescriptor",
       "properties": {
         "type_name": "Contains",
@@ -941,7 +941,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -971,7 +971,7 @@
       ]
     },
     {
-      "key": "(HolonLoaderBundle.HolonType)-[ContainedIn]->(HolonLoadSet.HolonType)",
+      "key": "(HolonLoaderBundle.HolonType)-[ContainedIn]->(HolonLoadSet.Ho)",
       "type": "#TypeDescriptor",
       "properties": {
         "type_name": "ContainedIn",
@@ -992,7 +992,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1010,7 +1010,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)"
+            "$ref": "#(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)"
           }
         },
         {
@@ -1043,7 +1043,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1074,7 +1074,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1111,7 +1111,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1148,7 +1148,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1187,7 +1187,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1226,7 +1226,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1265,7 +1265,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1304,7 +1304,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1343,7 +1343,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1382,7 +1382,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1421,7 +1421,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1460,7 +1460,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1499,7 +1499,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1538,7 +1538,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1577,7 +1577,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1616,7 +1616,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {
@@ -1655,7 +1655,7 @@
         {
           "name": "ComponentOf",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         },
         {

--- a/shared_crates/holons_core/src/descriptors/command_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/command_descriptor.rs
@@ -1,0 +1,107 @@
+use crate::descriptors::{Descriptor, TypeHeader};
+use crate::reference_layer::HolonReference;
+use base_types::MapString;
+use core_types::HolonError;
+
+/// Runtime wrapper for command descriptors.
+///
+/// Commands remain schema-declared `CommandType` holons. This wrapper exposes
+/// descriptor-local command identity without introducing routing or execution
+/// behavior.
+pub struct CommandDescriptor {
+    holon: HolonReference,
+}
+
+impl CommandDescriptor {
+    /// Wraps an already-resolved descriptor holon reference.
+    pub fn from_holon(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+
+    /// Projects the shared descriptor header view for this descriptor holon.
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+
+    /// Returns the command descriptor's canonical command name.
+    pub fn command_name(&self) -> Result<MapString, HolonError> {
+        self.header().type_name()
+    }
+}
+
+impl From<HolonReference> for CommandDescriptor {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
+    }
+}
+
+impl Descriptor for CommandDescriptor {
+    fn holon(&self) -> &HolonReference {
+        &self.holon
+    }
+}
+
+#[cfg(test)]
+const _: fn() = || {
+    // Compile-time guard: this wrapper must continue implementing Descriptor.
+    fn assert_impl<T: Descriptor>() {}
+    assert_impl::<CommandDescriptor>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{build_context, new_descriptor_holon};
+
+    #[test]
+    fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = HolonReference::from(&new_descriptor_holon(
+            &context,
+            "commit-command",
+            "Commit",
+            "Holon",
+        )?);
+
+        let descriptor = CommandDescriptor::from_holon(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+        assert_eq!(descriptor.header().type_name()?, MapString("Commit".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn command_name_uses_shared_type_name() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = new_descriptor_holon(
+            &context,
+            "begin-transaction-command",
+            "BeginTransaction",
+            "Holon",
+        )?;
+
+        let descriptor = CommandDescriptor::from_holon(holon.into());
+
+        assert_eq!(descriptor.command_name()?, MapString("BeginTransaction".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn from_holon_round_trips_through_from_trait() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon = HolonReference::from(&new_descriptor_holon(
+            &context,
+            "query-command",
+            "Query",
+            "Holon",
+        )?);
+
+        let descriptor = CommandDescriptor::from(holon.clone());
+
+        assert_eq!(descriptor.holon(), &holon);
+
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -1,10 +1,11 @@
 use std::collections::HashSet;
 
 use crate::descriptors::{
-    accessor_helpers, inheritance::flatten_related_members, Descriptor,
+    accessor_helpers, inheritance::flatten_related_members, CommandDescriptor, Descriptor,
     InverseRelationshipDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
 };
 use crate::reference_layer::HolonReference;
+use base_types::MapString;
 use core_types::{HolonError, PropertyName, RelationshipName};
 use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 
@@ -54,6 +55,12 @@ impl HolonDescriptor {
             .map(|members| members.into_iter().map(RelationshipDescriptor::from_holon).collect())
     }
 
+    /// Returns effective command descriptors across this descriptor's inheritance chain.
+    pub fn afforded_commands(&self) -> Result<Vec<CommandDescriptor>, HolonError> {
+        flatten_related_members(&self.holon, CoreRelationshipTypeName::AffordsCommand)
+            .map(|members| members.into_iter().map(CommandDescriptor::from_holon).collect())
+    }
+
     /// Returns effective property type descriptors across this descriptor's inheritance chain.
     pub fn properties(&self) -> Result<Vec<PropertyDescriptor>, HolonError> {
         self.flatten_property_descriptors(CoreRelationshipTypeName::Properties)
@@ -84,6 +91,33 @@ impl HolonDescriptor {
 
         found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
             kind: "property".to_string(),
+            name: requested,
+            descriptor: accessor_helpers::descriptor_label(&self.holon),
+        })
+    }
+
+    /// Finds an effective command affordance by command descriptor type name.
+    pub fn get_command_by_name(&self, name: MapString) -> Result<CommandDescriptor, HolonError> {
+        let requested = name.to_string();
+        let mut seen = HashSet::new();
+        let mut found = None;
+
+        for descriptor in self.afforded_commands()? {
+            let declaration_name = descriptor.command_name()?.to_string();
+            if !seen.insert(declaration_name.clone()) {
+                return Err(HolonError::DuplicateInheritedDeclaration {
+                    kind: "command".to_string(),
+                    name: declaration_name,
+                    descriptor: accessor_helpers::descriptor_label(&self.holon),
+                });
+            }
+            if declaration_name == requested {
+                found = Some(descriptor);
+            }
+        }
+
+        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+            kind: "command".to_string(),
             name: requested,
             descriptor: accessor_helpers::descriptor_label(&self.holon),
         })
@@ -184,6 +218,10 @@ mod tests {
     fn assert_is_descriptor<T: Descriptor>(descriptor: &T) {
         // Compile-time trait membership plus one trivial runtime use.
         let _ = descriptor.holon().reference_id_string();
+    }
+
+    fn command_names(commands: Vec<CommandDescriptor>) -> Result<Vec<MapString>, HolonError> {
+        commands.into_iter().map(|command| command.command_name()).collect()
     }
 
     #[test]
@@ -409,6 +447,199 @@ mod tests {
             ]
         );
         assert_eq!(properties_names, vec![MapString("PropertyType".to_string())]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn afforded_commands_returns_empty_when_no_affords_command_edges_present(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let holon_type = new_descriptor_holon(&context, "no-command-owner", "BookType")?;
+
+        let descriptor = HolonDescriptor::from_holon(holon_type.into());
+
+        assert!(descriptor.afforded_commands()?.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn afforded_commands_returns_self_first_then_inherited() -> Result<(), HolonError> {
+        let context = build_context();
+        let inherited_command =
+            new_descriptor_holon(&context, "inherited-command", "BeginTransaction")?;
+        let local_command = new_descriptor_holon(&context, "local-command", "Commit")?;
+        let mut parent = new_descriptor_holon(&context, "command-parent", "ParentType")?;
+        let mut leaf = new_descriptor_holon(&context, "command-leaf", "LeafType")?;
+
+        parent.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![inherited_command.into()],
+        )?;
+        leaf.add_related_holons(CoreRelationshipTypeName::Extends, vec![parent.into()])?;
+        leaf.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![local_command.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(leaf.into());
+
+        assert_eq!(
+            command_names(descriptor.afforded_commands()?)?,
+            vec![MapString("Commit".to_string()), MapString("BeginTransaction".to_string()),]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn afforded_commands_flattens_through_multi_step_extends_chain() -> Result<(), HolonError> {
+        let context = build_context();
+        let root_command = new_descriptor_holon(&context, "root-command", "BeginTransaction")?;
+        let middle_command = new_descriptor_holon(&context, "middle-command", "CloneHolon")?;
+        let leaf_command = new_descriptor_holon(&context, "leaf-command", "Commit")?;
+        let mut root = new_descriptor_holon(&context, "command-root", "RootType")?;
+        let mut middle = new_descriptor_holon(&context, "command-middle", "MiddleType")?;
+        let mut leaf = new_descriptor_holon(&context, "command-chain-leaf", "LeafType")?;
+
+        root.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![root_command.into()],
+        )?;
+        middle.add_related_holons(CoreRelationshipTypeName::Extends, vec![root.into()])?;
+        middle.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![middle_command.into()],
+        )?;
+        leaf.add_related_holons(CoreRelationshipTypeName::Extends, vec![middle.into()])?;
+        leaf.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![leaf_command.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(leaf.into());
+
+        assert_eq!(
+            command_names(descriptor.afforded_commands()?)?,
+            vec![
+                MapString("Commit".to_string()),
+                MapString("CloneHolon".to_string()),
+                MapString("BeginTransaction".to_string()),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_command_by_name_matches_on_shared_type_name() -> Result<(), HolonError> {
+        let context = build_context();
+        let command = new_descriptor_holon(&context, "commit-command-affordance", "Commit")?;
+        let mut holon_type = new_descriptor_holon(&context, "command-owner", "TransactionType")?;
+
+        holon_type
+            .add_related_holons(CoreRelationshipTypeName::AffordsCommand, vec![command.into()])?;
+
+        let descriptor = HolonDescriptor::from_holon(holon_type.into());
+
+        assert_eq!(
+            descriptor.get_command_by_name(MapString("Commit".to_string()))?.command_name()?,
+            MapString("Commit".to_string())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_command_by_name_errors_when_not_found() -> Result<(), HolonError> {
+        let context = build_context();
+        let command = new_descriptor_holon(&context, "query-command-affordance", "Query")?;
+        let mut holon_type = new_descriptor_holon(&context, "missing-command-owner", "BookType")?;
+
+        holon_type
+            .add_related_holons(CoreRelationshipTypeName::AffordsCommand, vec![command.into()])?;
+
+        let descriptor = HolonDescriptor::from_holon(holon_type.into());
+
+        assert!(matches!(
+            descriptor.get_command_by_name(MapString("Commit".to_string())),
+            Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
+                if kind == "command" && name == "Commit"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_command_by_name_detects_duplicate_inherited_declarations() -> Result<(), HolonError> {
+        let context = build_context();
+        let duplicate_root = new_descriptor_holon(&context, "duplicate-root-command", "Commit")?;
+        let duplicate_leaf = new_descriptor_holon(&context, "duplicate-leaf-command", "Commit")?;
+        let mut root = new_descriptor_holon(&context, "duplicate-command-root", "RootType")?;
+        let mut leaf = new_descriptor_holon(&context, "duplicate-command-leaf", "LeafType")?;
+
+        root.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![duplicate_root.into()],
+        )?;
+        leaf.add_related_holons(CoreRelationshipTypeName::Extends, vec![root.into()])?;
+        leaf.add_related_holons(
+            CoreRelationshipTypeName::AffordsCommand,
+            vec![duplicate_leaf.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(leaf.into());
+
+        assert!(matches!(
+            descriptor.get_command_by_name(MapString("Commit".to_string())),
+            Err(HolonError::DuplicateInheritedDeclaration { kind, name, .. })
+                if kind == "command" && name == "Commit"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn afforded_commands_errors_on_cyclic_extends() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut descriptor_a = new_descriptor_holon(&context, "command-cycle-a", "CycleA")?;
+        let mut descriptor_b = new_descriptor_holon(&context, "command-cycle-b", "CycleB")?;
+
+        descriptor_a.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![descriptor_b.clone().into()],
+        )?;
+        descriptor_b.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![descriptor_a.clone().into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(descriptor_a.into());
+
+        assert!(matches!(descriptor.afforded_commands(), Err(HolonError::CyclicExtends { .. })));
+
+        Ok(())
+    }
+
+    #[test]
+    fn afforded_commands_errors_when_multiple_extends_are_declared() -> Result<(), HolonError> {
+        let context = build_context();
+        let parent_a = new_descriptor_holon(&context, "command-parent-a", "ParentA")?;
+        let parent_b = new_descriptor_holon(&context, "command-parent-b", "ParentB")?;
+        let mut child = new_descriptor_holon(&context, "command-child", "ChildType")?;
+
+        child.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![parent_a.into(), parent_b.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(child.into());
+
+        assert!(matches!(
+            descriptor.afforded_commands(),
+            Err(HolonError::MultipleExtends { count, .. }) if count == 2
+        ));
 
         Ok(())
     }

--- a/shared_crates/holons_core/src/descriptors/mod.rs
+++ b/shared_crates/holons_core/src/descriptors/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod accessor_helpers;
+pub mod command_descriptor;
 pub mod declared_relationship_descriptor;
 pub mod descriptor;
 pub mod holon_descriptor;
@@ -16,6 +17,7 @@ pub mod type_header;
 pub mod value_descriptor;
 pub mod value_descriptor_subtypes;
 
+pub use command_descriptor::CommandDescriptor;
 pub use declared_relationship_descriptor::DeclaredRelationshipDescriptor;
 pub use descriptor::Descriptor;
 pub use holon_descriptor::HolonDescriptor;

--- a/shared_crates/type_system/type_names/src/holon_names.rs
+++ b/shared_crates/type_system/type_names/src/holon_names.rs
@@ -6,6 +6,7 @@ use strum_macros::VariantNames;
 pub enum CoreHolonTypeName {
     BytesValueConstraint,
     Collection,
+    CommandType,
     CommitResponseType,
     Dance,
     DanceType,
@@ -45,6 +46,10 @@ mod tests {
         assert_eq!(
             MapString("Collection".to_string()),
             CoreHolonTypeName::Collection.as_holon_name()
+        );
+        assert_eq!(
+            MapString("CommandType".to_string()),
+            CoreHolonTypeName::CommandType.as_holon_name()
         );
         assert_eq!(
             MapString("DeclaredRelationshipType".to_string()),

--- a/shared_crates/type_system/type_names/src/relationship_names.rs
+++ b/shared_crates/type_system/type_names/src/relationship_names.rs
@@ -68,6 +68,7 @@ impl ToRelationshipName for &RelationshipName {
 pub enum CoreRelationshipTypeName {
     AbandonedHolons,
     AffordedBy,
+    AffordsCommand,
     AffordsOperator,
     BundleMembers,
     ComponentOf,
@@ -123,6 +124,10 @@ mod tests {
         assert_eq!(
             RelationshipName(MapString("ComponentOf".to_string())),
             CoreRelationshipTypeName::ComponentOf.as_relationship_name()
+        );
+        assert_eq!(
+            RelationshipName(MapString("AffordsCommand".to_string())),
+            CoreRelationshipTypeName::AffordsCommand.as_relationship_name()
         );
         assert_eq!(
             RelationshipName(MapString("Extends".to_string())),

--- a/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
+++ b/tests/sweetests/import_files/MAP Schema Types-map-test-schema-book-person-inverse.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-05T11:58:05",
+    "generated_at": "2026-05-20T16:28:35",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-test-schema-book-person-inverse.csv"
@@ -29,7 +29,7 @@
         {
           "name": "DependsOn",
           "target": {
-            "$ref": "#MAP Core Schema-v0.0.6"
+            "$ref": "#MAP Core Schema-v0.0.7"
           }
         }
       ]

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -32,7 +32,7 @@ pub struct CoreSchemaLoadMetrics {
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
     staged: 246,
     committed: 246,
-    links_created: 1275,
+    links_created: 1290,
     errors: 0,
     total_bundles: 10,
     total_loader_holons: 246,

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -6,8 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const CORE_SCHEMA_RELATIVE_PATHS: [&str; 9] = [
+const CORE_SCHEMA_RELATIVE_PATHS: [&str; 10] = [
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json",
+    "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-command-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json",
@@ -29,12 +30,12 @@ pub struct CoreSchemaLoadMetrics {
 }
 
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
-    staged: 206,
-    committed: 206,
-    links_created: 1109,
+    staged: 246,
+    committed: 246,
+    links_created: 1275,
     errors: 0,
-    total_bundles: 9,
-    total_loader_holons: 206,
+    total_bundles: 10,
+    total_loader_holons: 246,
 };
 
 /// Absolute paths to all core schema import files used for loader-client testing.

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -206,6 +206,18 @@ impl DancesTestCase {
         Ok(())
     }
 
+    pub fn add_verify_core_schema_command_affordances_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Verify core schema command affordances".to_string());
+        self.steps.push(DanceTestStep::VerifyCoreSchemaCommandAffordances { description });
+
+        Ok(())
+    }
+
     pub fn add_verify_core_schema_value_semantics_step(
         &mut self,
         description: Option<String>,

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -64,6 +64,9 @@ pub enum DanceTestStep {
     VerifyCoreSchemaDescriptors {
         description: String,
     },
+    VerifyCoreSchemaCommandAffordances {
+        description: String,
+    },
     VerifyCoreSchemaValueSemantics {
         description: String,
     },
@@ -184,6 +187,9 @@ impl core::fmt::Display for DanceTestStep {
                 write!(f, "{description}")
             }
             DanceTestStep::VerifyCoreSchemaDescriptors { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::VerifyCoreSchemaCommandAffordances { description } => {
                 write!(f, "{description}")
             }
             DanceTestStep::VerifyCoreSchemaValueSemantics { description } => {

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -33,6 +33,7 @@ use tracing::{
 use execution_steps::abandon_staged_changes_executor::execute_abandon_staged_changes;
 use execution_steps::add_related_holons_executor::execute_add_related_holons;
 use execution_steps::begin_transaction_executor::execute_begin_transaction;
+use execution_steps::command_affordance_verification_executor::execute_verify_core_schema_command_affordances;
 use execution_steps::commit_executor::execute_commit;
 use execution_steps::delete_holon_executor::execute_delete_holon;
 use execution_steps::descriptor_verification_executor::{
@@ -211,6 +212,9 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
             }
             DanceTestStep::VerifyCoreSchemaDescriptors { .. } => {
                 execute_verify_core_schema_descriptors(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifyCoreSchemaCommandAffordances { .. } => {
+                execute_verify_core_schema_command_affordances(&mut test_execution_state).await
             }
             DanceTestStep::VerifyCoreSchemaValueSemantics { .. } => {
                 execute_verify_core_schema_value_semantics(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
@@ -1,0 +1,245 @@
+use holons_core::descriptors::{CommandDescriptor, HolonDescriptor, RelationshipDescriptor};
+use holons_prelude::prelude::*;
+use holons_test::TestExecutionState;
+use map_commands_contract::{MapCommand, MapResult, TransactionAction, TransactionCommand};
+use pretty_assertions::assert_eq;
+use tracing::info;
+
+const STABLE_COMMAND_TYPES: &[(&str, &str)] = &[
+    ("BeginTransaction.CommandType", "BeginTransaction"),
+    ("CloneHolon.CommandType", "CloneHolon"),
+    ("GetEssentialContent.CommandType", "GetEssentialContent"),
+    ("Summarize.CommandType", "Summarize"),
+    ("GetHolonId.CommandType", "GetHolonId"),
+    ("GetPredecessor.CommandType", "GetPredecessor"),
+    ("GetKey.CommandType", "GetKey"),
+    ("GetVersionedKey.CommandType", "GetVersionedKey"),
+    ("GetPropertyValue.CommandType", "GetPropertyValue"),
+    ("GetRelatedHolons.CommandType", "GetRelatedHolons"),
+    ("WithPropertyValue.CommandType", "WithPropertyValue"),
+    ("RemovePropertyValue.CommandType", "RemovePropertyValue"),
+    ("AddRelatedHolons.CommandType", "AddRelatedHolons"),
+    ("RemoveRelatedHolons.CommandType", "RemoveRelatedHolons"),
+    ("WithDescriptor.CommandType", "WithDescriptor"),
+    ("Commit.CommandType", "Commit"),
+    ("UndoLast.CommandType", "UndoLast"),
+    ("RedoLast.CommandType", "RedoLast"),
+    ("UndoToMarker.CommandType", "UndoToMarker"),
+    ("RedoToMarker.CommandType", "RedoToMarker"),
+    ("LoadHolons.CommandType", "LoadHolons"),
+    ("Dance.CommandType", "Dance"),
+    ("Query.CommandType", "Query"),
+    ("GetAllHolons.CommandType", "GetAllHolons"),
+    ("GetStagedHolonByBaseKey.CommandType", "GetStagedHolonByBaseKey"),
+    ("GetStagedHolonsByBaseKey.CommandType", "GetStagedHolonsByBaseKey"),
+    ("GetStagedHolonByVersionedKey.CommandType", "GetStagedHolonByVersionedKey"),
+    ("GetTransientHolonByBaseKey.CommandType", "GetTransientHolonByBaseKey"),
+    ("GetTransientHolonByVersionedKey.CommandType", "GetTransientHolonByVersionedKey"),
+    ("GetStagedCount.CommandType", "GetStagedCount"),
+    ("GetTransientCount.CommandType", "GetTransientCount"),
+    ("NewHolon.CommandType", "NewHolon"),
+    ("StageNewHolon.CommandType", "StageNewHolon"),
+    ("StageNewFromClone.CommandType", "StageNewFromClone"),
+    ("StageNewVersion.CommandType", "StageNewVersion"),
+    ("StageNewVersionFromId.CommandType", "StageNewVersionFromId"),
+    ("DeleteHolon.CommandType", "DeleteHolon"),
+];
+
+const HOLON_TYPE_AFFORDED_COMMANDS: &[&str] = &[
+    "CloneHolon",
+    "GetEssentialContent",
+    "Summarize",
+    "GetHolonId",
+    "GetPredecessor",
+    "GetKey",
+    "GetVersionedKey",
+    "GetPropertyValue",
+    "GetRelatedHolons",
+    "WithPropertyValue",
+    "RemovePropertyValue",
+    "AddRelatedHolons",
+    "RemoveRelatedHolons",
+    "WithDescriptor",
+];
+
+/// Verifies command descriptor inventory and schema-backed command affordance lookup.
+pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExecutionState) {
+    let holons = loaded_holons(state, "verify_core_schema_command_affordances").await;
+
+    let command_type = CommandDescriptor::from_holon(find_holon_by_key(&holons, "CommandType"));
+    assert_eq!(
+        command_type.command_name().expect("CommandType command_name"),
+        MapString("CommandType".to_string())
+    );
+    assert!(command_type.header().is_abstract_type().expect("CommandType is_abstract_type"));
+
+    for (key, expected_type_name) in STABLE_COMMAND_TYPES {
+        let command = CommandDescriptor::from_holon(find_holon_by_key(&holons, key));
+        assert_eq!(
+            command.command_name().expect("concrete command command_name"),
+            MapString((*expected_type_name).to_string()),
+            "{key} should expose its command identity through type_name"
+        );
+    }
+
+    let affordance_relationship = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        "(HolonType)-[AffordsCommand]->(CommandType)",
+    ))
+    .try_into_declared_relationship_descriptor()
+    .expect("AffordsCommand should be a declared relationship descriptor");
+    assert_eq!(
+        affordance_relationship
+            .base_relationship_name()
+            .expect("AffordsCommand base_relationship_name")
+            .to_string(),
+        "AffordsCommand"
+    );
+    assert_eq!(
+        affordance_relationship
+            .source_type()
+            .expect("AffordsCommand source_type")
+            .header()
+            .type_name()
+            .expect("AffordsCommand source type_name"),
+        MapString("HolonType".to_string())
+    );
+    assert_eq!(
+        affordance_relationship
+            .target_type()
+            .expect("AffordsCommand target_type")
+            .header()
+            .type_name()
+            .expect("AffordsCommand target type_name"),
+        MapString("CommandType".to_string())
+    );
+
+    let inverse_relationship = RelationshipDescriptor::from_holon(find_holon_by_key(
+        &holons,
+        "(CommandType)-[AffordedBy]->(HolonType)",
+    ))
+    .try_into_inverse_relationship_descriptor()
+    .expect("AffordedBy should be an inverse relationship descriptor");
+    assert_eq!(
+        inverse_relationship
+            .inverse_of()
+            .expect("AffordedBy inverse_of")
+            .base_relationship_name()
+            .expect("AffordedBy inverse_of base name")
+            .to_string(),
+        "AffordsCommand"
+    );
+
+    let holon_type_descriptor =
+        HolonDescriptor::from_holon(find_holon_by_key(&holons, "HolonType"));
+    let instance_relationship_names =
+        relationship_base_names(holon_type_descriptor.instance_relationships());
+    assert_contains(&instance_relationship_names, "AffordsCommand");
+
+    assert_command_set_eq(
+        command_names(holon_type_descriptor.afforded_commands()),
+        HOLON_TYPE_AFFORDED_COMMANDS,
+        "HolonType should afford exactly the PR4 holon-scoped commands",
+    );
+    assert_eq!(
+        holon_type_descriptor
+            .get_command_by_name(MapString("GetKey".to_string()))
+            .expect("GetKey lookup")
+            .command_name()
+            .expect("resolved GetKey command_name"),
+        MapString("GetKey".to_string())
+    );
+    assert!(matches!(
+        holon_type_descriptor.get_command_by_name(MapString("NonexistentCommand".to_string())),
+        Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
+            if kind == "command" && name == "NonexistentCommand"
+    ));
+
+    let schema_type_descriptor =
+        HolonDescriptor::from_holon(find_holon_by_key(&holons, "SchemaType"));
+    assert_command_set_eq(
+        command_names(schema_type_descriptor.afforded_commands()),
+        HOLON_TYPE_AFFORDED_COMMANDS,
+        "SchemaType should inherit HolonType's command affordances",
+    );
+
+    let holon_space_type_descriptor =
+        HolonDescriptor::from_holon(find_holon_by_key(&holons, "HolonSpaceType"));
+    let mut holon_space_commands: Vec<&str> = HOLON_TYPE_AFFORDED_COMMANDS.to_vec();
+    holon_space_commands.push("BeginTransaction");
+    assert_command_set_eq(
+        command_names(holon_space_type_descriptor.afforded_commands()),
+        &holon_space_commands,
+        "HolonSpaceType should afford BeginTransaction and inherit HolonType commands",
+    );
+
+    info!(
+        "verified core schema command inventory and HolonType command affordances: {:?}",
+        HOLON_TYPE_AFFORDED_COMMANDS
+    );
+}
+
+async fn loaded_holons(state: &mut TestExecutionState, step_name: &str) -> HolonCollection {
+    let context = state.open_assertion_context(step_name).await.unwrap_or_else(|error| {
+        panic!("{step_name}: failed to open assertion transaction: {error:?}")
+    });
+
+    let command = MapCommand::Transaction(TransactionCommand {
+        context: context.clone(),
+        action: TransactionAction::GetAllHolons,
+    });
+    let result = state
+        .dispatch_command(command, step_name)
+        .await
+        .unwrap_or_else(|error| panic!("{step_name}: get_all_holons failed: {error:?}"));
+
+    match result {
+        MapResult::Collection(collection) => collection,
+        other => panic!("{step_name}: expected Collection, got {other:?}"),
+    }
+}
+
+fn find_holon_by_key(holons: &HolonCollection, key: &str) -> HolonReference {
+    holons
+        .get_by_key(&MapString::from(key))
+        .unwrap_or_else(|error| panic!("key lookup for {key} failed: {error:?}"))
+        .unwrap_or_else(|| panic!("expected loaded holon with key {key}"))
+}
+
+fn relationship_base_names(
+    descriptors: Result<Vec<RelationshipDescriptor>, HolonError>,
+) -> Vec<String> {
+    descriptors
+        .expect("relationship descriptor list")
+        .into_iter()
+        .map(|descriptor| {
+            descriptor
+                .base_relationship_name()
+                .expect("relationship descriptor base name")
+                .to_string()
+        })
+        .collect()
+}
+
+fn assert_contains(values: &[String], expected: &str) {
+    assert!(
+        values.iter().any(|actual| actual == expected),
+        "expected {values:?} to contain {expected}"
+    );
+}
+
+fn command_names(descriptors: Result<Vec<CommandDescriptor>, HolonError>) -> Vec<String> {
+    descriptors
+        .expect("command descriptor list")
+        .into_iter()
+        .map(|descriptor| descriptor.command_name().expect("command_name").to_string())
+        .collect()
+}
+
+fn assert_command_set_eq(actual: Vec<String>, expected: &[&str], message: &str) {
+    let mut actual = actual;
+    let mut expected = expected.iter().map(|name| (*name).to_string()).collect::<Vec<_>>();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected, "{message}");
+}

--- a/tests/sweetests/tests/execution_steps/mod.rs
+++ b/tests/sweetests/tests/execution_steps/mod.rs
@@ -1,6 +1,7 @@
 pub mod abandon_staged_changes_executor;
 pub mod add_related_holons_executor;
 pub mod begin_transaction_executor;
+pub mod command_affordance_verification_executor;
 pub mod commit_executor;
 pub mod delete_holon_executor;
 pub mod descriptor_verification_executor;

--- a/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
@@ -14,6 +14,7 @@ pub fn load_core_schema_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_load_core_schema_step(None)?;
     test_case.add_verify_core_schema_descriptors_step(None)?;
     test_case.add_verify_core_schema_descriptor_subtypes_step(None)?;
+    test_case.add_verify_core_schema_command_affordances_step(None)?;
     test_case.add_verify_core_schema_value_semantics_step(None)?;
 
     test_case.finalize(&fixture_context)?;


### PR DESCRIPTION
## Summary

Implements Descriptors PR4 by introducing schema-backed command descriptor anchoring and descriptor-local command affordance discovery.

This PR adds:

- `CommandType` and concrete core command type holons for the stable MAP Commands leaf inventory
- `(HolonType)-[AffordsCommand]->(CommandType)` and inverse `(CommandType)-[AffordedBy]->(HolonType)`
- `holons_core::descriptors::CommandDescriptor` as a thin wrapper over `HolonReference`
- `HolonDescriptor::afforded_commands()`
- `HolonDescriptor::get_command_by_name(...)`
- `CoreHolonTypeName::CommandType`
- `CoreRelationshipTypeName::AffordsCommand`
- rename of `map_commands_contract::CommandDescriptor` to `CommandLifecyclePolicy`

Command identity is sourced from the command descriptor holon’s shared `type_name`. This PR intentionally does not add command routing, dispatch redistribution, execution behavior, DAHN/TypeScript surfaces, `CommandName` wrappers, or transaction model anchoring.

## Testing

Added coverage for:

- `CommandDescriptor` construction, descriptor trait behavior, and shared header/name access
- schema-backed command affordance flattening through `HolonDescriptor`
- lookup by concrete command `type_name`
- empty/missing command affordance behavior
- duplicate inherited command declarations
- cyclic and multiple `Extends` behavior
- lifecycle policy rename regression coverage
- Sweetest core schema verification for command inventory, `AffordsCommand`/`AffordedBy`, HolonType command affordances, inherited affordances, and `HolonSpaceType` `BeginTransaction`

Verified with targeted Rust checks and formatting.