### PR TITLE
502 descriptors pr4a   typekind specific names and descriptor accessor ergonomics

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,114 @@
+# MAP Holons
+
+This context defines the shared language for MAP holon runtime, query, navigation, dance, and command work in this repository.
+
+## Language
+
+**HolonReference**:
+The canonical singular bound runtime handle for a holon within a transaction.
+_Avoid_: Node id, raw holon pointer
+
+**BoundHolonCollection**:
+The canonical plural bound runtime result that carries a named collection of holon references without forcing row projection.
+_Avoid_: RowSet, HolonCollection as a cross-surface contract
+
+**BoundHolonCollectionReference**:
+A typed Rust facade over a HolonReference pointing at a holon-backed BoundHolonCollection.
+_Avoid_: Raw HolonCollection in new-world query contracts
+
+**ExecutionPlan**:
+A replayable MAP navigation/query view represented as holon-backed algebra operation nodes and accessed through typed Rust facades.
+_Avoid_: Plain query DTO, row pipeline
+
+**New-World Query Contract**:
+The descriptor-aware, bound-first query/navigation contract built around HolonReference, BoundHolonCollection, and holon-backed ExecutionPlans.
+_Avoid_: Legacy query bridge
+
+**NavigationQueryRequest**:
+The new-world transaction-bound request for executing MAP navigation/query work.
+_Avoid_: QueryRequest when old-world compatibility remains ambiguous
+
+**NavigationQuerySpec**:
+The new-world request discriminator for navigation/query execution modes.
+_Avoid_: QuerySpec when old-world compatibility remains ambiguous
+
+**NavigationQueryResult**:
+The new-world query result envelope that may return bound-first or materialized projection results.
+_Avoid_: NodeCollection
+
+**NavigationBindingSet**:
+The internal bound-first closure object for new-world navigation/query execution, carrying named holon bindings, bound collections, and topology/provenance needed for composition.
+_Avoid_: RowSet, a loose symbol table only
+
+**ExecutionPlanReference**:
+A typed Rust facade over a HolonReference pointing at a holon-backed ExecutionPlan.
+_Avoid_: Raw HolonReference when the plan role matters
+
+**Old-World Query Types**:
+Deprecated compatibility types retained only to avoid breaking existing tests and transitional consumers.
+_Avoid_: New query design foundation, Legacy-prefixed renames
+
+**Spec Revision Session**:
+A coherent design-update session that batches fine-grained decisions before applying one version bump per affected source spec.
+_Avoid_: Per-decision spec version bumps
+
+**PlanNode**:
+A holon-backed structural node in an ExecutionPlan that organizes one or more plan steps.
+_Avoid_: Result node, graph node
+
+**PlanStep**:
+A holon-backed navigation/query operation such as seed, expand, filter, project, distinct, order, skip, or limit.
+_Avoid_: Command action, dance step
+
+**Bound-First Operation**:
+A navigation/query operation that consumes and produces HolonReference or BoundHolonCollection values rather than row-shaped projections.
+_Avoid_: Row-native operator
+
+**FilterExpression**:
+A holon-backed predicate component combined by a FilterStep to preserve or remove members from a bound collection.
+_Avoid_: Freestanding query-owned operator semantics
+
+**BooleanConnective**:
+The single connective used by a FilterStep to combine its FilterExpressions.
+_Avoid_: Nested predicate tree for PRO3
+
+**Query Result**:
+The outcome of query execution, which may be bound-first through HolonReference or BoundHolonCollection, or materialized as BaseValue, Row, or RowSet at projection boundaries.
+_Avoid_: Query expression
+
+**Materialized Projection**:
+A scalar, row, or rowset shape produced when a contract, projection, ordering, distinctness, pagination, ABI, or serialization boundary requires values.
+_Avoid_: Internal execution state
+
+**ProjectStep**:
+The default PRO3 materialization boundary that converts bound query state into BaseValue, Row, or RowSet.
+_Avoid_: Implicit row materialization by order, distinct, skip, or limit
+
+## Relationships
+
+- A **NavigationQueryRequest** contains a **NavigationQuerySpec**.
+- A **NavigationQuerySpec** may execute an **ExecutionPlanReference**.
+- An **ExecutionPlan** contains one or more **PlanNodes**.
+- A **PlanNode** contains one or more **PlanSteps**.
+- Most **PlanSteps** are **Bound-First Operations**.
+- Most **PlanSteps** consume and produce a **NavigationBindingSet**.
+- A **NavigationBindingSet** is query-internal in PRO3 and is not a Commands, Dances, or SDK result contract.
+- A **BoundHolonCollection** is a real holon-backed contract type, even if implementation helpers reuse existing HolonCollection mechanics internally.
+- An **Expand** step extends a **NavigationBindingSet** with target **BoundHolonCollection** bindings and any topology/provenance needed for later composition.
+- A **Filter** step consumes a **NavigationBindingSet** and produces a filtered **NavigationBindingSet**.
+- A **Filter** step contains one or more **FilterExpressions** combined by exactly one **BooleanConnective** in PRO3.
+- **Distinct**, **OrderBy**, **Skip**, and **Limit** should preserve **NavigationBindingSet** as their carrier in PRO3.
+- A **ProjectStep** is the default operation that converts a **NavigationBindingSet** into a **Materialized Projection**.
+- A **NavigationQueryResult** may preserve bound holon state or return a **Materialized Projection**.
+- **Old-World Query Types** may remain for compatibility, but **New-World Query Contract** design must not depend on them.
+- A **Spec Revision Session** closes when the team produces a stable artifact for one coherent design slice, such as a revised issue body.
+
+## Example dialogue
+
+> **Dev:** "When a user expands a relationship and applies a filter, are we just building a JSON query?"
+> **Domain expert:** "No. We are building an **ExecutionPlan** from holon-backed **PlanSteps** so that navigation can be retrieved and replayed later."
+
+## Flagged ambiguities
+
+- "query expression" has been used to mean both the executable navigation/query structure and the returned query data. Resolved: use **ExecutionPlan**, **PlanNode**, and **PlanStep** for executable structure; use **Query Result** for returned data.
+- Existing `Node`, `NodeCollection`, `QueryPathMap`, and `QueryExpression` names should stay unchanged while deprecated compatibility code remains. Resolved: do not rename them to `Legacy*`, do not extend them, and do not use them as foundations for new query/navigation design.

--- a/host/crates/map_commands_contract/src/holon_command.rs
+++ b/host/crates/map_commands_contract/src/holon_command.rs
@@ -41,14 +41,14 @@ impl HolonAction {
     pub fn label(&self) -> &'static str {
         match self {
             HolonAction::Read(ReadableHolonAction::CloneHolon) => "clone_holon",
-            HolonAction::Read(ReadableHolonAction::EssentialContent) => "essential_content",
+            HolonAction::Read(ReadableHolonAction::GetEssentialContent) => "get_essential_content",
             HolonAction::Read(ReadableHolonAction::Summarize) => "summarize",
-            HolonAction::Read(ReadableHolonAction::HolonId) => "holon_id",
-            HolonAction::Read(ReadableHolonAction::Predecessor) => "predecessor",
-            HolonAction::Read(ReadableHolonAction::Key) => "key",
-            HolonAction::Read(ReadableHolonAction::VersionedKey) => "versioned_key",
-            HolonAction::Read(ReadableHolonAction::PropertyValue { .. }) => "property_value",
-            HolonAction::Read(ReadableHolonAction::RelatedHolons { .. }) => "related_holons",
+            HolonAction::Read(ReadableHolonAction::GetHolonId) => "get_holon_id",
+            HolonAction::Read(ReadableHolonAction::GetPredecessor) => "get_predecessor",
+            HolonAction::Read(ReadableHolonAction::GetKey) => "get_key",
+            HolonAction::Read(ReadableHolonAction::GetVersionedKey) => "get_versioned_key",
+            HolonAction::Read(ReadableHolonAction::GetPropertyValue { .. }) => "get_property_value",
+            HolonAction::Read(ReadableHolonAction::GetRelatedHolons { .. }) => "get_related_holons",
             HolonAction::Write(_) => "holon_write",
         }
     }
@@ -66,28 +66,28 @@ pub enum ReadableHolonAction {
     CloneHolon,
 
     /// `ReadableHolon::essential_content()` → `EssentialHolonContent`
-    EssentialContent,
+    GetEssentialContent,
 
     /// `ReadableHolon::summarize()` → `String`
     Summarize,
 
     /// `ReadableHolon::holon_id()` → `HolonId`
-    HolonId,
+    GetHolonId,
 
     /// `ReadableHolon::predecessor()` → `Option<HolonReference>`
-    Predecessor,
+    GetPredecessor,
 
     /// `ReadableHolon::key()` → `Option<MapString>`
-    Key,
+    GetKey,
 
     /// `ReadableHolon::versioned_key()` → `MapString`
-    VersionedKey,
+    GetVersionedKey,
 
     /// `ReadableHolon::property_value(name)` → `Option<PropertyValue>`
-    PropertyValue { name: PropertyName },
+    GetPropertyValue { name: PropertyName },
 
     /// `ReadableHolon::related_holons(name)` → `HolonCollection`
-    RelatedHolons { name: RelationshipName },
+    GetRelatedHolons { name: RelationshipName },
 }
 
 /// Mutating holon actions.

--- a/host/crates/map_commands_contract/src/tests.rs
+++ b/host/crates/map_commands_contract/src/tests.rs
@@ -18,11 +18,11 @@ fn space_begin_transaction_policy() {
 fn transaction_action_policies() {
     assert_eq!(TransactionAction::Commit.policy(), CommandLifecyclePolicy::mutating_with_guard());
     assert_eq!(
-        TransactionAction::StagedCount.policy(),
+        TransactionAction::GetStagedCount.policy(),
         CommandLifecyclePolicy::transaction_read_only()
     );
     assert_eq!(
-        TransactionAction::TransientCount.policy(),
+        TransactionAction::GetTransientCount.policy(),
         CommandLifecyclePolicy::transaction_read_only()
     );
     assert_eq!(
@@ -42,7 +42,7 @@ fn transaction_action_policies() {
 #[test]
 fn holon_action_policies() {
     assert_eq!(
-        HolonAction::Read(ReadableHolonAction::Key).policy(),
+        HolonAction::Read(ReadableHolonAction::GetKey).policy(),
         CommandLifecyclePolicy::holon_read_only()
     );
     assert_eq!(

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -69,10 +69,10 @@ pub enum TransactionAction {
     GetTransientHolonByVersionedKey { key: MapString },
 
     /// `staged_count()` → `i64`
-    StagedCount,
+    GetStagedCount,
 
     /// `transient_count()` → `i64`
-    TransientCount,
+    GetTransientCount,
 
     // ── Mutation actions (MutationFacade) ─────────────────────────────
     /// `new_holon(key)` → `TransientReference`
@@ -119,8 +119,10 @@ impl TransactionAction {
             | TransactionAction::GetStagedHolonByVersionedKey { .. }
             | TransactionAction::GetTransientHolonByBaseKey { .. }
             | TransactionAction::GetTransientHolonByVersionedKey { .. }
-            | TransactionAction::StagedCount
-            | TransactionAction::TransientCount => CommandLifecyclePolicy::transaction_read_only(),
+            | TransactionAction::GetStagedCount
+            | TransactionAction::GetTransientCount => {
+                CommandLifecyclePolicy::transaction_read_only()
+            }
 
             // Mutations
             TransactionAction::NewHolon { .. }
@@ -154,8 +156,8 @@ impl TransactionAction {
             TransactionAction::GetTransientHolonByVersionedKey { .. } => {
                 "get_transient_holon_by_versioned_key"
             }
-            TransactionAction::StagedCount => "staged_count",
-            TransactionAction::TransientCount => "transient_count",
+            TransactionAction::GetStagedCount => "get_staged_count",
+            TransactionAction::GetTransientCount => "get_transient_count",
             TransactionAction::NewHolon { .. } => "new_holon",
             TransactionAction::StageNewHolon { .. } => "stage_new_holon",
             TransactionAction::StageNewFromClone { .. } => "stage_new_from_clone",

--- a/host/crates/map_commands_runtime/src/holon_handler.rs
+++ b/host/crates/map_commands_runtime/src/holon_handler.rs
@@ -23,7 +23,7 @@ fn handle_read(
             let transient = target.clone_holon()?;
             Ok(MapResult::Reference(HolonReference::Transient(transient)))
         }
-        ReadableHolonAction::EssentialContent => {
+        ReadableHolonAction::GetEssentialContent => {
             let content = target.essential_content()?;
             Ok(MapResult::EssentialContent(content))
         }
@@ -31,27 +31,27 @@ fn handle_read(
             let summary = target.summarize()?;
             Ok(MapResult::Value(BaseValue::StringValue(MapString::from(summary))))
         }
-        ReadableHolonAction::HolonId => {
+        ReadableHolonAction::GetHolonId => {
             let id = target.holon_id()?;
             Ok(MapResult::HolonId(id))
         }
-        ReadableHolonAction::Predecessor => match target.predecessor()? {
+        ReadableHolonAction::GetPredecessor => match target.predecessor()? {
             Some(r) => Ok(MapResult::Reference(r)),
             None => Ok(MapResult::None),
         },
-        ReadableHolonAction::Key => match target.key()? {
+        ReadableHolonAction::GetKey => match target.key()? {
             Some(s) => Ok(MapResult::Value(BaseValue::StringValue(s))),
             None => Ok(MapResult::None),
         },
-        ReadableHolonAction::VersionedKey => {
+        ReadableHolonAction::GetVersionedKey => {
             let key = target.versioned_key()?;
             Ok(MapResult::Value(BaseValue::StringValue(key)))
         }
-        ReadableHolonAction::PropertyValue { name } => match target.property_value(name)? {
+        ReadableHolonAction::GetPropertyValue { name } => match target.property_value(name)? {
             Some(v) => Ok(MapResult::Value(v)),
             None => Ok(MapResult::None),
         },
-        ReadableHolonAction::RelatedHolons { name } => {
+        ReadableHolonAction::GetRelatedHolons { name } => {
             let collection_arc = target.related_holons(name)?;
             let collection = collection_arc
                 .read()

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -207,7 +207,7 @@ async fn staged_count_returns_zero_for_new_tx() {
 
     let result = runtime
         .execute_command(
-            tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),
+            tx_cmd(&runtime, &tx_id, TransactionAction::GetStagedCount),
             ExecutionPolicy::default(),
         )
         .await
@@ -226,7 +226,7 @@ async fn transient_count_returns_zero_for_new_tx() {
 
     let result = runtime
         .execute_command(
-            tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount),
+            tx_cmd(&runtime, &tx_id, TransactionAction::GetTransientCount),
             ExecutionPolicy::default(),
         )
         .await
@@ -293,7 +293,7 @@ async fn new_holon_then_transient_count() {
     // Transient count should be 1
     let result = runtime
         .execute_command(
-            tx_cmd(&runtime, &tx_id, TransactionAction::TransientCount),
+            tx_cmd(&runtime, &tx_id, TransactionAction::GetTransientCount),
             ExecutionPolicy::default(),
         )
         .await
@@ -335,10 +335,10 @@ async fn new_holon_stage_then_staged_count() {
         other => panic!("expected Staged reference, got {:?}", other),
     }
 
-    // StagedCount should be 1
+    // GetStagedCount should be 1
     let result = runtime
         .execute_command(
-            tx_cmd(&runtime, &tx_id, TransactionAction::StagedCount),
+            tx_cmd(&runtime, &tx_id, TransactionAction::GetStagedCount),
             ExecutionPolicy::default(),
         )
         .await
@@ -397,11 +397,11 @@ async fn stage_and_close(runtime: &Runtime, tx_id: &TxId, key: &str) {
 async fn staged_count(runtime: &Runtime, tx_id: &TxId) -> i64 {
     let result = runtime
         .execute_command(
-            tx_cmd(runtime, tx_id, TransactionAction::StagedCount),
+            tx_cmd(runtime, tx_id, TransactionAction::GetStagedCount),
             ExecutionPolicy::default(),
         )
         .await
-        .expect("StagedCount should succeed");
+        .expect("GetStagedCount should succeed");
     match result {
         MapResult::Value(BaseValue::IntegerValue(MapInteger(n))) => n,
         other => panic!("expected IntegerValue, got {:?}", other),

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -70,11 +70,11 @@ pub async fn handle_transaction(
             let transient = context.lookup().get_transient_holon_by_versioned_key(&key)?;
             Ok(MapResult::Reference(HolonReference::Transient(transient)))
         }
-        TransactionAction::StagedCount => {
+        TransactionAction::GetStagedCount => {
             let count = context.lookup().staged_count()?;
             Ok(MapResult::Value(BaseValue::IntegerValue(MapInteger(count))))
         }
-        TransactionAction::TransientCount => {
+        TransactionAction::GetTransientCount => {
             let count = context.lookup().transient_count()?;
             Ok(MapResult::Value(BaseValue::IntegerValue(MapInteger(count))))
         }

--- a/host/crates/map_commands_wire/src/holon_wire.rs
+++ b/host/crates/map_commands_wire/src/holon_wire.rs
@@ -34,28 +34,28 @@ pub enum ReadableHolonActionWire {
     CloneHolon,
 
     /// `essential_content()` → `EssentialHolonContent`
-    EssentialContent,
+    GetEssentialContent,
 
     /// `summarize()` → `String`
     Summarize,
 
     /// `holon_id()` → `HolonId`
-    HolonId,
+    GetHolonId,
 
     /// `predecessor()` → `Option<HolonReference>`
-    Predecessor,
+    GetPredecessor,
 
     /// `key()` → `Option<MapString>`
-    Key,
+    GetKey,
 
     /// `versioned_key()` → `MapString`
-    VersionedKey,
+    GetVersionedKey,
 
     /// `property_value(name)` → `Option<PropertyValue>`
-    PropertyValue { name: PropertyName },
+    GetPropertyValue { name: PropertyName },
 
     /// `related_holons(name)` → `HolonCollection`
-    RelatedHolons { name: RelationshipName },
+    GetRelatedHolons { name: RelationshipName },
 }
 
 /// Wire-level write (mutating) holon actions.
@@ -106,17 +106,19 @@ impl ReadableHolonActionWire {
     fn bind(self) -> ReadableHolonAction {
         match self {
             ReadableHolonActionWire::CloneHolon => ReadableHolonAction::CloneHolon,
-            ReadableHolonActionWire::EssentialContent => ReadableHolonAction::EssentialContent,
-            ReadableHolonActionWire::Summarize => ReadableHolonAction::Summarize,
-            ReadableHolonActionWire::HolonId => ReadableHolonAction::HolonId,
-            ReadableHolonActionWire::Predecessor => ReadableHolonAction::Predecessor,
-            ReadableHolonActionWire::Key => ReadableHolonAction::Key,
-            ReadableHolonActionWire::VersionedKey => ReadableHolonAction::VersionedKey,
-            ReadableHolonActionWire::PropertyValue { name } => {
-                ReadableHolonAction::PropertyValue { name }
+            ReadableHolonActionWire::GetEssentialContent => {
+                ReadableHolonAction::GetEssentialContent
             }
-            ReadableHolonActionWire::RelatedHolons { name } => {
-                ReadableHolonAction::RelatedHolons { name }
+            ReadableHolonActionWire::Summarize => ReadableHolonAction::Summarize,
+            ReadableHolonActionWire::GetHolonId => ReadableHolonAction::GetHolonId,
+            ReadableHolonActionWire::GetPredecessor => ReadableHolonAction::GetPredecessor,
+            ReadableHolonActionWire::GetKey => ReadableHolonAction::GetKey,
+            ReadableHolonActionWire::GetVersionedKey => ReadableHolonAction::GetVersionedKey,
+            ReadableHolonActionWire::GetPropertyValue { name } => {
+                ReadableHolonAction::GetPropertyValue { name }
+            }
+            ReadableHolonActionWire::GetRelatedHolons { name } => {
+                ReadableHolonAction::GetRelatedHolons { name }
             }
         }
     }

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -70,10 +70,10 @@ pub enum TransactionActionWire {
     GetTransientHolonByVersionedKey { key: MapString },
 
     /// `staged_count()` → `i64`
-    StagedCount,
+    GetStagedCount,
 
     /// `transient_count()` → `i64`
-    TransientCount,
+    GetTransientCount,
 
     // ── Mutation actions ─────────────────────────────────────────────
     /// `new_holon(key)` → `TransientReference`
@@ -146,8 +146,8 @@ impl TransactionActionWire {
             TransactionActionWire::GetTransientHolonByVersionedKey { key } => {
                 Ok(TransactionAction::GetTransientHolonByVersionedKey { key })
             }
-            TransactionActionWire::StagedCount => Ok(TransactionAction::StagedCount),
-            TransactionActionWire::TransientCount => Ok(TransactionAction::TransientCount),
+            TransactionActionWire::GetStagedCount => Ok(TransactionAction::GetStagedCount),
+            TransactionActionWire::GetTransientCount => Ok(TransactionAction::GetTransientCount),
 
             // Mutation actions — some require context binding
             TransactionActionWire::NewHolon { key } => Ok(TransactionAction::NewHolon { key }),

--- a/host/crates/map_commands_wire/tests/generate_fixtures.rs
+++ b/host/crates/map_commands_wire/tests/generate_fixtures.rs
@@ -166,12 +166,12 @@ fn generate_fixtures() {
     write_fixture(
         &fixtures_dir,
         "request-tx-staged-count.json",
-        &request(12, tx_command(41, TransactionActionWire::StagedCount), default_options()),
+        &request(12, tx_command(41, TransactionActionWire::GetStagedCount), default_options()),
     );
     write_fixture(
         &fixtures_dir,
         "request-tx-transient-count.json",
-        &request(13, tx_command(41, TransactionActionWire::TransientCount), default_options()),
+        &request(13, tx_command(41, TransactionActionWire::GetTransientCount), default_options()),
     );
     write_fixture(
         &fixtures_dir,
@@ -199,7 +199,7 @@ fn generate_fixtures() {
             holon_command(
                 41,
                 staged_reference(41, uuid_b()),
-                HolonActionWire::Read(ReadableHolonActionWire::PropertyValue {
+                HolonActionWire::Read(ReadableHolonActionWire::GetPropertyValue {
                     name: property_name("title"),
                 }),
             ),
@@ -214,7 +214,7 @@ fn generate_fixtures() {
             holon_command(
                 41,
                 smart_reference(41, local_holon_id(&[61, 62, 63]), None),
-                HolonActionWire::Read(ReadableHolonActionWire::RelatedHolons {
+                HolonActionWire::Read(ReadableHolonActionWire::GetRelatedHolons {
                     name: relationship_name("children"),
                 }),
             ),
@@ -229,7 +229,7 @@ fn generate_fixtures() {
             holon_command(
                 41,
                 staged_reference(41, uuid_b()),
-                HolonActionWire::Read(ReadableHolonActionWire::EssentialContent),
+                HolonActionWire::Read(ReadableHolonActionWire::GetEssentialContent),
             ),
             default_options(),
         ),
@@ -242,7 +242,7 @@ fn generate_fixtures() {
             holon_command(
                 41,
                 staged_reference(41, uuid_b()),
-                HolonActionWire::Read(ReadableHolonActionWire::Key),
+                HolonActionWire::Read(ReadableHolonActionWire::GetKey),
             ),
             default_options(),
         ),

--- a/host/map-sdk/src/internal/commands/holon.ts
+++ b/host/map-sdk/src/internal/commands/holon.ts
@@ -94,7 +94,7 @@ export function essentialContent(
   return runHolonCommand(
     txId,
     target,
-    { Read: 'EssentialContent' },
+    { Read: 'GetEssentialContent' },
     expectEssentialContent,
     options,
   );
@@ -128,7 +128,7 @@ export function readHolonId(
   return runHolonCommand(
     txId,
     target,
-    { Read: 'HolonId' },
+    { Read: 'GetHolonId' },
     expectHolonId,
     options,
   );
@@ -145,7 +145,7 @@ export function predecessor(
   return runHolonCommand(
     txId,
     target,
-    { Read: 'Predecessor' },
+    { Read: 'GetPredecessor' },
     expectOptionalReference,
     options,
   );
@@ -162,7 +162,7 @@ export function readKey(
   return runHolonCommand(
     txId,
     target,
-    { Read: 'Key' },
+    { Read: 'GetKey' },
     expectOptionalValue,
     options,
   );
@@ -179,7 +179,7 @@ export function readVersionedKey(
   return runHolonCommand(
     txId,
     target,
-    { Read: 'VersionedKey' },
+    { Read: 'GetVersionedKey' },
     expectValue,
     options,
   );
@@ -199,7 +199,7 @@ export function readPropertyValue(
     target,
     {
       Read: {
-        PropertyValue: {
+        GetPropertyValue: {
           name,
         },
       },
@@ -223,7 +223,7 @@ export function readRelatedHolons(
     target,
     {
       Read: {
-        RelatedHolons: {
+        GetRelatedHolons: {
           name,
         },
       },

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -369,7 +369,7 @@ export function stagedCount(
   txId: TxId,
   options?: RequestOptionsOverrides,
 ): Promise<BaseValue> {
-  return runTransactionCommand(txId, 'StagedCount', expectValue, options);
+  return runTransactionCommand(txId, 'GetStagedCount', expectValue, options);
 }
 
 /**
@@ -379,7 +379,7 @@ export function transientCount(
   txId: TxId,
   options?: RequestOptionsOverrides,
 ): Promise<BaseValue> {
-  return runTransactionCommand(txId, 'TransientCount', expectValue, options);
+  return runTransactionCommand(txId, 'GetTransientCount', expectValue, options);
 }
 
 /**

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -73,8 +73,8 @@ export type TransactionActionWire =
   | { GetStagedHolonByVersionedKey: { key: string } }
   | { GetTransientHolonByBaseKey: { key: string } }
   | { GetTransientHolonByVersionedKey: { key: string } }
-  | 'StagedCount'
-  | 'TransientCount'
+  | 'GetStagedCount'
+  | 'GetTransientCount'
   | { NewHolon: { key: string | null } }
   | { StageNewHolon: { source: TransientReferenceWire } }
   | { StageNewFromClone: { original: HolonReferenceWire; new_key: string } }
@@ -95,14 +95,14 @@ export interface HolonCommandWire {
 // Read-only holon actions.
 export type ReadableHolonActionWire =
   | 'CloneHolon'
-  | 'EssentialContent'
+  | 'GetEssentialContent'
   | 'Summarize'
-  | 'HolonId'
-  | 'Predecessor'
-  | 'Key'
-  | 'VersionedKey'
-  | { PropertyValue: { name: PropertyName } }
-  | { RelatedHolons: { name: RelationshipName } };
+  | 'GetHolonId'
+  | 'GetPredecessor'
+  | 'GetKey'
+  | 'GetVersionedKey'
+  | { GetPropertyValue: { name: PropertyName } }
+  | { GetRelatedHolons: { name: RelationshipName } };
 
 // Mutating holon actions.
 export type WritableHolonActionWire =
@@ -135,12 +135,12 @@ export type MapCommandWire =
 
 const READABLE_HOLON_UNIT_ACTIONS = new Set<ReadableHolonActionWire>([
   'CloneHolon',
-  'EssentialContent',
+  'GetEssentialContent',
   'Summarize',
-  'HolonId',
-  'Predecessor',
-  'Key',
-  'VersionedKey',
+  'GetHolonId',
+  'GetPredecessor',
+  'GetKey',
+  'GetVersionedKey',
 ]);
 
 const TRANSACTION_UNIT_ACTIONS = new Set([
@@ -148,8 +148,8 @@ const TRANSACTION_UNIT_ACTIONS = new Set([
   'UndoLast',
   'RedoLast',
   'GetAllHolons',
-  'StagedCount',
-  'TransientCount',
+  'GetStagedCount',
+  'GetTransientCount',
 ]);
 
 /**
@@ -193,10 +193,10 @@ export function isReadableHolonActionWire(
   return (
     (typeof value === 'string' &&
       READABLE_HOLON_UNIT_ACTIONS.has(value as ReadableHolonActionWire)) ||
-    (hasSingleKey(value, 'PropertyValue') &&
-      isStringFieldObject(value.PropertyValue, 'name')) ||
-    (hasSingleKey(value, 'RelatedHolons') &&
-      isStringFieldObject(value.RelatedHolons, 'name'))
+    (hasSingleKey(value, 'GetPropertyValue') &&
+      isStringFieldObject(value.GetPropertyValue, 'name')) ||
+    (hasSingleKey(value, 'GetRelatedHolons') &&
+      isStringFieldObject(value.GetRelatedHolons, 'name'))
   );
 }
 

--- a/host/map-sdk/tests/commands/holon.test.ts
+++ b/host/map-sdk/tests/commands/holon.test.ts
@@ -148,7 +148,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'essentialContent',
     run: () => essentialContent(txId, target),
-    action: { Read: 'EssentialContent' },
+    action: { Read: 'GetEssentialContent' },
     okResult: { EssentialContent: essential },
     expected: essential,
     wrongResult: { Reference: transientReference },
@@ -164,7 +164,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'readHolonId',
     run: () => readHolonId(txId, target),
-    action: { Read: 'HolonId' },
+    action: { Read: 'GetHolonId' },
     okResult: { HolonId: holonId },
     expected: holonId,
     wrongResult: { Value: integerValue },
@@ -172,7 +172,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'predecessor',
     run: () => predecessor(txId, target),
-    action: { Read: 'Predecessor' },
+    action: { Read: 'GetPredecessor' },
     okResult: { Reference: transientReference },
     expected: transientReference,
     wrongResult: { Value: stringValue },
@@ -180,7 +180,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'readKey',
     run: () => readKey(txId, target),
-    action: { Read: 'Key' },
+    action: { Read: 'GetKey' },
     okResult: { Value: stringValue },
     expected: stringValue,
     wrongResult: { Reference: transientReference },
@@ -188,7 +188,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'readVersionedKey',
     run: () => readVersionedKey(txId, target),
-    action: { Read: 'VersionedKey' },
+    action: { Read: 'GetVersionedKey' },
     okResult: { Value: stringValue },
     expected: stringValue,
     wrongResult: 'None',
@@ -196,7 +196,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'readPropertyValue',
     run: () => readPropertyValue(txId, target, 'title'),
-    action: { Read: { PropertyValue: { name: 'title' } } },
+    action: { Read: { GetPropertyValue: { name: 'title' } } },
     okResult: { Value: stringValue },
     expected: stringValue,
     wrongResult: { Reference: transientReference },
@@ -204,7 +204,7 @@ const holonCases: HolonCase<unknown>[] = [
   {
     name: 'readRelatedHolons',
     run: () => readRelatedHolons(txId, target, 'related_to'),
-    action: { Read: { RelatedHolons: { name: 'related_to' } } },
+    action: { Read: { GetRelatedHolons: { name: 'related_to' } } },
     okResult: { Collection: collection },
     expected: collection,
     wrongResult: { References: [transientReference] },
@@ -304,14 +304,14 @@ describe('holon command builders', () => {
     invokeMapCommandMock.mockResolvedValue(okResponse('None'));
 
     await expect(predecessor(txId, target)).resolves.toBeNull();
-    expectHolonRequest({ Read: 'Predecessor' });
+    expectHolonRequest({ Read: 'GetPredecessor' });
 
     invokeMapCommandMock.mockReset();
     resetRequestIdCounter();
     invokeMapCommandMock.mockResolvedValue(okResponse('None'));
 
     await expect(readKey(txId, target)).resolves.toBeNull();
-    expectHolonRequest({ Read: 'Key' });
+    expectHolonRequest({ Read: 'GetKey' });
   });
 
   it('passes request option overrides through holon builders', async () => {

--- a/host/map-sdk/tests/commands/transaction.test.ts
+++ b/host/map-sdk/tests/commands/transaction.test.ts
@@ -311,7 +311,7 @@ const transactionCases: TransactionCase<unknown>[] = [
   {
     name: 'stagedCount',
     run: () => stagedCount(txId),
-    action: 'StagedCount',
+    action: 'GetStagedCount',
     okResult: { Value: integerValue },
     expected: integerValue,
     wrongResult: 'None',
@@ -319,7 +319,7 @@ const transactionCases: TransactionCase<unknown>[] = [
   {
     name: 'transientCount',
     run: () => transientCount(txId),
-    action: 'TransientCount',
+    action: 'GetTransientCount',
     okResult: { Value: integerValue },
     expected: integerValue,
     wrongResult: 'None',

--- a/host/map-sdk/tests/fixtures/request-holon-read-essential.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-essential.json
@@ -10,7 +10,7 @@
         }
       },
       "action": {
-        "Read": "EssentialContent"
+        "Read": "GetEssentialContent"
       }
     }
   },

--- a/host/map-sdk/tests/fixtures/request-holon-read-key.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-key.json
@@ -10,7 +10,7 @@
         }
       },
       "action": {
-        "Read": "Key"
+        "Read": "GetKey"
       }
     }
   },

--- a/host/map-sdk/tests/fixtures/request-holon-read-property.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-property.json
@@ -11,7 +11,7 @@
       },
       "action": {
         "Read": {
-          "PropertyValue": {
+          "GetPropertyValue": {
             "name": "title"
           }
         }

--- a/host/map-sdk/tests/fixtures/request-holon-read-related.json
+++ b/host/map-sdk/tests/fixtures/request-holon-read-related.json
@@ -18,7 +18,7 @@
       },
       "action": {
         "Read": {
-          "RelatedHolons": {
+          "GetRelatedHolons": {
             "name": "children"
           }
         }

--- a/host/map-sdk/tests/fixtures/request-tx-staged-count.json
+++ b/host/map-sdk/tests/fixtures/request-tx-staged-count.json
@@ -3,7 +3,7 @@
   "command": {
     "Transaction": {
       "tx_id": 41,
-      "action": "StagedCount"
+      "action": "GetStagedCount"
     }
   },
   "options": {

--- a/host/map-sdk/tests/fixtures/request-tx-transient-count.json
+++ b/host/map-sdk/tests/fixtures/request-tx-transient-count.json
@@ -3,7 +3,7 @@
   "command": {
     "Transaction": {
       "tx_id": 41,
-      "action": "TransientCount"
+      "action": "GetTransientCount"
     }
   },
   "options": {

--- a/shared_crates/holons_core/src/descriptors/command_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/command_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::descriptors::{Descriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
-use base_types::MapString;
 use core_types::HolonError;
+use type_names::CommandName;
 
 /// Runtime wrapper for command descriptors.
 ///
@@ -24,8 +24,8 @@ impl CommandDescriptor {
     }
 
     /// Returns the command descriptor's canonical command name.
-    pub fn command_name(&self) -> Result<MapString, HolonError> {
-        self.header().type_name()
+    pub fn command_name(&self) -> Result<CommandName, HolonError> {
+        Ok(CommandName(self.header().type_name()?))
     }
 }
 
@@ -52,6 +52,7 @@ const _: fn() = || {
 mod tests {
     use super::*;
     use crate::descriptors::test_support::{build_context, new_descriptor_holon};
+    use base_types::MapString;
 
     #[test]
     fn wraps_reference_and_exposes_shared_header() -> Result<(), HolonError> {
@@ -83,7 +84,10 @@ mod tests {
 
         let descriptor = CommandDescriptor::from_holon(holon.into());
 
-        assert_eq!(descriptor.command_name()?, MapString("BeginTransaction".to_string()));
+        assert_eq!(
+            descriptor.command_name()?,
+            CommandName(MapString("BeginTransaction".to_string()))
+        );
 
         Ok(())
     }

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -5,9 +5,11 @@ use crate::descriptors::{
     InverseRelationshipDescriptor, PropertyDescriptor, RelationshipDescriptor, TypeHeader,
 };
 use crate::reference_layer::HolonReference;
-use base_types::MapString;
-use core_types::{HolonError, PropertyName, RelationshipName};
-use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
+use core_types::{HolonError, PropertyName};
+use type_names::{
+    CorePropertyTypeName, CoreRelationshipTypeName, ToCommandName, ToPropertyName,
+    ToRelationshipName,
+};
 
 /// Runtime wrapper for holon-type descriptors.
 ///
@@ -69,22 +71,24 @@ impl HolonDescriptor {
     /// Finds an effective instance property by property type identity.
     pub fn get_property_by_name(
         &self,
-        name: PropertyName,
+        name: impl ToPropertyName,
     ) -> Result<PropertyDescriptor, HolonError> {
-        let requested = name.to_string();
+        let requested_name = name.to_property_name();
+        let requested = requested_name.to_string();
         let mut seen = HashSet::new();
         let mut found = None;
 
         for descriptor in self.instance_properties()? {
-            let declaration_name = descriptor.header().type_name()?.to_string();
-            if !seen.insert(declaration_name.clone()) {
+            let declaration_name = PropertyName(descriptor.header().type_name()?);
+            let declaration_label = declaration_name.to_string();
+            if !seen.insert(declaration_label.clone()) {
                 return Err(HolonError::DuplicateInheritedDeclaration {
                     kind: "property".to_string(),
-                    name: declaration_name,
+                    name: declaration_label,
                     descriptor: accessor_helpers::descriptor_label(&self.holon),
                 });
             }
-            if declaration_name == requested {
+            if declaration_name == requested_name {
                 found = Some(descriptor);
             }
         }
@@ -97,21 +101,26 @@ impl HolonDescriptor {
     }
 
     /// Finds an effective command affordance by command descriptor type name.
-    pub fn get_command_by_name(&self, name: MapString) -> Result<CommandDescriptor, HolonError> {
-        let requested = name.to_string();
+    pub fn get_command_by_name(
+        &self,
+        name: impl ToCommandName,
+    ) -> Result<CommandDescriptor, HolonError> {
+        let requested_name = name.to_command_name();
+        let requested = requested_name.to_string();
         let mut seen = HashSet::new();
         let mut found = None;
 
         for descriptor in self.afforded_commands()? {
-            let declaration_name = descriptor.command_name()?.to_string();
-            if !seen.insert(declaration_name.clone()) {
+            let declaration_name = descriptor.command_name()?;
+            let declaration_label = declaration_name.to_string();
+            if !seen.insert(declaration_label.clone()) {
                 return Err(HolonError::DuplicateInheritedDeclaration {
                     kind: "command".to_string(),
-                    name: declaration_name,
+                    name: declaration_label,
                     descriptor: accessor_helpers::descriptor_label(&self.holon),
                 });
             }
-            if declaration_name == requested {
+            if declaration_name == requested_name {
                 found = Some(descriptor);
             }
         }
@@ -126,22 +135,24 @@ impl HolonDescriptor {
     /// Finds an effective instance relationship by base relationship name.
     pub fn get_relationship_by_name(
         &self,
-        name: RelationshipName,
+        name: impl ToRelationshipName,
     ) -> Result<RelationshipDescriptor, HolonError> {
-        let requested = name.to_string();
+        let requested_name = name.to_relationship_name();
+        let requested = requested_name.to_string();
         let mut seen = HashSet::new();
         let mut found = None;
 
         for descriptor in self.instance_relationships()? {
-            let declaration_name = descriptor.base_relationship_name()?.to_string();
-            if !seen.insert(declaration_name.clone()) {
+            let declaration_name = descriptor.base_relationship_name()?;
+            let declaration_label = declaration_name.to_string();
+            if !seen.insert(declaration_label.clone()) {
                 return Err(HolonError::DuplicateInheritedDeclaration {
                     kind: "relationship".to_string(),
-                    name: declaration_name,
+                    name: declaration_label,
                     descriptor: accessor_helpers::descriptor_label(&self.holon),
                 });
             }
-            if declaration_name == requested {
+            if declaration_name == requested_name {
                 found = Some(descriptor);
             }
         }
@@ -156,7 +167,7 @@ impl HolonDescriptor {
     /// Finds the inverse descriptor for an effective declared relationship name.
     pub fn get_inverse_relationship_by_name(
         &self,
-        declared_name: RelationshipName,
+        declared_name: impl ToRelationshipName,
     ) -> Result<InverseRelationshipDescriptor, HolonError> {
         let declared = self
             .get_relationship_by_name(declared_name)?
@@ -199,7 +210,10 @@ mod tests {
     use base_types::MapString;
     use core_types::{HolonError, PropertyName, RelationshipName};
     use std::sync::Arc;
-    use type_names::{CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName};
+    use type_names::{
+        CommandName, CoreCommandTypeName, CoreHolonTypeName, CorePropertyTypeName,
+        CoreRelationshipTypeName,
+    };
 
     fn new_descriptor_holon(
         context: &Arc<TransactionContext>,
@@ -220,7 +234,7 @@ mod tests {
         let _ = descriptor.holon().reference_id_string();
     }
 
-    fn command_names(commands: Vec<CommandDescriptor>) -> Result<Vec<MapString>, HolonError> {
+    fn command_names(commands: Vec<CommandDescriptor>) -> Result<Vec<CommandName>, HolonError> {
         commands.into_iter().map(|command| command.command_name()).collect()
     }
 
@@ -487,7 +501,10 @@ mod tests {
 
         assert_eq!(
             command_names(descriptor.afforded_commands()?)?,
-            vec![MapString("Commit".to_string()), MapString("BeginTransaction".to_string()),]
+            vec![
+                CommandName(MapString("Commit".to_string())),
+                CommandName(MapString("BeginTransaction".to_string())),
+            ]
         );
 
         Ok(())
@@ -523,9 +540,9 @@ mod tests {
         assert_eq!(
             command_names(descriptor.afforded_commands()?)?,
             vec![
-                MapString("Commit".to_string()),
-                MapString("CloneHolon".to_string()),
-                MapString("BeginTransaction".to_string()),
+                CommandName(MapString("Commit".to_string())),
+                CommandName(MapString("CloneHolon".to_string())),
+                CommandName(MapString("BeginTransaction".to_string())),
             ]
         );
 
@@ -544,8 +561,48 @@ mod tests {
         let descriptor = HolonDescriptor::from_holon(holon_type.into());
 
         assert_eq!(
-            descriptor.get_command_by_name(MapString("Commit".to_string()))?.command_name()?,
-            MapString("Commit".to_string())
+            descriptor.get_command_by_name(CoreCommandTypeName::Commit)?.command_name()?,
+            CommandName(MapString("Commit".to_string()))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_property_by_name_accepts_conversion_trait_inputs() -> Result<(), HolonError> {
+        let context = build_context();
+        let property = new_descriptor_holon(&context, "display-name-property", "DisplayName")?;
+        let mut holon_type = new_descriptor_holon(&context, "property-owner", "BookType")?;
+        holon_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceProperties,
+            vec![property.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(holon_type.into());
+
+        assert_eq!(
+            descriptor.get_property_by_name("display_name")?.header().type_name()?,
+            MapString("DisplayName".to_string())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_relationship_by_name_accepts_conversion_trait_inputs() -> Result<(), HolonError> {
+        let context = build_context();
+        let relationship = new_descriptor_holon(&context, "relationship-match", "AuthoredBy")?;
+        let mut holon_type = new_descriptor_holon(&context, "relationship-owner", "BookType")?;
+        holon_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceRelationships,
+            vec![relationship.into()],
+        )?;
+
+        let descriptor = HolonDescriptor::from_holon(holon_type.into());
+
+        assert_eq!(
+            descriptor.get_relationship_by_name("authored_by")?.base_relationship_name()?,
+            RelationshipName(MapString("AuthoredBy".to_string()))
         );
 
         Ok(())

--- a/shared_crates/holons_core/src/descriptors/operator_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/operator_descriptor.rs
@@ -5,7 +5,7 @@ use crate::descriptors::{
 use crate::reference_layer::HolonReference;
 use base_types::MapString;
 use core_types::HolonError;
-use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
+use type_names::{CorePropertyTypeName, CoreRelationshipTypeName, OperatorName};
 
 /// Runtime wrapper for operator descriptors.
 ///
@@ -26,9 +26,9 @@ impl OperatorDescriptor {
         TypeHeader::new(&self.holon)
     }
 
-    /// Returns the operator descriptor's canonical type name.
-    pub fn type_name(&self) -> Result<MapString, HolonError> {
-        self.header().type_name()
+    /// Returns the operator descriptor's canonical operator name.
+    pub fn operator_name(&self) -> Result<OperatorName, HolonError> {
+        Ok(OperatorName(self.header().type_name()?))
     }
 
     /// Returns the optional human-facing display name.
@@ -142,7 +142,10 @@ mod tests {
 
         let descriptor = OperatorDescriptor::from_holon(holon.into());
 
-        assert_eq!(descriptor.type_name()?, MapString("EqualsOperator".to_string()));
+        assert_eq!(
+            descriptor.operator_name()?,
+            OperatorName(MapString("EqualsOperator".to_string()))
+        );
         assert_eq!(descriptor.display_name()?, Some(MapString("Equals".to_string())));
         assert_eq!(descriptor.description()?, Some(MapString("Returns equality.".to_string())));
         assert_eq!(descriptor.arity()?, 2);
@@ -150,6 +153,22 @@ mod tests {
         assert_eq!(
             descriptor.afforded_by()?[0].header().type_name()?,
             MapString("IntegerValueType".to_string())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn operator_name_uses_shared_type_name() -> Result<(), HolonError> {
+        let context = build_context();
+        let holon =
+            new_descriptor_holon(&context, "less-than-operator", "LessThanOperator", "Holon")?;
+
+        let descriptor = OperatorDescriptor::from_holon(holon.into());
+
+        assert_eq!(
+            descriptor.operator_name()?,
+            OperatorName(MapString("LessThanOperator".to_string()))
         );
 
         Ok(())

--- a/shared_crates/holons_core/src/descriptors/value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::descriptors::inheritance::walk_extends_chain;
 use crate::descriptors::value_descriptor_subtypes::helpers::{
     supported_operators as collect_supported_operators,
@@ -12,6 +14,7 @@ use crate::descriptors::{
 use crate::reference_layer::HolonReference;
 use base_types::BaseValue;
 use core_types::HolonError;
+use type_names::{CoreOperatorTypeName, ToOperatorName};
 
 /// Runtime wrapper for value-type descriptors.
 ///
@@ -58,6 +61,52 @@ impl ValueDescriptor {
     /// Returns whether this descriptor affords the supplied operator.
     pub fn supports_operator(&self, op: &OperatorDescriptor) -> Result<bool, HolonError> {
         descriptor_supports_operator(&self.holon, op)
+    }
+
+    /// Finds an afforded operator by operator descriptor type name.
+    pub fn get_operator_by_name<N: ToOperatorName>(
+        &self,
+        operator_name: N,
+    ) -> Result<OperatorDescriptor, HolonError> {
+        let requested_name = operator_name.to_operator_name();
+        let requested = requested_name.to_string();
+        let mut seen = HashSet::new();
+        let mut found = None;
+
+        for operator_descriptor in self.supported_operators()? {
+            let declaration_name = operator_descriptor.operator_name()?;
+            let declaration_label = declaration_name.to_string();
+            if !seen.insert(declaration_label.clone()) {
+                return Err(HolonError::DuplicateInheritedDeclaration {
+                    kind: "operator".to_string(),
+                    name: declaration_label,
+                    descriptor: accessor_helpers::descriptor_label(&self.holon),
+                });
+            }
+            if declaration_name == requested_name {
+                found = Some(operator_descriptor);
+            }
+        }
+
+        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+            kind: "operator".to_string(),
+            name: requested,
+            descriptor: accessor_helpers::descriptor_label(&self.holon),
+        })
+    }
+
+    /// Returns whether this descriptor affords an operator with the supplied name.
+    pub fn supports_operator_by_name<N: ToOperatorName>(
+        &self,
+        operator_name: N,
+    ) -> Result<bool, HolonError> {
+        let requested_name = operator_name.to_operator_name();
+        for operator_descriptor in self.supported_operators()? {
+            if operator_descriptor.operator_name()? == requested_name {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Applies an afforded operator to runtime operands using this descriptor's value kind.
@@ -132,7 +181,7 @@ impl ValueDescriptor {
         lhs: &BaseValue,
         rhs: &BaseValue,
     ) -> Result<bool, HolonError> {
-        if op.type_name()?.0 != "EqualsOperator" {
+        if op.operator_name()? != CoreOperatorTypeName::EqualsOperator.as_operator_name() {
             return self.unsupported_operator(op);
         }
 
@@ -376,10 +425,82 @@ mod tests {
         let names = descriptor
             .supported_operators()?
             .into_iter()
-            .map(|op| op.type_name().map(|name| name.to_string()))
+            .map(|op| op.operator_name().map(|name| name.0.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(names, vec!["EqualsOperator"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_operator_by_name_returns_match_and_reports_missing() -> Result<(), HolonError> {
+        let context = build_context();
+        let equals = new_descriptor_holon(&context, "equals", "EqualsOperator", "Holon")?;
+        let mut value =
+            new_descriptor_holon(&context, "integer-value", "IntegerValueType", "Value")?;
+        value.add_related_holons(CoreRelationshipTypeName::AffordsOperator, vec![equals.into()])?;
+
+        let descriptor = ValueDescriptor::from_holon(value.into());
+
+        assert_eq!(
+            descriptor.get_operator_by_name("equals_operator")?.operator_name()?.0,
+            MapString("EqualsOperator".to_string())
+        );
+        assert!(matches!(
+            descriptor.get_operator_by_name("less_than_operator"),
+            Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
+                if kind == "operator" && name == "LessThanOperator"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_operator_by_name_detects_duplicate_inherited_declarations() -> Result<(), HolonError> {
+        let context = build_context();
+        let duplicate_parent =
+            new_descriptor_holon(&context, "parent-equals", "EqualsOperator", "Holon")?;
+        let duplicate_child =
+            new_descriptor_holon(&context, "child-equals", "EqualsOperator", "Holon")?;
+        let mut parent =
+            new_descriptor_holon(&context, "integer-parent", "IntegerValueType", "Value")?;
+        let mut child =
+            new_descriptor_holon(&context, "integer-child", "CustomIntegerValueType", "Value")?;
+
+        parent.add_related_holons(
+            CoreRelationshipTypeName::AffordsOperator,
+            vec![duplicate_parent.into()],
+        )?;
+        child.add_related_holons(CoreRelationshipTypeName::Extends, vec![parent.into()])?;
+        child.add_related_holons(
+            CoreRelationshipTypeName::AffordsOperator,
+            vec![duplicate_child.into()],
+        )?;
+
+        let descriptor = ValueDescriptor::from_holon(child.into());
+
+        assert!(matches!(
+            descriptor.get_operator_by_name("equals_operator"),
+            Err(HolonError::DuplicateInheritedDeclaration { kind, name, .. })
+                if kind == "operator" && name == "EqualsOperator"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn supports_operator_by_name_reports_membership() -> Result<(), HolonError> {
+        let context = build_context();
+        let equals = new_descriptor_holon(&context, "equals", "EqualsOperator", "Holon")?;
+        let mut value =
+            new_descriptor_holon(&context, "integer-value", "IntegerValueType", "Value")?;
+        value.add_related_holons(CoreRelationshipTypeName::AffordsOperator, vec![equals.into()])?;
+
+        let descriptor = ValueDescriptor::from_holon(value.into());
+
+        assert!(descriptor.supports_operator_by_name("equals_operator")?);
+        assert!(!descriptor.supports_operator_by_name("less_than_operator")?);
 
         Ok(())
     }

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/enum_value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/enum_value_descriptor.rs
@@ -203,7 +203,7 @@ mod tests {
         let names = descriptor
             .supported_operators()?
             .into_iter()
-            .map(|op| op.type_name().map(|name| name.to_string()))
+            .map(|op| op.operator_name().map(|name| name.0.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(names, vec!["EqualsOperator"]);

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/helpers.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/helpers.rs
@@ -42,7 +42,7 @@ fn unsupported_operator_error(
     operator_descriptor: &OperatorDescriptor,
 ) -> Result<HolonError, HolonError> {
     Ok(HolonError::UnsupportedOperator {
-        operator: operator_descriptor.type_name()?.to_string(),
+        operator: operator_descriptor.operator_name()?.0.to_string(),
         value_type: value_type_name(holon)?,
         descriptor: accessor_helpers::descriptor_label(holon),
     })
@@ -61,9 +61,9 @@ pub(crate) fn supports_operator(
     holon: &HolonReference,
     operator_descriptor: &OperatorDescriptor,
 ) -> Result<bool, HolonError> {
-    let operator_name = operator_descriptor.type_name()?;
+    let operator_name = operator_descriptor.operator_name()?;
     for supported_operator in supported_operators(holon)? {
-        if supported_operator.type_name()? == operator_name {
+        if supported_operator.operator_name()? == operator_name {
             return Ok(true);
         }
     }
@@ -87,5 +87,5 @@ pub(crate) fn type_name_is(
     operator_descriptor: &OperatorDescriptor,
     expected: &str,
 ) -> Result<bool, HolonError> {
-    Ok(operator_descriptor.type_name()?.0 == expected)
+    Ok(operator_descriptor.operator_name()?.0 .0 == expected)
 }

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/integer_value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/integer_value_descriptor.rs
@@ -381,7 +381,7 @@ mod tests {
         let names = descriptor
             .supported_operators()?
             .into_iter()
-            .map(|op| op.type_name().map(|name| name.to_string()))
+            .map(|op| op.operator_name().map(|name| name.0.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(names, vec!["EqualsOperator", "LessThanOperator"]);

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/string_value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/string_value_descriptor.rs
@@ -388,7 +388,7 @@ mod tests {
         let names = descriptor
             .supported_operators()?
             .into_iter()
-            .map(|op| op.type_name().map(|name| name.to_string()))
+            .map(|op| op.operator_name().map(|name| name.0.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(names, vec!["EqualsOperator", "LessThanOperator"]);

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/value_array_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/value_array_descriptor.rs
@@ -150,7 +150,7 @@ mod tests {
         let names = descriptor
             .supported_operators()?
             .into_iter()
-            .map(|op| op.type_name().map(|name| name.to_string()))
+            .map(|op| op.operator_name().map(|name| name.0.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(names, vec!["EqualsOperator"]);

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -58,9 +58,9 @@ pub use holons_core::reference_layer::{
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
 pub use holons_core::{
-    ancestors, classify_relationship_direction, walk_extends_chain, Descriptor, ExtendsIter,
-    HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, RelationshipDirection, TypeHeader,
-    ValueDescriptor,
+    Descriptor, ExtendsIter, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor,
+    RelationshipDirection, TypeHeader, ValueDescriptor, ancestors, classify_relationship_direction,
+    walk_extends_chain,
 };
 
 pub use type_names::{

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -58,12 +58,13 @@ pub use holons_core::reference_layer::{
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
 pub use holons_core::{
-    Descriptor, ExtendsIter, HolonDescriptor, PropertyDescriptor, RelationshipDescriptor,
-    RelationshipDirection, TypeHeader, ValueDescriptor, ancestors, classify_relationship_direction,
-    walk_extends_chain,
+    ancestors, classify_relationship_direction, walk_extends_chain, Descriptor, ExtendsIter,
+    HolonDescriptor, PropertyDescriptor, RelationshipDescriptor, RelationshipDirection, TypeHeader,
+    ValueDescriptor,
 };
 
 pub use type_names::{
-    CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName, CoreValueTypeName,
-    ToPropertyName, ToRelationshipName,
+    CommandName, CoreCommandTypeName, CoreHolonTypeName, CoreOperatorTypeName,
+    CorePropertyTypeName, CoreRelationshipTypeName, CoreValueTypeName, OperatorName, ToCommandName,
+    ToOperatorName, ToPropertyName, ToRelationshipName,
 };

--- a/shared_crates/type_system/type_names/src/command_names.rs
+++ b/shared_crates/type_system/type_names/src/command_names.rs
@@ -1,10 +1,17 @@
 use base_types::MapString;
 use convert_case::{Case, Casing};
+use std::fmt;
 use strum_macros::VariantNames;
 
 /// A strongly-typed wrapper around the shared descriptor `type_name` for command types.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CommandName(pub MapString);
+
+impl fmt::Display for CommandName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
 
 /// Converts common command-name inputs into a typed `CommandName`.
 pub trait ToCommandName {

--- a/shared_crates/type_system/type_names/src/command_names.rs
+++ b/shared_crates/type_system/type_names/src/command_names.rs
@@ -1,0 +1,218 @@
+use base_types::MapString;
+use convert_case::{Case, Casing};
+use strum_macros::VariantNames;
+
+/// A strongly-typed wrapper around the shared descriptor `type_name` for command types.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CommandName(pub MapString);
+
+/// Converts common command-name inputs into a typed `CommandName`.
+pub trait ToCommandName {
+    /// Returns the typed command name represented by this value.
+    fn to_command_name(self) -> CommandName;
+}
+
+// --- Internal single point for canonicalization (ClassCase) ---
+#[inline]
+fn canonical_command_name<S: AsRef<str>>(command_name: S) -> CommandName {
+    CommandName(MapString(command_name.as_ref().to_case(Case::UpperCamel)))
+}
+
+// --- to_command_name impls ---
+
+impl ToCommandName for &str {
+    fn to_command_name(self) -> CommandName {
+        canonical_command_name(self)
+    }
+}
+
+impl ToCommandName for String {
+    fn to_command_name(self) -> CommandName {
+        CommandName(MapString(self))
+    }
+}
+
+impl ToCommandName for MapString {
+    fn to_command_name(self) -> CommandName {
+        CommandName(self)
+    }
+}
+
+impl ToCommandName for &MapString {
+    fn to_command_name(self) -> CommandName {
+        CommandName(self.clone())
+    }
+}
+
+impl ToCommandName for CoreCommandTypeName {
+    fn to_command_name(self) -> CommandName {
+        self.as_command_name()
+    }
+}
+
+impl ToCommandName for &CoreCommandTypeName {
+    fn to_command_name(self) -> CommandName {
+        self.clone().as_command_name()
+    }
+}
+
+impl ToCommandName for CommandName {
+    fn to_command_name(self) -> CommandName {
+        self
+    }
+}
+
+impl ToCommandName for &CommandName {
+    fn to_command_name(self) -> CommandName {
+        self.clone()
+    }
+}
+
+/// Stable MAP Core command type names backed by concrete `CommandType` descriptors.
+#[derive(Debug, Clone, PartialEq, Eq, VariantNames)]
+pub enum CoreCommandTypeName {
+    BeginTransaction,
+    CloneHolon,
+    GetEssentialContent,
+    Summarize,
+    GetHolonId,
+    GetPredecessor,
+    GetKey,
+    GetVersionedKey,
+    GetPropertyValue,
+    GetRelatedHolons,
+    WithPropertyValue,
+    RemovePropertyValue,
+    AddRelatedHolons,
+    RemoveRelatedHolons,
+    WithDescriptor,
+    Commit,
+    UndoLast,
+    RedoLast,
+    UndoToMarker,
+    RedoToMarker,
+    LoadHolons,
+    Dance,
+    Query,
+    GetAllHolons,
+    GetStagedHolonByBaseKey,
+    GetStagedHolonsByBaseKey,
+    GetStagedHolonByVersionedKey,
+    GetTransientHolonByBaseKey,
+    GetTransientHolonByVersionedKey,
+    GetStagedCount,
+    GetTransientCount,
+    NewHolon,
+    StageNewHolon,
+    StageNewFromClone,
+    StageNewVersion,
+    StageNewVersionFromId,
+    DeleteHolon,
+}
+
+impl CoreCommandTypeName {
+    /// Canonical command type name in ClassCase (UpperCamel).
+    pub fn as_command_name(&self) -> CommandName {
+        // Use the Rust variant identifier as the core inventory source, then apply
+        // the shared type-name case convention used by the neighboring modules.
+        let command_name = format!("{self:?}").to_case(Case::UpperCamel);
+        CommandName(MapString(command_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::VariantNames as _;
+
+    fn expected_command_name(command_name: &str) -> CommandName {
+        CommandName(MapString(command_name.to_string()))
+    }
+
+    fn all_core_command_type_names() -> Vec<CoreCommandTypeName> {
+        vec![
+            CoreCommandTypeName::BeginTransaction,
+            CoreCommandTypeName::CloneHolon,
+            CoreCommandTypeName::GetEssentialContent,
+            CoreCommandTypeName::Summarize,
+            CoreCommandTypeName::GetHolonId,
+            CoreCommandTypeName::GetPredecessor,
+            CoreCommandTypeName::GetKey,
+            CoreCommandTypeName::GetVersionedKey,
+            CoreCommandTypeName::GetPropertyValue,
+            CoreCommandTypeName::GetRelatedHolons,
+            CoreCommandTypeName::WithPropertyValue,
+            CoreCommandTypeName::RemovePropertyValue,
+            CoreCommandTypeName::AddRelatedHolons,
+            CoreCommandTypeName::RemoveRelatedHolons,
+            CoreCommandTypeName::WithDescriptor,
+            CoreCommandTypeName::Commit,
+            CoreCommandTypeName::UndoLast,
+            CoreCommandTypeName::RedoLast,
+            CoreCommandTypeName::UndoToMarker,
+            CoreCommandTypeName::RedoToMarker,
+            CoreCommandTypeName::LoadHolons,
+            CoreCommandTypeName::Dance,
+            CoreCommandTypeName::Query,
+            CoreCommandTypeName::GetAllHolons,
+            CoreCommandTypeName::GetStagedHolonByBaseKey,
+            CoreCommandTypeName::GetStagedHolonsByBaseKey,
+            CoreCommandTypeName::GetStagedHolonByVersionedKey,
+            CoreCommandTypeName::GetTransientHolonByBaseKey,
+            CoreCommandTypeName::GetTransientHolonByVersionedKey,
+            CoreCommandTypeName::GetStagedCount,
+            CoreCommandTypeName::GetTransientCount,
+            CoreCommandTypeName::NewHolon,
+            CoreCommandTypeName::StageNewHolon,
+            CoreCommandTypeName::StageNewFromClone,
+            CoreCommandTypeName::StageNewVersion,
+            CoreCommandTypeName::StageNewVersionFromId,
+            CoreCommandTypeName::DeleteHolon,
+        ]
+    }
+
+    #[test]
+    fn test_variant_string_conversion() {
+        let variants = all_core_command_type_names();
+        assert_eq!(CoreCommandTypeName::VARIANTS.len(), variants.len());
+
+        for (variant_name, core_command_type_name) in
+            CoreCommandTypeName::VARIANTS.iter().zip(variants)
+        {
+            assert_eq!(
+                expected_command_name(variant_name),
+                core_command_type_name.as_command_name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_command_name_accepts_common_input_shapes() {
+        assert_eq!(expected_command_name("GetKey"), "get_key".to_command_name());
+        assert_eq!(
+            expected_command_name("AlreadyCanonical"),
+            String::from("AlreadyCanonical").to_command_name()
+        );
+
+        let map_string = MapString("GetPropertyValue".to_string());
+        assert_eq!(expected_command_name("GetPropertyValue"), map_string.clone().to_command_name());
+        assert_eq!(expected_command_name("GetPropertyValue"), (&map_string).to_command_name());
+
+        let command_name = expected_command_name("GetRelatedHolons");
+        assert_eq!(
+            expected_command_name("GetRelatedHolons"),
+            command_name.clone().to_command_name()
+        );
+        assert_eq!(expected_command_name("GetRelatedHolons"), (&command_name).to_command_name());
+
+        let core_command_type_name = CoreCommandTypeName::GetEssentialContent;
+        assert_eq!(
+            expected_command_name("GetEssentialContent"),
+            core_command_type_name.clone().to_command_name()
+        );
+        assert_eq!(
+            expected_command_name("GetEssentialContent"),
+            (&core_command_type_name).to_command_name()
+        );
+    }
+}

--- a/shared_crates/type_system/type_names/src/lib.rs
+++ b/shared_crates/type_system/type_names/src/lib.rs
@@ -1,9 +1,13 @@
+pub mod command_names;
 pub mod holon_names;
+pub mod operator_names;
 pub mod property_names;
 pub mod relationship_names;
 pub mod value_names;
 
+pub use command_names::*;
 pub use holon_names::*;
+pub use operator_names::*;
 pub use property_names::*;
 pub use relationship_names::*;
 pub use value_names::*;

--- a/shared_crates/type_system/type_names/src/operator_names.rs
+++ b/shared_crates/type_system/type_names/src/operator_names.rs
@@ -1,0 +1,148 @@
+use base_types::MapString;
+use convert_case::{Case, Casing};
+use strum_macros::VariantNames;
+
+/// A strongly-typed wrapper around the shared descriptor `type_name` for operator types.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OperatorName(pub MapString);
+
+/// Converts common operator-name inputs into a typed `OperatorName`.
+pub trait ToOperatorName {
+    /// Returns the typed operator name represented by this value.
+    fn to_operator_name(self) -> OperatorName;
+}
+
+// --- Internal single point for canonicalization (ClassCase) ---
+#[inline]
+fn canonical_operator_name<S: AsRef<str>>(operator_name: S) -> OperatorName {
+    OperatorName(MapString(operator_name.as_ref().to_case(Case::UpperCamel)))
+}
+
+// --- to_operator_name impls ---
+
+impl ToOperatorName for &str {
+    fn to_operator_name(self) -> OperatorName {
+        canonical_operator_name(self)
+    }
+}
+
+impl ToOperatorName for String {
+    fn to_operator_name(self) -> OperatorName {
+        OperatorName(MapString(self))
+    }
+}
+
+impl ToOperatorName for MapString {
+    fn to_operator_name(self) -> OperatorName {
+        OperatorName(self)
+    }
+}
+
+impl ToOperatorName for &MapString {
+    fn to_operator_name(self) -> OperatorName {
+        OperatorName(self.clone())
+    }
+}
+
+impl ToOperatorName for CoreOperatorTypeName {
+    fn to_operator_name(self) -> OperatorName {
+        self.as_operator_name()
+    }
+}
+
+impl ToOperatorName for &CoreOperatorTypeName {
+    fn to_operator_name(self) -> OperatorName {
+        self.clone().as_operator_name()
+    }
+}
+
+impl ToOperatorName for OperatorName {
+    fn to_operator_name(self) -> OperatorName {
+        self
+    }
+}
+
+impl ToOperatorName for &OperatorName {
+    fn to_operator_name(self) -> OperatorName {
+        self.clone()
+    }
+}
+
+/// Stable MAP Core operator type names backed by concrete `OperatorType` descriptors.
+#[derive(Debug, Clone, PartialEq, Eq, VariantNames)]
+pub enum CoreOperatorTypeName {
+    EqualsOperator,
+    LessThanOperator,
+}
+
+impl CoreOperatorTypeName {
+    /// Canonical operator type name in ClassCase (UpperCamel).
+    pub fn as_operator_name(&self) -> OperatorName {
+        // Use the Rust variant identifier as the core inventory source, then apply
+        // the shared type-name case convention used by the neighboring modules.
+        let operator_name = format!("{self:?}").to_case(Case::UpperCamel);
+        OperatorName(MapString(operator_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::VariantNames as _;
+
+    fn expected_operator_name(operator_name: &str) -> OperatorName {
+        OperatorName(MapString(operator_name.to_string()))
+    }
+
+    fn all_core_operator_type_names() -> Vec<CoreOperatorTypeName> {
+        vec![CoreOperatorTypeName::EqualsOperator, CoreOperatorTypeName::LessThanOperator]
+    }
+
+    #[test]
+    fn test_variant_string_conversion() {
+        let variants = all_core_operator_type_names();
+        assert_eq!(CoreOperatorTypeName::VARIANTS.len(), variants.len());
+
+        for (variant_name, core_operator_type_name) in
+            CoreOperatorTypeName::VARIANTS.iter().zip(variants)
+        {
+            assert_eq!(
+                expected_operator_name(variant_name),
+                core_operator_type_name.as_operator_name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_operator_name_accepts_common_input_shapes() {
+        assert_eq!(expected_operator_name("EqualsOperator"), "equals_operator".to_operator_name());
+        assert_eq!(
+            expected_operator_name("AlreadyCanonical"),
+            String::from("AlreadyCanonical").to_operator_name()
+        );
+
+        let map_string = MapString("LessThanOperator".to_string());
+        assert_eq!(
+            expected_operator_name("LessThanOperator"),
+            map_string.clone().to_operator_name()
+        );
+        assert_eq!(expected_operator_name("LessThanOperator"), (&map_string).to_operator_name());
+
+        let operator_name = expected_operator_name("EqualsOperator");
+        assert_eq!(
+            expected_operator_name("EqualsOperator"),
+            operator_name.clone().to_operator_name()
+        );
+        assert_eq!(expected_operator_name("EqualsOperator"), (&operator_name).to_operator_name());
+
+        let core_operator_type_name = CoreOperatorTypeName::LessThanOperator;
+        assert_eq!(
+            expected_operator_name("LessThanOperator"),
+            core_operator_type_name.clone().to_operator_name()
+        );
+        assert_eq!(
+            expected_operator_name("LessThanOperator"),
+            (&core_operator_type_name).to_operator_name()
+        );
+    }
+}

--- a/shared_crates/type_system/type_names/src/operator_names.rs
+++ b/shared_crates/type_system/type_names/src/operator_names.rs
@@ -1,10 +1,17 @@
 use base_types::MapString;
 use convert_case::{Case, Casing};
+use std::fmt;
 use strum_macros::VariantNames;
 
 /// A strongly-typed wrapper around the shared descriptor `type_name` for operator types.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OperatorName(pub MapString);
+
+impl fmt::Display for OperatorName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
 
 /// Converts common operator-name inputs into a typed `OperatorName`.
 pub trait ToOperatorName {

--- a/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
@@ -1,3 +1,15 @@
+//! Schema contract verification for core command descriptors and command affordances.
+//!
+//! This executor is not a command-routing or command-execution test. It loads the
+//! current holon collection through an assertion transaction, selects known schema
+//! descriptors by key, verifies the stable concrete `CommandType` inventory,
+//! checks the `AffordsCommand` / `AffordedBy` descriptor graph, and exercises
+//! typed command-name lookup through `CoreCommandTypeName` and `CommandName`.
+//!
+//! The goal is to catch drift between the MAP Core schema JSON, the Rust command
+//! type-name inventory, and the descriptor accessor ergonomics introduced by PR4
+//! and PR4a.
+
 use holons_core::descriptors::{CommandDescriptor, HolonDescriptor, RelationshipDescriptor};
 use holons_prelude::prelude::*;
 use holons_test::TestExecutionState;
@@ -5,6 +17,8 @@ use map_commands_contract::{MapCommand, MapResult, TransactionAction, Transactio
 use pretty_assertions::assert_eq;
 use tracing::info;
 
+// Concrete command descriptor holons that must exist in the loaded MAP Core schema.
+// The abstract `CommandType` descriptor is checked separately and intentionally excluded here.
 const STABLE_COMMAND_TYPES: &[(&str, CoreCommandTypeName)] = &[
     ("BeginTransaction.CommandType", CoreCommandTypeName::BeginTransaction),
     ("CloneHolon.CommandType", CoreCommandTypeName::CloneHolon),
@@ -48,6 +62,7 @@ const STABLE_COMMAND_TYPES: &[(&str, CoreCommandTypeName)] = &[
     ("DeleteHolon.CommandType", CoreCommandTypeName::DeleteHolon),
 ];
 
+// The command surface that every `HolonType` descendant should inherit from the core schema.
 const HOLON_TYPE_AFFORDED_COMMANDS: &[CoreCommandTypeName] = &[
     CoreCommandTypeName::CloneHolon,
     CoreCommandTypeName::GetEssentialContent,
@@ -67,8 +82,10 @@ const HOLON_TYPE_AFFORDED_COMMANDS: &[CoreCommandTypeName] = &[
 
 /// Verifies command descriptor inventory and schema-backed command affordance lookup.
 pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExecutionState) {
+    // Fetch the current collection once; later checks select expected schema descriptors by key.
     let holons = loaded_holons(state, "verify_core_schema_command_affordances").await;
 
+    // `CommandType` is the abstract descriptor family root, not a concrete command inventory item.
     let command_type = CommandDescriptor::from_holon(find_holon_by_key(&holons, "CommandType"));
     assert_eq!(
         command_type.command_name().expect("CommandType command_name"),
@@ -76,6 +93,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
     );
     assert!(command_type.header().is_abstract_type().expect("CommandType is_abstract_type"));
 
+    // Every concrete command descriptor should expose its canonical `CommandName` via `type_name`.
     for (key, expected_type_name) in STABLE_COMMAND_TYPES {
         let command = CommandDescriptor::from_holon(find_holon_by_key(&holons, key));
         assert_eq!(
@@ -85,6 +103,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
         );
     }
 
+    // `AffordsCommand` is the declared descriptor edge from holon types to command types.
     let affordance_relationship = RelationshipDescriptor::from_holon(find_holon_by_key(
         &holons,
         "(HolonType)-[AffordsCommand]->(CommandType)",
@@ -117,6 +136,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
         MapString("CommandType".to_string())
     );
 
+    // `AffordedBy` must be the inverse view of the same command affordance relationship.
     let inverse_relationship = RelationshipDescriptor::from_holon(find_holon_by_key(
         &holons,
         "(CommandType)-[AffordedBy]->(HolonType)",
@@ -133,6 +153,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
         "AffordsCommand"
     );
 
+    // `HolonType` owns the baseline command affordance set and typed command lookup behavior.
     let holon_type_descriptor =
         HolonDescriptor::from_holon(find_holon_by_key(&holons, "HolonType"));
     let instance_relationship_names =
@@ -158,6 +179,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
             if kind == "command" && name == "NonexistentCommand"
     ));
 
+    // Ordinary holon descriptor families should inherit the baseline `HolonType` commands.
     let schema_type_descriptor =
         HolonDescriptor::from_holon(find_holon_by_key(&holons, "SchemaType"));
     assert_command_set_eq(
@@ -166,6 +188,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
         "SchemaType should inherit HolonType's command affordances",
     );
 
+    // `HolonSpaceType` extends the baseline holon command set with space-level transaction entry.
     let holon_space_type_descriptor =
         HolonDescriptor::from_holon(find_holon_by_key(&holons, "HolonSpaceType"));
     let mut holon_space_commands: Vec<CoreCommandTypeName> = HOLON_TYPE_AFFORDED_COMMANDS.to_vec();
@@ -187,6 +210,8 @@ async fn loaded_holons(state: &mut TestExecutionState, step_name: &str) -> Holon
         panic!("{step_name}: failed to open assertion transaction: {error:?}")
     });
 
+    // GetAllHolons may return more than schema descriptors; callers below pick the relevant
+    // loaded schema holons by stable keys and ignore unrelated entries.
     let command = MapCommand::Transaction(TransactionCommand {
         context: context.clone(),
         action: TransactionAction::GetAllHolons,

--- a/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs
@@ -5,61 +5,64 @@ use map_commands_contract::{MapCommand, MapResult, TransactionAction, Transactio
 use pretty_assertions::assert_eq;
 use tracing::info;
 
-const STABLE_COMMAND_TYPES: &[(&str, &str)] = &[
-    ("BeginTransaction.CommandType", "BeginTransaction"),
-    ("CloneHolon.CommandType", "CloneHolon"),
-    ("GetEssentialContent.CommandType", "GetEssentialContent"),
-    ("Summarize.CommandType", "Summarize"),
-    ("GetHolonId.CommandType", "GetHolonId"),
-    ("GetPredecessor.CommandType", "GetPredecessor"),
-    ("GetKey.CommandType", "GetKey"),
-    ("GetVersionedKey.CommandType", "GetVersionedKey"),
-    ("GetPropertyValue.CommandType", "GetPropertyValue"),
-    ("GetRelatedHolons.CommandType", "GetRelatedHolons"),
-    ("WithPropertyValue.CommandType", "WithPropertyValue"),
-    ("RemovePropertyValue.CommandType", "RemovePropertyValue"),
-    ("AddRelatedHolons.CommandType", "AddRelatedHolons"),
-    ("RemoveRelatedHolons.CommandType", "RemoveRelatedHolons"),
-    ("WithDescriptor.CommandType", "WithDescriptor"),
-    ("Commit.CommandType", "Commit"),
-    ("UndoLast.CommandType", "UndoLast"),
-    ("RedoLast.CommandType", "RedoLast"),
-    ("UndoToMarker.CommandType", "UndoToMarker"),
-    ("RedoToMarker.CommandType", "RedoToMarker"),
-    ("LoadHolons.CommandType", "LoadHolons"),
-    ("Dance.CommandType", "Dance"),
-    ("Query.CommandType", "Query"),
-    ("GetAllHolons.CommandType", "GetAllHolons"),
-    ("GetStagedHolonByBaseKey.CommandType", "GetStagedHolonByBaseKey"),
-    ("GetStagedHolonsByBaseKey.CommandType", "GetStagedHolonsByBaseKey"),
-    ("GetStagedHolonByVersionedKey.CommandType", "GetStagedHolonByVersionedKey"),
-    ("GetTransientHolonByBaseKey.CommandType", "GetTransientHolonByBaseKey"),
-    ("GetTransientHolonByVersionedKey.CommandType", "GetTransientHolonByVersionedKey"),
-    ("GetStagedCount.CommandType", "GetStagedCount"),
-    ("GetTransientCount.CommandType", "GetTransientCount"),
-    ("NewHolon.CommandType", "NewHolon"),
-    ("StageNewHolon.CommandType", "StageNewHolon"),
-    ("StageNewFromClone.CommandType", "StageNewFromClone"),
-    ("StageNewVersion.CommandType", "StageNewVersion"),
-    ("StageNewVersionFromId.CommandType", "StageNewVersionFromId"),
-    ("DeleteHolon.CommandType", "DeleteHolon"),
+const STABLE_COMMAND_TYPES: &[(&str, CoreCommandTypeName)] = &[
+    ("BeginTransaction.CommandType", CoreCommandTypeName::BeginTransaction),
+    ("CloneHolon.CommandType", CoreCommandTypeName::CloneHolon),
+    ("GetEssentialContent.CommandType", CoreCommandTypeName::GetEssentialContent),
+    ("Summarize.CommandType", CoreCommandTypeName::Summarize),
+    ("GetHolonId.CommandType", CoreCommandTypeName::GetHolonId),
+    ("GetPredecessor.CommandType", CoreCommandTypeName::GetPredecessor),
+    ("GetKey.CommandType", CoreCommandTypeName::GetKey),
+    ("GetVersionedKey.CommandType", CoreCommandTypeName::GetVersionedKey),
+    ("GetPropertyValue.CommandType", CoreCommandTypeName::GetPropertyValue),
+    ("GetRelatedHolons.CommandType", CoreCommandTypeName::GetRelatedHolons),
+    ("WithPropertyValue.CommandType", CoreCommandTypeName::WithPropertyValue),
+    ("RemovePropertyValue.CommandType", CoreCommandTypeName::RemovePropertyValue),
+    ("AddRelatedHolons.CommandType", CoreCommandTypeName::AddRelatedHolons),
+    ("RemoveRelatedHolons.CommandType", CoreCommandTypeName::RemoveRelatedHolons),
+    ("WithDescriptor.CommandType", CoreCommandTypeName::WithDescriptor),
+    ("Commit.CommandType", CoreCommandTypeName::Commit),
+    ("UndoLast.CommandType", CoreCommandTypeName::UndoLast),
+    ("RedoLast.CommandType", CoreCommandTypeName::RedoLast),
+    ("UndoToMarker.CommandType", CoreCommandTypeName::UndoToMarker),
+    ("RedoToMarker.CommandType", CoreCommandTypeName::RedoToMarker),
+    ("LoadHolons.CommandType", CoreCommandTypeName::LoadHolons),
+    ("Dance.CommandType", CoreCommandTypeName::Dance),
+    ("Query.CommandType", CoreCommandTypeName::Query),
+    ("GetAllHolons.CommandType", CoreCommandTypeName::GetAllHolons),
+    ("GetStagedHolonByBaseKey.CommandType", CoreCommandTypeName::GetStagedHolonByBaseKey),
+    ("GetStagedHolonsByBaseKey.CommandType", CoreCommandTypeName::GetStagedHolonsByBaseKey),
+    ("GetStagedHolonByVersionedKey.CommandType", CoreCommandTypeName::GetStagedHolonByVersionedKey),
+    ("GetTransientHolonByBaseKey.CommandType", CoreCommandTypeName::GetTransientHolonByBaseKey),
+    (
+        "GetTransientHolonByVersionedKey.CommandType",
+        CoreCommandTypeName::GetTransientHolonByVersionedKey,
+    ),
+    ("GetStagedCount.CommandType", CoreCommandTypeName::GetStagedCount),
+    ("GetTransientCount.CommandType", CoreCommandTypeName::GetTransientCount),
+    ("NewHolon.CommandType", CoreCommandTypeName::NewHolon),
+    ("StageNewHolon.CommandType", CoreCommandTypeName::StageNewHolon),
+    ("StageNewFromClone.CommandType", CoreCommandTypeName::StageNewFromClone),
+    ("StageNewVersion.CommandType", CoreCommandTypeName::StageNewVersion),
+    ("StageNewVersionFromId.CommandType", CoreCommandTypeName::StageNewVersionFromId),
+    ("DeleteHolon.CommandType", CoreCommandTypeName::DeleteHolon),
 ];
 
-const HOLON_TYPE_AFFORDED_COMMANDS: &[&str] = &[
-    "CloneHolon",
-    "GetEssentialContent",
-    "Summarize",
-    "GetHolonId",
-    "GetPredecessor",
-    "GetKey",
-    "GetVersionedKey",
-    "GetPropertyValue",
-    "GetRelatedHolons",
-    "WithPropertyValue",
-    "RemovePropertyValue",
-    "AddRelatedHolons",
-    "RemoveRelatedHolons",
-    "WithDescriptor",
+const HOLON_TYPE_AFFORDED_COMMANDS: &[CoreCommandTypeName] = &[
+    CoreCommandTypeName::CloneHolon,
+    CoreCommandTypeName::GetEssentialContent,
+    CoreCommandTypeName::Summarize,
+    CoreCommandTypeName::GetHolonId,
+    CoreCommandTypeName::GetPredecessor,
+    CoreCommandTypeName::GetKey,
+    CoreCommandTypeName::GetVersionedKey,
+    CoreCommandTypeName::GetPropertyValue,
+    CoreCommandTypeName::GetRelatedHolons,
+    CoreCommandTypeName::WithPropertyValue,
+    CoreCommandTypeName::RemovePropertyValue,
+    CoreCommandTypeName::AddRelatedHolons,
+    CoreCommandTypeName::RemoveRelatedHolons,
+    CoreCommandTypeName::WithDescriptor,
 ];
 
 /// Verifies command descriptor inventory and schema-backed command affordance lookup.
@@ -69,7 +72,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
     let command_type = CommandDescriptor::from_holon(find_holon_by_key(&holons, "CommandType"));
     assert_eq!(
         command_type.command_name().expect("CommandType command_name"),
-        MapString("CommandType".to_string())
+        CommandName(MapString("CommandType".to_string()))
     );
     assert!(command_type.header().is_abstract_type().expect("CommandType is_abstract_type"));
 
@@ -77,7 +80,7 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
         let command = CommandDescriptor::from_holon(find_holon_by_key(&holons, key));
         assert_eq!(
             command.command_name().expect("concrete command command_name"),
-            MapString((*expected_type_name).to_string()),
+            expected_type_name.as_command_name(),
             "{key} should expose its command identity through type_name"
         );
     }
@@ -143,11 +146,11 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
     );
     assert_eq!(
         holon_type_descriptor
-            .get_command_by_name(MapString("GetKey".to_string()))
+            .get_command_by_name(CoreCommandTypeName::GetKey)
             .expect("GetKey lookup")
             .command_name()
             .expect("resolved GetKey command_name"),
-        MapString("GetKey".to_string())
+        CoreCommandTypeName::GetKey.as_command_name()
     );
     assert!(matches!(
         holon_type_descriptor.get_command_by_name(MapString("NonexistentCommand".to_string())),
@@ -165,8 +168,8 @@ pub async fn execute_verify_core_schema_command_affordances(state: &mut TestExec
 
     let holon_space_type_descriptor =
         HolonDescriptor::from_holon(find_holon_by_key(&holons, "HolonSpaceType"));
-    let mut holon_space_commands: Vec<&str> = HOLON_TYPE_AFFORDED_COMMANDS.to_vec();
-    holon_space_commands.push("BeginTransaction");
+    let mut holon_space_commands: Vec<CoreCommandTypeName> = HOLON_TYPE_AFFORDED_COMMANDS.to_vec();
+    holon_space_commands.push(CoreCommandTypeName::BeginTransaction);
     assert_command_set_eq(
         command_names(holon_space_type_descriptor.afforded_commands()),
         &holon_space_commands,
@@ -228,17 +231,22 @@ fn assert_contains(values: &[String], expected: &str) {
     );
 }
 
-fn command_names(descriptors: Result<Vec<CommandDescriptor>, HolonError>) -> Vec<String> {
+fn command_names(descriptors: Result<Vec<CommandDescriptor>, HolonError>) -> Vec<CommandName> {
     descriptors
         .expect("command descriptor list")
         .into_iter()
-        .map(|descriptor| descriptor.command_name().expect("command_name").to_string())
+        .map(|descriptor| descriptor.command_name().expect("command_name"))
         .collect()
 }
 
-fn assert_command_set_eq(actual: Vec<String>, expected: &[&str], message: &str) {
+fn assert_command_set_eq(
+    actual: Vec<CommandName>,
+    expected: &[CoreCommandTypeName],
+    message: &str,
+) {
     let mut actual = actual;
-    let mut expected = expected.iter().map(|name| (*name).to_string()).collect::<Vec<_>>();
+    let mut expected =
+        expected.iter().map(CoreCommandTypeName::as_command_name).collect::<Vec<_>>();
     actual.sort();
     expected.sort();
     assert_eq!(actual, expected, "{message}");

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -350,7 +350,7 @@ fn operator_type_names(descriptors: Result<Vec<OperatorDescriptor>, HolonError>)
     descriptors
         .expect("operator descriptor list")
         .into_iter()
-        .map(|descriptor| descriptor.type_name().expect("operator descriptor type_name").0)
+        .map(|descriptor| descriptor.operator_name().expect("operator descriptor name").to_string())
         .collect()
 }
 


### PR DESCRIPTION
## Summary

Follow-on to PR4 (#473). Tightens the Rust descriptor API with typed name
wrappers, conversion-trait accessor signatures, and a coordinated rename of
`MapCommand` action variants to match canonical schema names.

Closes #502.

### 4.1 — New type-name wrappers (`shared_crates/type_system/type_names/`)

- `CommandName` / `ToCommandName` / `CoreCommandTypeName` — mirrors the existing
  `PropertyName` / `ToPropertyName` / `CorePropertyTypeName` pattern. Enum covers
  all 37 concrete `CommandType` schema entries.
- `OperatorName` / `ToOperatorName` / `CoreOperatorTypeName` — same shape;
  enum covers the 2 concrete operator types (`EqualsOperator`, `LessThanOperator`).
- Blanket `impl ToXName` for: `&str` (canonicalizes to UpperCamel),
  `String`, `MapString`, `&MapString`, `CoreXTypeName`, `&CoreXTypeName`,
  `XName`, `&XName`.
- All types re-exported via `holons_prelude::prelude`.

### 4.2 — Descriptor return-type updates (`shared_crates/holons_core/descriptors/`)

- `CommandDescriptor::command_name()` now returns `Result<CommandName, HolonError>`
  (was `MapString`).
- `OperatorDescriptor::operator_name()` added, returns `Result<OperatorName, HolonError>`.
- `OperatorDescriptor::type_name()` removed — callers use `header().type_name()` directly.

### 4.3 — Conversion-trait accessor signatures

- `HolonDescriptor::get_property_by_name` → `impl ToPropertyName`
- `HolonDescriptor::get_relationship_by_name` → `impl ToRelationshipName`
- `HolonDescriptor::get_inverse_relationship_by_name` → `impl ToRelationshipName`
- `HolonDescriptor::get_command_by_name` → `impl ToCommandName` (was `MapString`)
- `ValueDescriptor::get_operator_by_name<N: ToOperatorName>` — new
- `ValueDescriptor::supports_operator_by_name<N: ToOperatorName>` — new

### 4.4 — `MapCommand` variant rename (Rust + TS + fixtures)

Single coordinated rename across contract / wire / runtime / TS SDK / JSON fixtures.
No backward-compat aliases (pre-production).

| Old | New |
|---|---|
| `EssentialContent` | `GetEssentialContent` |
| `HolonId` | `GetHolonId` |
| `Predecessor` | `GetPredecessor` |
| `Key` | `GetKey` |
| `VersionedKey` | `GetVersionedKey` |
| `PropertyValue { name }` | `GetPropertyValue { name }` |
| `RelatedHolons { name }` | `GetRelatedHolons { name }` |
| `StagedCount` | `GetStagedCount` |
| `TransientCount` | `GetTransientCount` |

Rust files updated: `map_commands_contract`, `map_commands_wire`, `map_commands_runtime`.
TS files updated: `commands.ts` type unions, guards, and `Set` literals; `holon.ts` builders.
JSON fixtures regenerated.

### 4.5 — Sweetest migration

`command_affordance_verification_executor.rs` migrated from raw `MapString` literals
to `CoreCommandTypeName` enum variants throughout `STABLE_COMMAND_TYPES` and
`HOLON_TYPE_AFFORDED_COMMANDS`. Assertions now compare typed `CommandName` values
via `as_command_name()`.

## Files Changed

**New:**
- `shared_crates/type_system/type_names/src/command_names.rs`
- `shared_crates/type_system/type_names/src/operator_names.rs`

**Updated — shared crates:**
- `shared_crates/type_system/type_names/src/lib.rs`
- `shared_crates/holons_core/src/descriptors/command_descriptor.rs`
- `shared_crates/holons_core/src/descriptors/operator_descriptor.rs`
- `shared_crates/holons_core/src/descriptors/holon_descriptor.rs`
- `shared_crates/holons_core/src/descriptors/value_descriptor.rs`

**Updated — host (Rust):**
- `host/crates/map_commands_contract/src/holon_command.rs`
- `host/crates/map_commands_contract/src/transaction_command.rs`
- `host/crates/map_commands_wire/src/holon_wire.rs`
- `host/crates/map_commands_wire/src/transaction_wire.rs`
- `host/crates/map_commands_runtime/src/holon_handler.rs`
- `host/crates/map_commands_runtime/src/transaction_handler.rs`
- `host/crates/map_commands_wire/tests/generate_fixtures.rs`

**Updated — host (TS/fixtures):**
- `host/map-sdk/src/internal/wire-types/commands.ts`
- `host/map-sdk/src/internal/commands/holon.ts`
- `host/map-sdk/tests/fixtures/request-holon-read-*.json`
- `host/map-sdk/tests/fixtures/request-tx-staged-count.json`
- `host/map-sdk/tests/fixtures/request-tx-transient-count.json`

**Updated — tests:**
- `tests/sweetests/tests/execution_steps/command_affordance_verification_executor.rs`

## Out of Scope

Per issue spec: routing/dispatch redistribution, `TransactionType` work (Issue 503),
DAHN/TS public API, dance descriptors / `DanceName`, schema persistence changes.

## Known Follow-ups

None currently identified for this PR.
