### PR TITLE
506 move holon loader schema types into core schema

### DIFF
--- a/host/crates/holons_loader_client/src/builder.rs
+++ b/host/crates/holons_loader_client/src/builder.rs
@@ -481,6 +481,8 @@ mod tests {
     use super::*;
     use serde::Deserialize;
     use serde_json::json;
+    use std::collections::BTreeSet;
+    use std::{fs, path::PathBuf};
 
     #[derive(Debug, Deserialize)]
     struct TargetWrapper {
@@ -491,6 +493,135 @@ mod tests {
     fn parse_targets(target_json: serde_json::Value) -> Result<Vec<String>, serde_json::Error> {
         serde_json::from_value::<TargetWrapper>(json!({ "target": target_json }))
             .map(|parsed| parsed.target)
+    }
+
+    #[derive(Debug)]
+    struct SchemaExportIndex {
+        descriptor_keys: BTreeSet<String>,
+        type_names: BTreeSet<String>,
+    }
+
+    fn load_core_schema_export_index() -> SchemaExportIndex {
+        let core_schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("import_files")
+            .join("map-schema")
+            .join("core-schema");
+
+        let mut schema_paths = fs::read_dir(&core_schema_dir)
+            .unwrap_or_else(|error| {
+                panic!("failed to read core schema dir {}: {error}", core_schema_dir.display())
+            })
+            .map(|entry| {
+                entry
+                    .unwrap_or_else(|error| panic!("failed to read core schema dir entry: {error}"))
+                    .path()
+            })
+            .filter(|path| {
+                path.extension().and_then(|extension| extension.to_str()) == Some("json")
+            })
+            .collect::<Vec<_>>();
+        schema_paths.sort();
+
+        let mut descriptor_keys = BTreeSet::new();
+        let mut type_names = BTreeSet::new();
+
+        for schema_path in schema_paths {
+            let raw_contents = fs::read_to_string(&schema_path).unwrap_or_else(|error| {
+                panic!("failed to read core schema export {}: {error}", schema_path.display())
+            });
+            let document: serde_json::Value =
+                serde_json::from_str(&raw_contents).unwrap_or_else(|error| {
+                    panic!("failed to parse core schema export {}: {error}", schema_path.display())
+                });
+
+            let holons =
+                document.get("holons").and_then(|value| value.as_array()).unwrap_or_else(|| {
+                    panic!("core schema export {} is missing holons[]", schema_path.display())
+                });
+
+            for holon in holons {
+                if let Some(key) = holon.get("key").and_then(|value| value.as_str()) {
+                    descriptor_keys.insert(key.to_string());
+                }
+                if let Some(type_name) = holon
+                    .get("properties")
+                    .and_then(|properties| properties.get("type_name"))
+                    .and_then(|value| value.as_str())
+                {
+                    type_names.insert(type_name.to_string());
+                }
+            }
+        }
+
+        SchemaExportIndex { descriptor_keys, type_names }
+    }
+
+    fn assert_type_names_exist(schema_index: &SchemaExportIndex, expected_names: &[String]) {
+        let missing_names = expected_names
+            .iter()
+            .filter(|name| !schema_index.type_names.contains(*name))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert!(
+            missing_names.is_empty(),
+            "core schema export is missing loader-used type_name values: {missing_names:?}"
+        );
+    }
+
+    fn assert_descriptor_keys_exist(schema_index: &SchemaExportIndex, expected_keys: &[&str]) {
+        let missing_keys = expected_keys
+            .iter()
+            .filter(|key| !schema_index.descriptor_keys.contains(**key))
+            .copied()
+            .collect::<Vec<_>>();
+
+        assert!(
+            missing_keys.is_empty(),
+            "core schema export is missing loader graph descriptor keys: {missing_keys:?}"
+        );
+    }
+
+    #[test]
+    fn loader_client_vocabulary_exists_in_core_schema_exports() {
+        let schema_index = load_core_schema_export_index();
+
+        let required_property_type_names = [
+            CorePropertyTypeName::Filename,
+            CorePropertyTypeName::HolonKey,
+            CorePropertyTypeName::RelationshipName,
+            CorePropertyTypeName::StartUtf8ByteOffset,
+        ]
+        .iter()
+        .map(|name| name.as_property_name().to_string())
+        .collect::<Vec<_>>();
+
+        let required_relationship_type_names = [
+            CoreRelationshipTypeName::BundleMembers,
+            CoreRelationshipTypeName::Contains,
+            CoreRelationshipTypeName::DescribedBy,
+            CoreRelationshipTypeName::HasRelationshipReference,
+            CoreRelationshipTypeName::ReferenceSource,
+            CoreRelationshipTypeName::ReferenceTarget,
+        ]
+        .iter()
+        .map(|name| name.as_relationship_name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_type_names_exist(&schema_index, &required_property_type_names);
+        assert_type_names_exist(&schema_index, &required_relationship_type_names);
+        assert_descriptor_keys_exist(
+            &schema_index,
+            &[
+                "HolonLoadSet.HolonType",
+                "HolonLoaderBundle.HolonType",
+                "LoaderHolon.HolonType",
+                "LoaderRelationshipReference.HolonType",
+                "LoaderHolonReference.HolonType",
+            ],
+        );
     }
 
     #[test]

--- a/host/crates/holons_loader_client/src/lib.rs
+++ b/host/crates/holons_loader_client/src/lib.rs
@@ -22,4 +22,4 @@ pub use loader_client::load_holons_from_files;
 // tooling can use them without reaching into private modules.
 pub use builder::{RawLoaderHolon, RawLoaderMeta, RawRelationshipEndpoints, RawRelationshipSpec};
 pub use parser::{ImportFileParsingIssue, ImportFileParsingIssueKind, RawLoaderFileWithSlices};
-pub use types::BOOTSTRAP_IMPORT_SCHEMA_PATH;
+pub use types::BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH;

--- a/host/crates/holons_loader_client/src/types.rs
+++ b/host/crates/holons_loader_client/src/types.rs
@@ -1,23 +1,8 @@
-/// Raw file contents as seen by the loader client.
-/// All filesystem access happens in the receptor layer.
-/* #[derive(Debug, Clone)]
-pub struct FileData {
-    pub filename: String, // original path or logical name, used for provenance / errors
-    pub raw_contents: String,
-}
-
-/// A full loader invocation: schema + the files to load.
-#[derive(Debug, Clone)]
-pub struct ContentSet {
-    pub schema: FileData,
-    pub files_to_load: Vec<FileData>,
-} */
-
-/// Canonical on-disk path to the Holon Loader JSON Schema.
+/// Canonical on-disk path to the Holon Loader JSON Import File Validation Schema.
 ///
 /// This path is intended for caller (receptor/test) use when constructing a ContentSet.
 /// The loader client itself only works with in-memory file contents.
-pub const BOOTSTRAP_IMPORT_SCHEMA_PATH: &str = concat!(
+pub const BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../import_files/map-schema/bootstrap-import.schema.json"
 );

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-23T10:51:55",
+    "generated_at": "2026-05-23T11:57:15",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-loader-types.csv"
@@ -374,7 +374,7 @@
         {
           "name": "InstanceRelationships",
           "target": {
-            "$ref": "#(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)"
+            "$ref": "#(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)"
           }
         }
       ]
@@ -920,7 +920,7 @@
       ]
     },
     {
-      "key": "(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)",
+      "key": "(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)",
       "type": "#TypeDescriptor",
       "properties": {
         "type_name": "Contains",
@@ -1010,7 +1010,7 @@
         {
           "name": "InverseOf",
           "target": {
-            "$ref": "#(HolonLoadSet.Ho)-[Contains]->(HolonLoaderBundle.HolonType)"
+            "$ref": "#(HolonLoadSet.HolonType)-[Contains]->(HolonLoaderBundle.HolonType)"
           }
         },
         {

--- a/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json
+++ b/host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json
@@ -1,10 +1,10 @@
 {
   "meta": {
     "generator": "MAP CSV->JSON Notebook (row-wise SchemaType detection)",
-    "generated_at": "2026-05-20T16:28:35",
+    "generated_at": "2026-05-23T10:51:55",
     "export_mode": "by-file",
     "source_files": [
-      "MAP Schema Types-map-holon-loader-schema.csv"
+      "MAP Schema Types-map-core-schema-loader-types.csv"
     ],
     "load_with": [
       "MAP Schema Types-map-core-schema-root.json",

--- a/shared_crates/type_system/core_types/src/ids.rs
+++ b/shared_crates/type_system/core_types/src/ids.rs
@@ -103,12 +103,14 @@ impl fmt::Display for HolonId {
     }
 }
 
+/// Raw file contents as seen by the loader client.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct FileData {
     pub filename: String,
     pub raw_contents: String,
 }
 
+/// A full loader invocation: schema + the files to load.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ContentSet {
     pub schema: FileData,

--- a/shared_crates/type_system/core_types/src/ids.rs
+++ b/shared_crates/type_system/core_types/src/ids.rs
@@ -102,17 +102,3 @@ impl fmt::Display for HolonId {
         }
     }
 }
-
-/// Raw file contents as seen by the loader client.
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct FileData {
-    pub filename: String,
-    pub raw_contents: String,
-}
-
-/// A full loader invocation: schema + the files to load.
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct ContentSet {
-    pub schema: FileData,
-    pub files_to_load: Vec<FileData>,
-}

--- a/shared_crates/type_system/core_types/src/lib.rs
+++ b/shared_crates/type_system/core_types/src/lib.rs
@@ -15,9 +15,11 @@
 //! and are shared across guest and client implementations.
 
 pub mod ids;
+pub mod loader_content;
 pub mod type_kinds;
 
 pub use ids::*;
+pub use loader_content::*;
 pub use type_kinds::*;
 
 //Re-export selected integrity_core_types at the root.

--- a/shared_crates/type_system/core_types/src/loader_content.rs
+++ b/shared_crates/type_system/core_types/src/loader_content.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+/// Raw file contents as seen by the loader client.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct FileData {
+    pub filename: String,
+    pub raw_contents: String,
+}
+
+/// A full loader invocation: schema + the files to load.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct ContentSet {
+    pub schema: FileData,
+    pub files_to_load: Vec<FileData>,
+}

--- a/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
+++ b/tests/sweetests/src/harness/helpers/book_person_inverse_schema.rs
@@ -1,5 +1,5 @@
 use core_types::ContentSet;
-use holons_loader_client::BOOTSTRAP_IMPORT_SCHEMA_PATH;
+use holons_loader_client::BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH;
 use holons_prelude::prelude::*;
 use std::path::PathBuf;
 
@@ -22,7 +22,7 @@ pub fn domain_schema_path() -> PathBuf {
 }
 
 pub fn build_book_person_inverse_content_set() -> Result<ContentSet, HolonError> {
-    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_SCHEMA_PATH);
+    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH);
     let schema = read_file_data(&schema_path, "validation schema")?;
 
     let files_to_load =

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -1,5 +1,5 @@
 use core_types::{ContentSet, FileData};
-use holons_loader_client::BOOTSTRAP_IMPORT_SCHEMA_PATH;
+use holons_loader_client::BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH;
 use holons_prelude::prelude::*;
 use std::{
     fs,
@@ -49,7 +49,7 @@ pub fn map_core_schema_paths() -> Vec<PathBuf> {
 }
 
 pub fn build_core_schema_content_set() -> Result<ContentSet, HolonError> {
-    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_SCHEMA_PATH);
+    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH);
     let schema = read_file_data(&schema_path, "validation schema")?;
     let files_to_load = map_core_schema_paths()
         .into_iter()

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -6,12 +6,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const CORE_SCHEMA_RELATIVE_PATHS: [&str; 10] = [
+const CORE_SCHEMA_RELATIVE_PATHS: [&str; 11] = [
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-abstract-value-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-command-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-concrete-value-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-dance-schema.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-keyrules-schema.json",
+    "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-operator-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-property-types.json",
     "import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-relationship-types.json",
@@ -30,12 +31,12 @@ pub struct CoreSchemaLoadMetrics {
 }
 
 pub const CORE_SCHEMA_METRICS: CoreSchemaLoadMetrics = CoreSchemaLoadMetrics {
-    staged: 246,
-    committed: 246,
-    links_created: 1290,
+    staged: 282,
+    committed: 282,
+    links_created: 1505,
     errors: 0,
-    total_bundles: 10,
-    total_loader_holons: 246,
+    total_bundles: 11,
+    total_loader_holons: 282,
 };
 
 /// Absolute paths to all core schema import files used for loader-client testing.


### PR DESCRIPTION
## Summary

Moves the holon loader schema types into the core schema export set.

The loader types file was renamed, regenerated, and moved from the old `holon-loader-schema` location into `core-schema` as:

`host/import_files/map-schema/core-schema/MAP Schema Types-map-core-schema-loader-types.json`

This reflects that `LoadHolons` and the canonical JSON import format are now part of core MAP functionality rather than a separate optional loader schema.

Closes #506.

## Changes

- Added the regenerated loader types export under `host/import_files/map-schema/core-schema/`.
- Removed/retired the old `host/import_files/map-schema/holon-loader-schema/` loader schema file.
- Updated core schema loading to include the loader types file.
- Updated expected core schema loader metrics.
- Renamed and clarified the bootstrap import validation schema path constant.
- Added a loader/schema alignment unit test that verifies the hard-coded loader client vocabulary still exists in the definitive core schema exports.
- Cleaned up a prior move of `FileData` and `ContentSet` by moving them out of `ids.rs` into `loader_content.rs`, while preserving the existing `core_types::{FileData, ContentSet}` re-exports.

## Testing

- Core schema loading tests pass.
- Loader-related checks pass.
- Added alignment unit test for loader client vocabulary vs. core schema exports.