### PR TITLE
529 minimal UI follow up for holons data loader response presentation

### DIFF
--- a/host/conductora/src/setup/providers/holochain/setup.rs
+++ b/host/conductora/src/setup/providers/holochain/setup.rs
@@ -285,6 +285,8 @@ impl ProviderWindowSetup for HolochainWindowSetup {
             .map_err(|e| anyhow::anyhow!("Failed to build holochain window: {}", e))?;
 
         let _main_window = main_window_builder
+            .inner_size(1280.0, 1040.0)
+            .min_inner_size(1100.0, 900.0)
             .theme(Some(Theme::Dark))
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to build main window: {}", e))?;

--- a/host/conductora/src/setup/window_setup.rs
+++ b/host/conductora/src/setup/window_setup.rs
@@ -22,6 +22,8 @@ impl ProviderWindowSetup for DefaultWindowSetup {
 
         let _main_window =
             WebviewWindowBuilder::new(handle, "main", WebviewUrl::App("index.html".into()))
+                .inner_size(1280.0, 1040.0)
+                .min_inner_size(1100.0, 900.0)
                 .theme(Some(Theme::Dark))
                 .build()
                 .map_err(|e| anyhow::anyhow!("Failed to create default window: {}", e))?;

--- a/host/conductora/tauri.conf.json
+++ b/host/conductora/tauri.conf.json
@@ -14,8 +14,10 @@
 		"windows": [
 			{
 				"title": "MAP Holons client",
-				"width": 800,
-				"height": 600,
+				"width": 1280,
+				"height": 1040,
+				"minWidth": 1100,
+				"minHeight": 900,
 				"resizable": true,
 				"fullscreen": false,
 				"theme": "Dark"

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -60,12 +60,21 @@ impl RuntimeSession {
     }
 
     pub async fn begin_transaction(&self) -> Result<TxId, HolonError> {
+        eprintln!("[RUNTIME] begin_transaction: opening new client session");
         let session = Arc::new(ClientSession::open_new(
             Arc::clone(&self.space_manager),
             self.recovery.clone(),
         )?);
 
+        eprintln!(
+            "[RUNTIME] begin_transaction: opened session tx_id={}, persisting initial recovery snapshot",
+            session.tx_id().value()
+        );
         session.persist("begin_transaction", false, false, None, None).await?;
+        eprintln!(
+            "[RUNTIME] begin_transaction: initial persistence complete for tx_id={}",
+            session.tx_id().value()
+        );
 
         let tx_id = session.tx_id();
         let mut active = self.active_sessions.write().map_err(|e| {
@@ -75,6 +84,7 @@ impl RuntimeSession {
             ))
         })?;
         active.insert(tx_id, session);
+        eprintln!("[RUNTIME] begin_transaction: session registered tx_id={}", tx_id.value());
 
         Ok(tx_id)
     }

--- a/host/crates/map_commands_runtime/src/runtime_session.rs
+++ b/host/crates/map_commands_runtime/src/runtime_session.rs
@@ -60,21 +60,12 @@ impl RuntimeSession {
     }
 
     pub async fn begin_transaction(&self) -> Result<TxId, HolonError> {
-        eprintln!("[RUNTIME] begin_transaction: opening new client session");
         let session = Arc::new(ClientSession::open_new(
             Arc::clone(&self.space_manager),
             self.recovery.clone(),
         )?);
 
-        eprintln!(
-            "[RUNTIME] begin_transaction: opened session tx_id={}, persisting initial recovery snapshot",
-            session.tx_id().value()
-        );
         session.persist("begin_transaction", false, false, None, None).await?;
-        eprintln!(
-            "[RUNTIME] begin_transaction: initial persistence complete for tx_id={}",
-            session.tx_id().value()
-        );
 
         let tx_id = session.tx_id();
         let mut active = self.active_sessions.write().map_err(|e| {
@@ -84,7 +75,6 @@ impl RuntimeSession {
             ))
         })?;
         active.insert(tx_id, session);
-        eprintln!("[RUNTIME] begin_transaction: session registered tx_id={}", tx_id.value());
 
         Ok(tx_id)
     }

--- a/host/crates/recovery_receptor/src/storage/transaction_store.rs
+++ b/host/crates/recovery_receptor/src/storage/transaction_store.rs
@@ -93,6 +93,7 @@ impl RecoveryStore for TransactionRecoveryStore {
 
         conn.execute_batch(SCHEMA_SQL)
             .map_err(|e| HolonError::Misc(format!("Schema init failed: {e}")))?;
+        ensure_schema_compatibility(&conn)?;
 
         tracing::debug!("[RECOVERY STORE] Ready at {path:?}");
         Ok(Self { conn: Mutex::new(conn) })
@@ -744,4 +745,40 @@ fn load_snapshot(
 
     serde_json::from_slice(&blob)
         .map_err(|e| HolonError::Misc(format!("Deserialize snapshot '{checkpoint_id}': {e}")))
+}
+
+fn ensure_schema_compatibility(conn: &Connection) -> Result<(), HolonError> {
+    ensure_recovery_session_column(
+        conn,
+        "undo_checkpointing_enabled",
+        "ALTER TABLE recovery_session ADD COLUMN undo_checkpointing_enabled INTEGER NOT NULL DEFAULT 1",
+    )?;
+
+    Ok(())
+}
+
+fn ensure_recovery_session_column(
+    conn: &Connection,
+    column_name: &str,
+    alter_sql: &str,
+) -> Result<(), HolonError> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(recovery_session)")
+        .map_err(|e| HolonError::Misc(format!("Inspect recovery_session schema: {e}")))?;
+
+    let column_names = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| HolonError::Misc(format!("Read recovery_session schema rows: {e}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| HolonError::Misc(format!("Collect recovery_session schema rows: {e}")))?;
+
+    if column_names.iter().any(|name| name == column_name) {
+        return Ok(());
+    }
+
+    conn.execute(alter_sql, [])
+        .map_err(|e| HolonError::Misc(format!("Add recovery_session.{column_name}: {e}")))?;
+
+    tracing::info!("[RECOVERY STORE] Added missing recovery_session column '{column_name}'");
+    Ok(())
 }

--- a/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.html
+++ b/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.html
@@ -155,6 +155,75 @@
     </div>
   }
 
+  @if (showLoaderResult) {
+    <div class="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-4">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-sm font-semibold text-slate-900">Loader result</p>
+          <p class="text-xs text-slate-600">{{ loaderResultStatus || 'Summary reported by the HolonLoadResponse holon.' }}</p>
+        </div>
+        @if (hasLoadErrors()) {
+          <button
+            type="button"
+            (click)="toggleLoadErrors()"
+            class="rounded-md border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-white">
+            {{ showLoadErrors ? 'Hide load errors' : 'Show load errors' }}
+          </button>
+        }
+      </div>
+
+      @if (loaderResult; as result) {
+        <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Holons staged</p>
+            <p class="mt-1 text-lg font-semibold text-slate-900">{{ displayLoaderField(result.holonsStaged) }}</p>
+          </div>
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Holons committed</p>
+            <p class="mt-1 text-lg font-semibold text-slate-900">{{ displayLoaderField(result.holonsCommitted) }}</p>
+          </div>
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Error count</p>
+            <p class="mt-1 text-lg font-semibold text-slate-900">{{ displayLoaderField(result.errorCount) }}</p>
+          </div>
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Dance summary</p>
+            <p class="mt-1 text-sm text-slate-700">{{ displayLoaderField(result.danceSummary) }}</p>
+          </div>
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Links created</p>
+            <p class="mt-1 text-lg font-semibold text-slate-900">{{ displayLoaderField(result.linksCreated) }}</p>
+          </div>
+          <div class="rounded-md bg-white p-3 border border-slate-200">
+            <p class="text-[11px] uppercase tracking-wide text-slate-500">Commit status</p>
+            <p class="mt-1 text-sm font-semibold text-slate-900">{{ displayLoaderField(result.loadCommitStatus) }}</p>
+          </div>
+        </div>
+
+        @if (showLoadErrors && result.loadErrors.length > 0) {
+          <div class="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3">
+            <p class="text-sm font-semibold text-amber-900">Load errors</p>
+            <div class="mt-3 space-y-2">
+              @for (error of result.loadErrors; track $index) {
+                <div class="rounded-md bg-white border border-amber-200 p-3 text-xs sm:text-sm">
+                  <p class="font-semibold text-slate-900">{{ error.filename }}</p>
+                  <p class="text-slate-700">Type: {{ error.errorType }}</p>
+                  <p class="text-slate-700">Message: {{ error.errorMessage }}</p>
+                  <p class="text-slate-700">Loader key: {{ error.loaderHolonKey }}</p>
+                  <p class="text-slate-700">Start byte offset: {{ error.startUtf8ByteOffset }}</p>
+                </div>
+              }
+            </div>
+          </div>
+        }
+      } @else {
+        <div class="mt-4 rounded-md bg-white border border-slate-200 p-3 text-sm text-slate-700">
+          Loader result is pending.
+        </div>
+      }
+    </div>
+  }
+
   <!-- Action Buttons -->
   <div class="flex gap-2 justify-start">
     <button

--- a/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
+++ b/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
@@ -60,7 +60,6 @@ export class JsonDataUploader implements OnInit {
   async ngOnInit() {
         const contentStore = this.contentController.getStoreById(this.spaceId);
         this.store.set(contentStore);
-        console.log('ContentSpace initialized with id:', this.spaceId);
     await this.loadSchema();
   }
 
@@ -79,9 +78,7 @@ export class JsonDataUploader implements OnInit {
       // Check if running in Tauri (production) or web (mock mode)
       if (!environment.mock || isTauri()) {
         const schemaPath = await resolveResource('resources/bootstrap-import.schema.json');
-        console.log("Resolved schema path:", schemaPath);
-        schemaContent = await readTextFile(schemaPath)
-        console.log("Read schema content:", schemaContent);
+        schemaContent = await readTextFile(schemaPath);
       } else {
         // Web/Mock environment - load from assets directory
           const response = await fetch('/bootstrap-import.schema.json');
@@ -122,7 +119,6 @@ export class JsonDataUploader implements OnInit {
               content,
               validationResult: null
             });
-            console.log(`Added file: ${file.name}`);
           }
           this.dataFiles.set([...currentFiles]);
         });
@@ -217,9 +213,7 @@ export class JsonDataUploader implements OnInit {
   }
 
   async savetohost() {
-      console.log('[Uploader] savetohost() entered');
       const storeInstance = this.store();
-      console.log('[Uploader] store() resolved to:', storeInstance ? 'present' : 'missing');
     if (storeInstance) {
       // Check if all files are validated and valid
       const validFiles = this.dataFiles().filter(
@@ -249,8 +243,6 @@ export class JsonDataUploader implements OnInit {
       this.cdr.markForCheck();
 
       try {
-        console.log('[Uploader] Preparing content set for uploadHolons(...)');
-        
         // Prepare batch data with all valid files
         const filedata: FileData[] = validFiles.map(dataFile => ({
           filename: dataFile.filename,
@@ -267,13 +259,8 @@ export class JsonDataUploader implements OnInit {
           files_to_load: filedata
         };
 
-        console.log("Sending file data to Host:", filedata);
-        console.log('[Uploader] Calling storeInstance.uploadHolons(...) now');
-        console.log('[Uploader] Awaiting SDK uploadHolons(...) result');
         const loaderReference = await storeInstance.uploadHolons(file_and_schema_Data);
-        console.log('[Uploader] SDK uploadHolons resolved with loader reference:', loaderReference);
         this.loaderResultStatus = 'Loading loader result...';
-        console.log('[Uploader] Scheduling loader result read...');
         void this.loadLoaderResult(loaderReference);
         this.successMessage = 'Operation submitted, waiting for loader result.';
         this.clearForms();
@@ -318,9 +305,7 @@ export class JsonDataUploader implements OnInit {
 
   private async loadLoaderResult(loaderReference: HolonReference): Promise<void> {
     try {
-      console.log('[Uploader] Reading loader result holon...');
       this.loaderResult = await presentLoaderResult(loaderReference);
-      console.log('[Uploader] Loader result holon read complete:', this.loaderResult);
       this.loaderResultStatus = 'Loader result received.';
       if (Number(this.loaderResult.errorCount) > 0) {
         this.successMessage = '';

--- a/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
+++ b/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, signal, Output, EventEmitter, Input, WritableSignal, effect } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, WritableSignal, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { invoke } from '@tauri-apps/api/core';
 import { SchemaValidatorService } from '../../services/schema-validation.service';
 import { readTextFile } from '@tauri-apps/plugin-fs';
 import { resolveResource } from '@tauri-apps/api/path';
@@ -74,7 +73,6 @@ export class JsonDataUploader implements OnInit {
     this.schemaLoading.set(true);
 
     try {
-      let schemaUrl: string;
       let schemaContent: string;
       const schemaLocalPath = 'bootstrap-import.schema.json';
       
@@ -86,7 +84,6 @@ export class JsonDataUploader implements OnInit {
         console.log("Read schema content:", schemaContent);
       } else {
         // Web/Mock environment - load from assets directory
-          schemaUrl = `/${schemaLocalPath}`;
           const response = await fetch('/bootstrap-import.schema.json');
           if (!response.ok) {
             throw new Error(`Failed to load schema: ${response.statusText}`);

--- a/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
+++ b/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy, signal, Output, EventEmitter, Input, WritableSignal, effect } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, signal, Output, EventEmitter, Input, WritableSignal, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { invoke } from '@tauri-apps/api/core';
@@ -8,9 +8,9 @@ import { resolveResource } from '@tauri-apps/api/path';
 import { environment } from '../../../environments/environment.mock';
 import { ContentSet, FileData } from '../../models/shared-types';
 import { ContentStoreInstance } from '../../stores/content.store';
-import { SpaceController } from '../../contollers/space.controller';
 import { ContentController } from '../../contollers/content.controller';
-import { ResponseStatusCode } from '../../models/map.response';
+import { type HolonReference } from '../../../dahn/deps/map-sdk';
+import { presentLoaderResult, type LoaderResultView } from './loader-result.presenter';
 
 // Helper function to check if the app is running in a Tauri window
 const isTauri = () => !!(window as any).__TAURI__;
@@ -47,10 +47,15 @@ export class JsonDataUploader implements OnInit {
   isLoading: boolean = false;
   successMessage: string = '';
   errorMessage: string = '';
+  loaderResult: LoaderResultView | null = null;
+  loaderResultStatus: string = '';
+  showLoadErrors = false;
+  showLoaderResult = false;
 
   constructor(
     private schemaValidatorService: SchemaValidatorService,
-    private contentController: ContentController)
+    private contentController: ContentController,
+    private cdr: ChangeDetectorRef)
     {}
 
   async ngOnInit() {
@@ -215,7 +220,9 @@ export class JsonDataUploader implements OnInit {
   }
 
   async savetohost() {
+      console.log('[Uploader] savetohost() entered');
       const storeInstance = this.store();
+      console.log('[Uploader] store() resolved to:', storeInstance ? 'present' : 'missing');
     if (storeInstance) {
       // Check if all files are validated and valid
       const validFiles = this.dataFiles().filter(
@@ -230,8 +237,22 @@ export class JsonDataUploader implements OnInit {
       this.isLoading = true;
       this.errorMessage = '';
       this.successMessage = '';
+      this.loaderResult = {
+        holonsStaged: 'n/a',
+        holonsCommitted: 'n/a',
+        errorCount: 'n/a',
+        danceSummary: 'Waiting for loader result...',
+        linksCreated: 'n/a',
+        loadCommitStatus: 'n/a',
+        loadErrors: [],
+      };
+      this.loaderResultStatus = 'Submitting...';
+      this.showLoaderResult = true;
+      this.showLoadErrors = false;
+      this.cdr.markForCheck();
 
       try {
+        console.log('[Uploader] Preparing content set for uploadHolons(...)');
         
         // Prepare batch data with all valid files
         const filedata: FileData[] = validFiles.map(dataFile => ({
@@ -250,20 +271,22 @@ export class JsonDataUploader implements OnInit {
         };
 
         console.log("Sending file data to Host:", filedata);
-        this.successMessage = `✓ ${validFiles.length} file(s) submitted to the host}`;
-        await storeInstance.uploadHolons(file_and_schema_Data)
-
-        let last_response = storeInstance.last_map_response;
-        if (last_response && last_response()?.status_code !== ResponseStatusCode.OK) {
-          this.errorMessage = `Error from Host: ${last_response()?.description || 'Unknown error'}`;
-        } else {
-          this.successMessage = `Operation completed successfully, for ${validFiles.length} file(s).`;
-        }
+        console.log('[Uploader] Calling storeInstance.uploadHolons(...) now');
+        console.log('[Uploader] Awaiting SDK uploadHolons(...) result');
+        const loaderReference = await storeInstance.uploadHolons(file_and_schema_Data);
+        console.log('[Uploader] SDK uploadHolons resolved with loader reference:', loaderReference);
+        this.loaderResultStatus = 'Loading loader result...';
+        console.log('[Uploader] Scheduling loader result read...');
+        void this.loadLoaderResult(loaderReference);
+        this.successMessage = 'Operation submitted, waiting for loader result.';
         this.clearForms();
+        this.cdr.markForCheck();
       } catch (error) {
         this.errorMessage = `Tauri Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        this.cdr.markForCheck();
       } finally {
         this.isLoading = false;
+        this.cdr.markForCheck();
       }
     } else {
       this.errorMessage = 'Content store is not initialized.';
@@ -274,5 +297,48 @@ export class JsonDataUploader implements OnInit {
     this.schemaJson.set('');
     this.schemaFilename = '';
     this.dataFiles.set([]);
+  }
+
+  toggleLoadErrors(): void {
+    this.showLoadErrors = !this.showLoadErrors;
+  }
+
+  hasLoadErrors(): boolean {
+    return !!this.loaderResult && Number(this.loaderResult.errorCount) > 0;
+  }
+
+  displayLoaderField(value: string): string {
+    if (value !== 'n/a') {
+      return value;
+    }
+
+    if (this.loaderResultStatus.includes('could not be read') || this.errorMessage) {
+      return 'unavailable';
+    }
+
+    return value;
+  }
+
+  private async loadLoaderResult(loaderReference: HolonReference): Promise<void> {
+    try {
+      console.log('[Uploader] Reading loader result holon...');
+      this.loaderResult = await presentLoaderResult(loaderReference);
+      console.log('[Uploader] Loader result holon read complete:', this.loaderResult);
+      this.loaderResultStatus = 'Loader result received.';
+      if (Number(this.loaderResult.errorCount) > 0) {
+        this.successMessage = '';
+        this.errorMessage = `Load completed with ${this.loaderResult.errorCount} error(s).`;
+      } else {
+        this.successMessage = 'Load completed successfully.';
+        this.errorMessage = '';
+      }
+      this.cdr.markForCheck();
+    } catch (error) {
+      console.error('[Uploader] Failed to read loader result holon:', error);
+      this.loaderResultStatus = 'Loader result could not be read.';
+      this.errorMessage = 'Load completed, but the loader summary could not be read.';
+      this.successMessage = '';
+      this.cdr.markForCheck();
+    }
   }
 }

--- a/host/ui/src/app/components/json-data-uploader/loader-result.presenter.spec.ts
+++ b/host/ui/src/app/components/json-data-uploader/loader-result.presenter.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  BaseValue,
+  EssentialHolonContent,
+  HolonCollection,
+  HolonId,
+  HolonReference,
+  ReadableHolon,
+} from '../../../dahn/deps/map-sdk';
+import { presentLoaderResult } from './loader-result.presenter';
+
+function holonMock(
+  properties: Record<string, BaseValue>,
+  relatedErrors: Array<Record<string, BaseValue>> = [],
+): ReadableHolon {
+  const members = relatedErrors.map(
+    (error) => holonMock(error) as unknown as HolonReference,
+  );
+  const relatedCollection = {
+    length: members.length,
+    members,
+    getByKey: vi.fn<(key: string) => HolonReference | undefined>(),
+    [Symbol.iterator]: function* (): Iterator<HolonReference> {
+      for (const member of members) {
+        yield member;
+      }
+    },
+  } as unknown as HolonCollection;
+
+  return {
+    cloneHolon: vi.fn<() => Promise<never>>(),
+    essentialContent: vi.fn<() => Promise<EssentialHolonContent>>(),
+    summarize: vi.fn<() => Promise<string>>(),
+    holonId: vi.fn<() => Promise<HolonId>>(),
+    predecessor: vi.fn<() => Promise<HolonReference | null>>(),
+    key: vi.fn<() => Promise<string | null>>(),
+    versionedKey: vi.fn<() => Promise<string>>(),
+    propertyValue: vi.fn<(name: string) => Promise<BaseValue | null>>(
+      async (name: string) => properties[name] ?? null,
+    ),
+    relatedHolons: vi.fn<(name: string) => Promise<HolonCollection>>(
+      async () => relatedCollection,
+    ),
+  };
+}
+
+describe('presentLoaderResult', () => {
+  it('reads the loader summary without errors', async () => {
+    const loaderHolon = holonMock({
+      HolonsStaged: { IntegerValue: 3 },
+      HolonsCommitted: { IntegerValue: 2 },
+      ErrorCount: { IntegerValue: 0 },
+      DanceSummary: { StringValue: 'loaded' },
+      LinksCreated: { IntegerValue: 7 },
+      LoadCommitStatus: { StringValue: 'Committed' },
+    });
+
+    await expect(presentLoaderResult(loaderHolon)).resolves.toEqual({
+      holonsStaged: '3',
+      holonsCommitted: '2',
+      errorCount: '0',
+      danceSummary: 'loaded',
+      linksCreated: '7',
+      loadCommitStatus: 'Committed',
+      loadErrors: [],
+    });
+  });
+
+  it('reads related load errors when present', async () => {
+    const loaderHolon = holonMock(
+      {
+        HolonsStaged: { IntegerValue: 8 },
+        HolonsCommitted: { IntegerValue: 5 },
+        ErrorCount: { IntegerValue: 1 },
+        DanceSummary: { StringValue: 'loaded with errors' },
+        LinksCreated: { IntegerValue: 0 },
+        LoadCommitStatus: { StringValue: 'CommittedWithWarnings' },
+      },
+      [
+        {
+          Filename: { StringValue: 'sample-loader-file.json' },
+          StartUtf8ByteOffset: { IntegerValue: 123 },
+          LoaderHolonKey: { StringValue: 'alpha' },
+          ErrorType: { StringValue: 'ValidationError' },
+          ErrorMessage: { StringValue: 'Missing required field' },
+        },
+      ],
+    );
+
+    await expect(presentLoaderResult(loaderHolon)).resolves.toEqual({
+      holonsStaged: '8',
+      holonsCommitted: '5',
+      errorCount: '1',
+      danceSummary: 'loaded with errors',
+      linksCreated: '0',
+      loadCommitStatus: 'CommittedWithWarnings',
+      loadErrors: [
+        {
+          filename: 'sample-loader-file.json',
+          startUtf8ByteOffset: '123',
+          loaderHolonKey: 'alpha',
+          errorType: 'ValidationError',
+          errorMessage: 'Missing required field',
+        },
+      ],
+    });
+  });
+});

--- a/host/ui/src/app/components/json-data-uploader/loader-result.presenter.ts
+++ b/host/ui/src/app/components/json-data-uploader/loader-result.presenter.ts
@@ -38,7 +38,6 @@ const LOAD_ERROR_PROPERTY_NAMES = {
 export async function presentLoaderResult(
   loaderHolon: ReadableHolon,
 ): Promise<LoaderResultView> {
-  console.log('[LoaderResult] Reading core loader result properties...');
   const [
     holonsStaged,
     holonsCommitted,
@@ -72,7 +71,6 @@ async function readIntegerProperty(
   holon: ReadableHolon,
   propertyName: string,
 ): Promise<string> {
-  console.log('[LoaderResult] Reading integer property:', propertyName);
   const value = await holon.propertyValue(propertyName);
   if (value === null) {
     return 'n/a';
@@ -89,7 +87,6 @@ async function readStringProperty(
   holon: ReadableHolon,
   propertyName: string,
 ): Promise<string> {
-  console.log('[LoaderResult] Reading string property:', propertyName);
   const value = await holon.propertyValue(propertyName);
   if (value === null) {
     return 'n/a';
@@ -105,9 +102,7 @@ async function readStringProperty(
 async function readLoadErrors(
   loaderHolon: ReadableHolon,
 ): Promise<LoaderErrorView[]> {
-  console.log('[LoaderResult] Reading HasLoadError relationships...');
   const errorCollection = await loaderHolon.relatedHolons('HasLoadError');
-  console.log('[LoaderResult] HasLoadError member count:', errorCollection.length);
 
   return Promise.all(
     errorCollection.members.map(async (errorHolon: ReadableHolon) => ({

--- a/host/ui/src/app/components/json-data-uploader/loader-result.presenter.ts
+++ b/host/ui/src/app/components/json-data-uploader/loader-result.presenter.ts
@@ -1,0 +1,130 @@
+import { extractNumber, extractString, type ReadableHolon } from '../../../dahn/deps/map-sdk';
+
+export interface LoaderErrorView {
+  filename: string;
+  startUtf8ByteOffset: string;
+  loaderHolonKey: string;
+  errorType: string;
+  errorMessage: string;
+}
+
+export interface LoaderResultView {
+  holonsStaged: string;
+  holonsCommitted: string;
+  errorCount: string;
+  danceSummary: string;
+  linksCreated: string;
+  loadCommitStatus: string;
+  loadErrors: LoaderErrorView[];
+}
+
+const CORE_PROPERTY_NAMES = {
+  holonsStaged: 'HolonsStaged',
+  holonsCommitted: 'HolonsCommitted',
+  errorCount: 'ErrorCount',
+  danceSummary: 'DanceSummary',
+  linksCreated: 'LinksCreated',
+  loadCommitStatus: 'LoadCommitStatus',
+} as const;
+
+const LOAD_ERROR_PROPERTY_NAMES = {
+  filename: 'Filename',
+  startUtf8ByteOffset: 'StartUtf8ByteOffset',
+  loaderHolonKey: 'LoaderHolonKey',
+  errorType: 'ErrorType',
+  errorMessage: 'ErrorMessage',
+} as const;
+
+export async function presentLoaderResult(
+  loaderHolon: ReadableHolon,
+): Promise<LoaderResultView> {
+  console.log('[LoaderResult] Reading core loader result properties...');
+  const [
+    holonsStaged,
+    holonsCommitted,
+    errorCount,
+    danceSummary,
+    linksCreated,
+    loadCommitStatus,
+    loadErrors,
+  ] = await Promise.all([
+    readIntegerProperty(loaderHolon, CORE_PROPERTY_NAMES.holonsStaged),
+    readIntegerProperty(loaderHolon, CORE_PROPERTY_NAMES.holonsCommitted),
+    readIntegerProperty(loaderHolon, CORE_PROPERTY_NAMES.errorCount),
+    readStringProperty(loaderHolon, CORE_PROPERTY_NAMES.danceSummary),
+    readIntegerProperty(loaderHolon, CORE_PROPERTY_NAMES.linksCreated),
+    readStringProperty(loaderHolon, CORE_PROPERTY_NAMES.loadCommitStatus),
+    readLoadErrors(loaderHolon),
+  ]);
+
+  return {
+    holonsStaged,
+    holonsCommitted,
+    errorCount,
+    danceSummary,
+    linksCreated,
+    loadCommitStatus,
+    loadErrors,
+  };
+}
+
+async function readIntegerProperty(
+  holon: ReadableHolon,
+  propertyName: string,
+): Promise<string> {
+  console.log('[LoaderResult] Reading integer property:', propertyName);
+  const value = await holon.propertyValue(propertyName);
+  if (value === null) {
+    return 'n/a';
+  }
+
+  try {
+    return String(extractNumber(value));
+  } catch {
+    return JSON.stringify(value);
+  }
+}
+
+async function readStringProperty(
+  holon: ReadableHolon,
+  propertyName: string,
+): Promise<string> {
+  console.log('[LoaderResult] Reading string property:', propertyName);
+  const value = await holon.propertyValue(propertyName);
+  if (value === null) {
+    return 'n/a';
+  }
+
+  try {
+    return extractString(value);
+  } catch {
+    return JSON.stringify(value);
+  }
+}
+
+async function readLoadErrors(
+  loaderHolon: ReadableHolon,
+): Promise<LoaderErrorView[]> {
+  console.log('[LoaderResult] Reading HasLoadError relationships...');
+  const errorCollection = await loaderHolon.relatedHolons('HasLoadError');
+  console.log('[LoaderResult] HasLoadError member count:', errorCollection.length);
+
+  return Promise.all(
+    errorCollection.members.map(async (errorHolon: ReadableHolon) => ({
+      filename: await readStringProperty(errorHolon, LOAD_ERROR_PROPERTY_NAMES.filename),
+      startUtf8ByteOffset: await readIntegerProperty(
+        errorHolon,
+        LOAD_ERROR_PROPERTY_NAMES.startUtf8ByteOffset,
+      ),
+      loaderHolonKey: await readStringProperty(
+        errorHolon,
+        LOAD_ERROR_PROPERTY_NAMES.loaderHolonKey,
+      ),
+      errorType: await readStringProperty(errorHolon, LOAD_ERROR_PROPERTY_NAMES.errorType),
+      errorMessage: await readStringProperty(
+        errorHolon,
+        LOAD_ERROR_PROPERTY_NAMES.errorMessage,
+      ),
+    })),
+  );
+}

--- a/host/ui/src/app/stores/content.store.ts
+++ b/host/ui/src/app/stores/content.store.ts
@@ -1,12 +1,12 @@
-import { computed, inject, Injector, runInInjectionContext, Signal } from '@angular/core';
-import { signalStore, withHooks, withMethods, withState, patchState, DeepSignal, withComputed,  } from '@ngrx/signals';
+import { computed, Injector } from '@angular/core';
+import { patchState, signalStore, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
 //import { Cell } from '../helpers/interface.cell';
 import { HolonSpace } from '../models/interface.space';
-import { Holon, SavedHolon, StagedHolon, StagedHolonFactory, TransientHolon } from '../models/holon';
+import { SavedHolon, StagedHolon, TransientHolon } from '../models/holon';
 import { HolonsClient } from '../clients/holons.client';
-import { SignalStore, StoreState } from '../models/interface.store';
+import { StoreState } from '../models/interface.store';
 import { getCommittedHolons, getStagedHolons, getTransientHolons, MapResponse } from '../models/map.response';
-import { ContentSet, HolonId, PropertyMap, StagedReference, TransientReference } from '../models/shared-types';
+import { ContentSet, HolonId, PropertyMap, StagedReference } from '../models/shared-types';
 import { MapClient, type HolonReference } from '../../dahn/deps/map-sdk';
 
 export interface ContentStoreState extends StoreState{
@@ -259,7 +259,7 @@ export function createContentStore(
 
       })),
       withHooks({
-        onInit({ loadall }){
+        onInit(){
           //loadall();
           console.log('Holon store loaded:');
         },

--- a/host/ui/src/app/stores/content.store.ts
+++ b/host/ui/src/app/stores/content.store.ts
@@ -7,6 +7,7 @@ import { HolonsClient } from '../clients/holons.client';
 import { SignalStore, StoreState } from '../models/interface.store';
 import { getCommittedHolons, getStagedHolons, getTransientHolons, MapResponse } from '../models/map.response';
 import { ContentSet, HolonId, PropertyMap, StagedReference, TransientReference } from '../models/shared-types';
+import { MapClient, type HolonReference } from '../../dahn/deps/map-sdk';
 
 export interface ContentStoreState extends StoreState{
   transient_holons: TransientHolon[];
@@ -27,6 +28,7 @@ export function createContentStore(
   initialSpace: HolonSpace
 ) {
     const client = injector.get(HolonsClient);
+    const mapClient = new MapClient();
 
     const initialState: ContentStoreState = {
       space: initialSpace,
@@ -220,45 +222,36 @@ export function createContentStore(
           }
         },
 
-        async uploadHolons(contentSet: ContentSet) {
+        async uploadHolons(contentSet: ContentSet): Promise<HolonReference> {
           console.log('%c[STORE] loadHolons called with contentSet:', 'color: #4CAF50; font-weight: bold;', contentSet);
           patchState(store, { loading: true });
 
           try {
+            console.log('%c[STORE] Beginning SDK transaction for loadHolons...', 'color: #03A9F4; font-weight: bold;');
+            const transaction = await mapClient.beginTransaction();
+            console.log('%c[STORE] SDK transaction begun:', 'color: #03A9F4; font-weight: bold;', transaction);
+            console.log('%c[STORE] Calling transaction.loadHolons(...)', 'color: #03A9F4; font-weight: bold;');
+            const loaderReference = await transaction.loadHolons(contentSet);
+            console.log('%c[STORE] load_holons loader reference received:', 'color: #03A9F4; font-weight: bold;', loaderReference);
 
-              const mapResponse = await client.uploadHolons(store.space()!, contentSet);
-
-            console.log('%c[STORE] load_holons response received:', 'color: #03A9F4; font-weight: bold;', mapResponse);
-
-            // Handle the MapResponse from the server
-           // const mapResponse = response as MapResponse;
-
-            const transientFromServer = getTransientHolons(mapResponse);
-            const stagedFromServer = getStagedHolons(mapResponse);
-            const committedFromServer = getCommittedHolons(mapResponse);
-
-            console.log('%c[STORE] Transient data from load_holons:', 'color: #03A9F4;', transientFromServer);
-            console.log('%c[STORE] Staged data from load_holons:', 'color: #03A9F4;', stagedFromServer);
-            console.log('%c[STORE] Committed data from load_holons:', 'color: #03A9F4;', committedFromServer);
-
-            // Merge with existing committed holons
-            const allCommitted = [...store.committed_holons(), ...committedFromServer];
-
-            patchState(store, {
-              transient_holons: transientFromServer,
-              staged_holons: stagedFromServer,
-              committed_holons: allCommitted,
-              last_map_response: mapResponse,
-              loading: false
-            });
-
-            console.log('%c[STORE] State after loadHolons:', 'color: #4CAF50;', {
-              transient_count: transientFromServer.length,
-              staged_count: stagedFromServer.length,
-              committed_count: allCommitted.length
-            });
+            patchState(store, { loading: false });
+            return loaderReference;
           } catch (error) {
             console.error('[STORE] Error during loadHolons:', error);
+            if (error && typeof error === 'object') {
+              const domainLikeError = error as {
+                code?: unknown;
+                variant?: unknown;
+                payload?: unknown;
+                cause?: unknown;
+              };
+              console.error('[STORE] Error details:', {
+                code: domainLikeError.code,
+                variant: domainLikeError.variant,
+                payload: domainLikeError.payload,
+                cause: domainLikeError.cause,
+              });
+            }
             patchState(store, { loading: false });
             throw error;
           }

--- a/host/ui/src/app/stores/content.store.ts
+++ b/host/ui/src/app/stores/content.store.ts
@@ -42,13 +42,9 @@ export function createContentStore(
     const ContentStore = signalStore(
 
       withState(initialState),
-           // --- THIS IS THE DIAGNOSTIC SPY ---
-      // Add this block to log every change to staging_area.
       withComputed((store) => ({
         _stagingAreaTracker: computed(() => {
-          const area = store.staged_holons();
-          console.log(`%c[TRACKER] staged_holons signal updated. New value:`, 'color: #9C27B0; font-weight: bold;', area);
-          return area;
+          return store.staged_holons();
         })
       })),
       /* withComputed((store) => ({
@@ -223,35 +219,15 @@ export function createContentStore(
         },
 
         async uploadHolons(contentSet: ContentSet): Promise<HolonReference> {
-          console.log('%c[STORE] loadHolons called with contentSet:', 'color: #4CAF50; font-weight: bold;', contentSet);
           patchState(store, { loading: true });
 
           try {
-            console.log('%c[STORE] Beginning SDK transaction for loadHolons...', 'color: #03A9F4; font-weight: bold;');
             const transaction = await mapClient.beginTransaction();
-            console.log('%c[STORE] SDK transaction begun:', 'color: #03A9F4; font-weight: bold;', transaction);
-            console.log('%c[STORE] Calling transaction.loadHolons(...)', 'color: #03A9F4; font-weight: bold;');
             const loaderReference = await transaction.loadHolons(contentSet);
-            console.log('%c[STORE] load_holons loader reference received:', 'color: #03A9F4; font-weight: bold;', loaderReference);
 
             patchState(store, { loading: false });
             return loaderReference;
           } catch (error) {
-            console.error('[STORE] Error during loadHolons:', error);
-            if (error && typeof error === 'object') {
-              const domainLikeError = error as {
-                code?: unknown;
-                variant?: unknown;
-                payload?: unknown;
-                cause?: unknown;
-              };
-              console.error('[STORE] Error details:', {
-                code: domainLikeError.code,
-                variant: domainLikeError.variant,
-                payload: domainLikeError.payload,
-                cause: domainLikeError.cause,
-              });
-            }
             patchState(store, { loading: false });
             throw error;
           }
@@ -261,10 +237,8 @@ export function createContentStore(
       withHooks({
         onInit(){
           //loadall();
-          console.log('Holon store loaded:');
         },
         onDestroy() {
-          console.log('on destroy')
         }
       })
     )

--- a/host/ui/src/dahn/deps/map-sdk.ts
+++ b/host/ui/src/dahn/deps/map-sdk.ts
@@ -6,10 +6,20 @@
  */
 export type {
   BaseValue,
+  ContentSet,
   EssentialHolonContent,
+  FileData,
   HolonCollection,
   HolonId,
   HolonReference,
+  ReadableHolon,
   PropertyName,
   RelationshipName,
+} from '../../../../map-sdk/src';
+
+export {
+  MapClient,
+  MapTransaction,
+  extractNumber,
+  extractString,
 } from '../../../../map-sdk/src';


### PR DESCRIPTION
# Summary

Follow up the holons data loader response presentation work by wiring the uploader through the SDK transaction path, surfacing loader-result holon details in the UI, enlarging the default window size, and cleaning up the remaining TypeScript warning noise touched during the work.

The Holons Loader UI now correctly reports on whether the load succeeded or not, displays the counts returned by the loader, and allows the list of errors returned by the loader to be displayed.

## Changes

- route uploader submission through the SDK transaction flow instead of the legacy `map_request` submit path
- read the returned loader-result holon and present loader summary details in the uploader UI
- add client-side and host-side diagnostics to trace the loader flow and isolate transaction/runtime failures
- fix async UI refresh so loader-result cards update correctly after the holon read completes
- restore the larger default app window sizing that fits the uploader workflow better
- add recovery-store schema compatibility handling for older local DBs missing `undo_checkpointing_enabled`
- restore missing DAHN SDK seam exports needed after the branch rebase
- tighten loader presenter spec typing to match the current SDK interfaces
- clean up unused imports and minor TypeScript warning noise in the uploader/content store files

## Why

The branch was stuck between old and new ingress paths:

- the uploader submit flow initially appeared not to reach host/runtime
- after instrumentation, the real flow was shown to reach `beginTransaction()` and `load_holons`
- loader results were being produced, but the UI was not reliably refreshing or surfacing them
- local recovery DB schema drift could also break the new transaction path
- default window sizing regressed and made the uploader workflow cramped

This PR makes the loader-response flow visible and reliable while preserving the broader descriptor-driven migration direction.

## User-visible behavior

- uploader submissions now return a loader-result card populated from the loader response holon
- successful imports show staged/committed counts, error count, links created, dance summary, and commit status
- incomplete or invalid imports can now surface loader errors through the same UI path
- the app opens at the previously agreed larger default size again

## Testing

- [x] `npm test`
- [x] `npm start`

## Notes

- the uploader submit flow is now on the SDK transaction path
- most of the rest of the content-space UI still depends on the legacy `HolonsClient` / `map_request` ingress path
- this PR improves the loader workflow without attempting the larger legacy-ingress removal, which is better handled incrementally alongside the descriptor-driven implementation waves