### PR TITLE
528 build the v13 new world ts sdk and preserve old world paths as deprecated

### DIFF
--- a/host/map-sdk/src/sdk/transaction.ts
+++ b/host/map-sdk/src/sdk/transaction.ts
@@ -108,8 +108,10 @@ export class MapTransaction {
    * or effectively commit the active transaction rather than behaving like a
    * normal in-transaction mutation.
    */
-  async loadHolons(contentSet: ContentSet): Promise<void> {
-    await internalTransaction.loadHolons(txIdFor(this), contentSet);
+  async loadHolons(contentSet: ContentSet): Promise<TransientHolonReference> {
+    const txId = txIdFor(this);
+    const wireRef = await internalTransaction.loadHolons(txId, contentSet);
+    return createTransientHolonReference(txId, wireRef);
   }
 
   async getAllHolons(): Promise<HolonCollection> {

--- a/host/map-sdk/src/sdk/transaction.ts
+++ b/host/map-sdk/src/sdk/transaction.ts
@@ -1,11 +1,11 @@
-import { DomainError } from '../internal/errors';
+import { DomainError } from '../internal';
 import * as internalTransaction from '../internal/commands/transaction';
 import type {
   HolonId,
   LocalId,
   SmartReferenceWire,
   TxId,
-} from '../internal/wire-types/references';
+} from '../internal';
 import { HolonCollection } from './collection';
 import {
   createHolonReference,

--- a/host/map-sdk/tests/sdk/transaction.test.ts
+++ b/host/map-sdk/tests/sdk/transaction.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DomainError } from '../../src/internal/errors';
+import { DomainError } from '../../src';
 import type {
   BaseValue,
   ContentSet,
@@ -65,7 +65,7 @@ vi.mock('../../src/internal/commands/transaction', () => ({
   transientCount: transientCountMock,
 }));
 
-import { HolonCollection } from '../../src/sdk/collection';
+import { HolonCollection } from '../../src';
 import {
   createHolonReference,
   createTransientHolonReference,

--- a/host/map-sdk/tests/sdk/transaction.test.ts
+++ b/host/map-sdk/tests/sdk/transaction.test.ts
@@ -255,11 +255,22 @@ describe('MapTransaction', () => {
     expect(deleteHolonMock).toHaveBeenCalledWith(txId, localId);
   });
 
-  it('delegates loadHolons and discards the internal payload', async () => {
+  it('wraps loadHolons results as transient references', async () => {
     loadHolonsMock.mockResolvedValue(transientReference);
 
-    await expect(transaction().loadHolons(contentSet)).resolves.toBeUndefined();
+    const holon = await transaction().loadHolons(contentSet);
+
     expect(loadHolonsMock).toHaveBeenCalledWith(txId, contentSet);
+    expect(holon).toBeInstanceOf(TransientHolonReference);
+  });
+
+  it('returns a loadHolons transient handle with direct readable methods', async () => {
+    loadHolonsMock.mockResolvedValue(transientReference);
+
+    const holon = await transaction().loadHolons(contentSet);
+
+    expect(holon.propertyValue).toEqual(expect.any(Function));
+    expect(holon.relatedHolons).toEqual(expect.any(Function));
   });
 
   it('wraps getAllHolons results as a HolonCollection', async () => {


### PR DESCRIPTION
# Summary

Return the `loadHolons` result from the TS SDK as a `TransientHolonReference` instead of discarding the runtime payload.

This lets UI evaluate the `load_holons` response directly through the public holon reference API, which is the core behavior Issue 528 is meant to demonstrate.

## Changes

- Updated `MapTransaction.loadHolons(contentSet)` to return `Promise<TransientHolonReference>`
- Wrapped the internal returned wire reference with the existing public transient reference wrapper
- Updated SDK transaction tests to verify:
    - `loadHolons()` returns a `TransientHolonReference`
    - the returned handle exposes direct readable methods such as `propertyValue` and `relatedHolons`

## Testing

- Attempted: `npm run test -w map-sdk -- host/map-sdk/tests/sdk/transaction.test.ts`
- Attempted: `npm run test -w map-sdk -- host/map-sdk/tests/commands/transaction.test.ts`
- Blocked locally by missing optional dependency: `@rollup/rollup-darwin-x64`

## Notes

This change preserves the existing `load_holons` invocation path and focuses the SDK change on exposing the returned transient subject directly to TypeScript callers.