### PR TITLE
Clarify command contract posture and legacy compatibility surfaces

### DIFF
--- a/host/conductora/src/runtime/dispatch_map_command.rs
+++ b/host/conductora/src/runtime/dispatch_map_command.rs
@@ -43,7 +43,8 @@ async fn dispatch_inner(
 
     log_marker_context(request_id, &options);
 
-    // Bind wire → domain
+    // Bind wire → domain before runtime execution so compatibility-only
+    // ingress payloads never leak below the adapter seam.
     let command = bind_command(&runtime, command)?;
 
     // Execute via runtime (policy enforcement + handler routing)

--- a/host/crates/map_commands_contract/src/map_result.rs
+++ b/host/crates/map_commands_contract/src/map_result.rs
@@ -33,10 +33,12 @@ pub enum MapResult {
     /// Returns a holon reference.
     Reference(HolonReference),
 
-    /// Returns a collection of holon references.
+    /// Deliberate exception for duplicate-base-key staging lookup.
+    ///
+    /// General plural command results should prefer `Collection(HolonCollection)`.
     References(Vec<HolonReference>),
 
-    /// Returns an indexed collection of holons.
+    /// Canonical plural command result carrier.
     Collection(HolonCollection),
 
     /// Universal scalar return — covers MapString, MapInteger, MapBoolean, PropertyValue.
@@ -48,6 +50,6 @@ pub enum MapResult {
     /// Returns the essential content of a holon.
     EssentialContent(EssentialHolonContent),
 
-    /// Returns a dance response.
+    /// Transitional dance-result exception retained for legacy and in-flight dance paths.
     DanceResponse(DanceResponse),
 }

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -42,7 +42,11 @@ pub enum TransactionAction {
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
-    /// Executes a dance request within this transaction.
+    /// Executes the retained legacy dance ingress within this transaction.
+    ///
+    /// `DanceRequest` remains operational for compatibility, including
+    /// old-world query traversal dances, but is not the foundation for
+    /// new command-surface work.
     Dance(DanceRequest),
 
     // ── Lookup actions (LookupFacade) ────────────────────────────────
@@ -53,6 +57,8 @@ pub enum TransactionAction {
     GetStagedHolonByBaseKey { key: MapString },
 
     /// `get_staged_holons_by_base_key(key)` → `Vec<StagedReference>`
+    ///
+    /// This remains the deliberate reference-shaped plural exception.
     GetStagedHolonsByBaseKey { key: MapString },
 
     /// `get_staged_holon_by_versioned_key(key)` → `StagedReference`

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -36,6 +36,9 @@ pub async fn handle_transaction(
         }
         TransactionAction::Dance(request) => {
             let response = context.initiate_ingress_dance(request, false).await?;
+            // Deliberate transitional exception: dance execution still returns
+            // a `DanceResponse` instead of projecting onto the canonical
+            // command result family.
             Ok(MapResult::DanceResponse(response))
         }
         TransactionAction::LoadHolons { content_set } => {
@@ -53,7 +56,8 @@ pub async fn handle_transaction(
         }
         TransactionAction::GetStagedHolonsByBaseKey { key } => {
             let staged_refs = context.lookup().get_staged_holons_by_base_key(&key)?;
-            // Intentional exception: duplicate base-key staging lookup stays reference-shaped.
+            // Deliberate exception: duplicate base-key staging lookup stays
+            // reference-shaped rather than returning `HolonCollection`.
             Ok(MapResult::References(staged_refs.into_iter().map(HolonReference::Staged).collect()))
         }
         TransactionAction::GetStagedHolonByVersionedKey { key } => {

--- a/host/crates/map_commands_wire/src/result_wire.rs
+++ b/host/crates/map_commands_wire/src/result_wire.rs
@@ -34,10 +34,12 @@ pub enum MapResultWire {
     /// Returns a holon reference.
     Reference(HolonReferenceWire),
 
-    /// Returns a collection of holon references.
+    /// Deliberate exception for duplicate-base-key staging lookup.
+    ///
+    /// General plural command results should prefer `Collection(HolonCollectionWire)`.
     References(Vec<HolonReferenceWire>),
 
-    /// Returns an indexed collection of holons.
+    /// Canonical plural command result carrier at the IPC boundary.
     Collection(HolonCollectionWire),
 
     /// Universal scalar return.
@@ -49,7 +51,7 @@ pub enum MapResultWire {
     /// Returns the essential content of a holon.
     EssentialContent(EssentialHolonContent),
 
-    /// Returns a dance response.
+    /// Transitional dance-result exception retained at the IPC boundary.
     DanceResponse(DanceResponseWire),
 }
 

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -43,7 +43,11 @@ pub enum TransactionActionWire {
     /// Loads holons from uploaded/imported file content.
     LoadHolons { content_set: ContentSet },
 
-    /// Executes a dance request within this transaction.
+    /// Executes the retained legacy dance ingress within this transaction.
+    ///
+    /// This wire shape stays operational for compatibility, including
+    /// old-world query traversal dances, but is not the preferred
+    /// foundation for new command-surface work.
     Dance(DanceRequestWire),
 
     // ── Lookup actions ───────────────────────────────────────────────
@@ -54,6 +58,8 @@ pub enum TransactionActionWire {
     GetStagedHolonByBaseKey { key: MapString },
 
     /// `get_staged_holons_by_base_key(key)` → `Vec<StagedReference>`
+    ///
+    /// This remains the deliberate reference-shaped plural exception.
     GetStagedHolonsByBaseKey { key: MapString },
 
     /// `get_staged_holon_by_versioned_key(key)` → `StagedReference`

--- a/host/crates/map_commands_wire/tests/generate_fixtures.rs
+++ b/host/crates/map_commands_wire/tests/generate_fixtures.rs
@@ -177,6 +177,8 @@ fn generate_fixtures() {
         "request-tx-dance.json",
         &request(
             14,
+            // Retained legacy dance ingress example. Keep operational, but do
+            // not treat it as the foundation for new command-surface work.
             tx_command(41, TransactionActionWire::Dance(sample_dance_request())),
             mutation_options("dance request"),
         ),
@@ -388,6 +390,9 @@ fn generate_fixtures() {
     write_fixture(
         &fixtures_dir,
         "response-ok-dance-response.json",
+        // Transitional `DanceResponse` result example using a legacy
+        // query-shaped body. The outer result variant remains the command-side
+        // exception while the nested node collection stays compatibility-only.
         &response(112, Ok(MapResultWire::DanceResponse(sample_dance_response()))),
     );
     write_fixture(
@@ -580,6 +585,8 @@ fn sample_collection() -> HolonCollectionWire {
     }
 }
 
+/// Legacy compatibility node payload used only inside retained old-world query
+/// dance fixtures.
 fn sample_node_collection() -> NodeCollectionWire {
     let leaf = NodeCollectionWire {
         members: vec![NodeWire {
@@ -601,18 +608,21 @@ fn sample_node_collection() -> NodeCollectionWire {
     }
 }
 
+/// Legacy compatibility dance request fixture exercising the retained
+/// old-world dance ingress.
 fn sample_dance_request() -> DanceRequestWire {
     DanceRequestWire {
-        dance_name: map_string("load-descriptor"),
+        dance_name: map_string("legacy-query-compat"),
         dance_type: DanceTypeWire::QueryMethod(sample_node_collection()),
         body: RequestBodyWire::ParameterValues(sample_property_map()),
     }
 }
 
+/// Transitional dance-response fixture carrying a legacy query-shaped body.
 fn sample_dance_response() -> DanceResponseWire {
     DanceResponseWire {
         status_code: ResponseStatusCode::OK,
-        description: map_string("dance completed"),
+        description: map_string("legacy compatibility dance completed"),
         body: ResponseBodyWire::NodeCollection(sample_node_collection()),
         descriptor: Some(smart_reference(41, local_holon_id(&[151, 152, 153]), None)),
     }

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -281,6 +281,9 @@ export function getStagedHolonByBaseKey(
 
 /**
  * Return all staged holons bound to a base key.
+ *
+ * This remains the deliberate reference-shaped plural exception. Canonical
+ * plural command results should prefer `HolonCollectionWire`.
  */
 export function getStagedHolonsByBaseKey(
   txId: TxId,
@@ -380,7 +383,11 @@ export function transientCount(
 }
 
 /**
- * Execute a transaction-scoped dance request.
+ * Execute a transaction-scoped legacy dance request.
+ *
+ * This retained ingress stays operational for compatibility, including
+ * old-world query traversal dances. The command layer still treats the
+ * resulting `DanceResponseWire` as a transitional exception.
  */
 export function dance(
   txId: TxId,

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -52,6 +52,11 @@ export interface ContentSet {
 /**
  * Flat transaction action enum mirroring Rust `TransactionActionWire`.
  *
+ * Canonical command work should treat `HolonCollection` as the ordinary
+ * plural result posture. The retained `Dance` action is the legacy dance
+ * ingress, and `GetStagedHolonsByBaseKey` remains the intentional
+ * reference-shaped plural exception.
+ *
  * Serde encoding rules:
  * - unit variants -> bare strings
  * - struct variants -> single-key objects
@@ -64,9 +69,13 @@ export type TransactionActionWire =
   | { UndoToMarker: { marker_id: string } }
   | { RedoToMarker: { marker_id: string } }
   | { LoadHolons: { content_set: ContentSet } }
+  // Retained legacy dance ingress. Keep operational, but do not treat as the
+  // foundation for new command-surface work.
   | { Dance: DanceRequestWire }
   | 'GetAllHolons'
   | { GetStagedHolonByBaseKey: { key: string } }
+  // Deliberate exception: duplicate-base-key staging lookup stays
+  // reference-shaped rather than using HolonCollection.
   | { GetStagedHolonsByBaseKey: { key: string } }
   | { GetStagedHolonByVersionedKey: { key: string } }
   | { GetTransientHolonByBaseKey: { key: string } }

--- a/host/map-sdk/src/internal/wire-types/references.ts
+++ b/host/map-sdk/src/internal/wire-types/references.ts
@@ -82,20 +82,38 @@ export interface HolonCollectionWire {
   keyed_index: Record<string, number>;
 }
 
+/**
+ * Deprecated compatibility payload retained only for legacy dance/query flows.
+ *
+ * This remains operational so old-world dance ingress keeps working, but it is
+ * not a canonical command-foundation type for new work.
+ */
 export interface QueryExpression {
   relationship_name: RelationshipName;
 }
 
+/**
+ * Deprecated compatibility payload retained only inside legacy dance/query
+ * request and response bodies.
+ */
 export interface NodeWire {
   source_holon: HolonReferenceWire;
   relationships: QueryPathMapWire | null;
 }
 
+/**
+ * Deprecated compatibility payload family retained only for legacy dance/query
+ * traversal results and requests.
+ */
 export interface NodeCollectionWire {
   members: NodeWire[];
   query_spec: QueryExpression | null;
 }
 
+/**
+ * Deprecated compatibility payload retained only inside old-world query dance
+ * traversal structures.
+ */
 export type QueryPathMapWire = Record<string, NodeCollectionWire>;
 
 // ===========================================
@@ -167,6 +185,7 @@ export type HolonWire =
 
 export type DanceTypeWire =
   | 'Standalone'
+  // Deprecated compatibility branch for old-world query traversal dances.
   | { QueryMethod: NodeCollectionWire }
   | { CommandMethod: HolonReferenceWire }
   | { CloneMethod: HolonReferenceWire }
@@ -181,8 +200,15 @@ export type RequestBodyWire =
   | { HolonId: HolonId }
   | { ParameterValues: PropertyMap }
   | { StagedRef: StagedReferenceWire }
+  // Deprecated compatibility branch retained only for old-world query dance flows.
   | { QueryExpression: QueryExpression };
 
+/**
+ * Retained legacy dance ingress payload.
+ *
+ * `DanceRequestWire` remains operational for compatibility, but should not be
+ * treated as the long-term command payload center for new work.
+ */
 export interface DanceRequestWire {
   dance_name: MapString;
   dance_type: DanceTypeWire;
@@ -208,8 +234,14 @@ export type ResponseBodyWire =
   | { HolonCollection: HolonCollectionWire }
   | { Holons: HolonWire[] }
   | { HolonReference: HolonReferenceWire }
+  // Deprecated compatibility branch retained only for old-world query dance results.
   | { NodeCollection: NodeCollectionWire };
 
+/**
+ * Transitional dance response payload retained as the command-result exception
+ * for dance execution. Legacy query-shaped bodies may still appear inside it as
+ * compatibility payloads.
+ */
 export interface DanceResponseWire {
   status_code: ResponseStatusCode;
   description: MapString;
@@ -477,6 +509,10 @@ export function isHolonReferenceWire(value: unknown): value is HolonReferenceWir
 // ===========================================
 // Collection / Query Guards
 // ===========================================
+//
+// The query-shaped guards below remain so legacy dance/query payloads stay
+// decodable. They should not be mistaken for the canonical new command
+// contract posture.
 
 export function isCollectionState(value: unknown): value is CollectionState {
   return typeof value === 'string' && COLLECTION_STATES.has(value as CollectionState);
@@ -740,6 +776,9 @@ export function isHolonWire(value: unknown): value is HolonWire {
 // ===========================================
 // Dance / Query Guards
 // ===========================================
+//
+// These guards intentionally preserve the retained legacy dance ingress and its
+// nested compatibility payload family alongside the newer command-result posture.
 
 export function isDanceTypeWire(value: unknown): value is DanceTypeWire {
   return (

--- a/host/map-sdk/tests/commands/transaction.test.ts
+++ b/host/map-sdk/tests/commands/transaction.test.ts
@@ -111,14 +111,14 @@ const integerValue: BaseValue = {
 };
 
 const danceRequest: DanceRequestWire = {
-  dance_name: 'sync',
+  dance_name: 'legacy-query-compat',
   dance_type: 'Standalone',
   body: 'None',
 };
 
 const danceResponse: DanceResponseWire = {
   status_code: 'Accepted',
-  description: 'queued',
+  description: 'queued legacy compatibility dance',
   body: {
     HolonReference: transientReference,
   },
@@ -383,5 +383,25 @@ describe('transaction command builders', () => {
     invokeMapCommandMock.mockResolvedValue(okResponse('RedoComplete'));
     await redoLast(txId);
     expectTransactionRequest('RedoLast', defaultOptions);
+  });
+
+  it('treats Collection as the canonical plural result shape for getAllHolons', async () => {
+    invokeMapCommandMock.mockResolvedValue(okResponse({ Collection: holonCollection }));
+
+    await expect(getAllHolons(txId)).resolves.toEqual(holonCollection);
+  });
+
+  it('keeps References as the deliberate plural exception for staged base-key lookup', async () => {
+    invokeMapCommandMock.mockResolvedValue(okResponse({ References: [stagedReference] }));
+
+    await expect(getStagedHolonsByBaseKey(txId, 'alpha')).resolves.toEqual([
+      stagedReference,
+    ]);
+  });
+
+  it('keeps DanceResponse as the transitional exception for legacy dance ingress', async () => {
+    invokeMapCommandMock.mockResolvedValue(okResponse({ DanceResponse: danceResponse }));
+
+    await expect(dance(txId, danceRequest)).resolves.toEqual(danceResponse);
   });
 });

--- a/host/map-sdk/tests/fixtures/request-tx-dance.json
+++ b/host/map-sdk/tests/fixtures/request-tx-dance.json
@@ -5,7 +5,7 @@
       "tx_id": 41,
       "action": {
         "Dance": {
-          "dance_name": "load-descriptor",
+          "dance_name": "legacy-query-compat",
           "dance_type": {
             "QueryMethod": {
               "members": [

--- a/host/map-sdk/tests/fixtures/response-ok-dance-response.json
+++ b/host/map-sdk/tests/fixtures/response-ok-dance-response.json
@@ -4,7 +4,7 @@
     "Ok": {
       "DanceResponse": {
         "status_code": "OK",
-        "description": "dance completed",
+        "description": "legacy compatibility dance completed",
         "body": {
           "NodeCollection": {
             "members": [

--- a/host/map-sdk/tests/result-decoders.test.ts
+++ b/host/map-sdk/tests/result-decoders.test.ts
@@ -73,7 +73,7 @@ const essentialContent: EssentialHolonContent = {
 
 const danceResponse: DanceResponseWire = {
   status_code: 'Accepted',
-  description: 'dance accepted',
+  description: 'legacy compatibility dance accepted',
   body: {
     HolonReference: transientReference,
   },
@@ -134,7 +134,7 @@ describe('result decoders', () => {
     );
   });
 
-  it('decodes References results', () => {
+  it('decodes References results for the deliberate staging lookup exception', () => {
     expect(
       expectReferences({
         References: [transientReference, stagedReference],
@@ -148,7 +148,7 @@ describe('result decoders', () => {
     );
   });
 
-  it('decodes Collection results', () => {
+  it('decodes Collection results as the canonical plural command posture', () => {
     expect(
       expectCollection({
         Collection: holonCollection,
@@ -217,7 +217,7 @@ describe('result decoders', () => {
     );
   });
 
-  it('decodes DanceResponse results', () => {
+  it('decodes DanceResponse results as the transitional dance exception', () => {
     expect(
       expectDanceResponse({
         DanceResponse: danceResponse,

--- a/tests/sweetests/tests/execution_steps/query_relationships_executor.rs
+++ b/tests/sweetests/tests/execution_steps/query_relationships_executor.rs
@@ -4,7 +4,8 @@ use map_commands_contract::{MapCommand, MapResult, TransactionAction, Transactio
 use pretty_assertions::assert_eq;
 use tracing::debug;
 
-/// Queries relationships via the retained deprecated `query_relationships` Dance.
+/// Queries relationships via the retained deprecated `query_relationships`
+/// dance compatibility path.
 pub async fn execute_query_relationships(
     state: &mut TestExecutionState,
     step_token: TestReference,
@@ -23,7 +24,8 @@ pub async fn execute_query_relationships(
     let node_collection =
         NodeCollection { members: vec![Node::new(source_reference, None)], query_spec: None };
 
-    // 2. BUILD — wrap dance request in TransactionAction::Dance
+    // 2. BUILD — wrap the legacy compatibility dance request in
+    // `TransactionAction::Dance`
     let dance_request = build_query_relationships_dance_request(node_collection, query_expression)
         .expect("Failed to build query_relationships request");
     debug!("Dance Request (via TransactionAction::Dance): {:#?}", dance_request);


### PR DESCRIPTION
# Summary

Align the remaining Command PRO1 contract posture with the typed `HolonCollection` foundation by making the canonical-vs-compatibility split explicit across command contract comments, SDK wire types, fixtures, and tests.

This PR keeps the existing ingress path and retained legacy dance/query payload family operational, but stops presenting those legacy payloads as the apparent foundation for new command work. It does not change runtime behavior, wire shape, binding ownership, or import paths.

## Changes

- clarified canonical result posture in Rust command contract and wire comments
  - `HolonCollection` is the normal plural command result carrier
  - `MapResult::References` remains the deliberate `GetStagedHolonsByBaseKey` exception
  - `MapResult::DanceResponse` remains the deliberate transitional exception

- clarified retained legacy ingress posture in command transaction surfaces
  - `TransactionAction::Dance(DanceRequest)` and `TransactionActionWire::Dance(DanceRequestWire)` remain operational
  - they are now documented as retained legacy compatibility ingress rather than the foundation for new command-surface work

- classified the nested old-world query payload family as compatibility-only in the SDK wire layer
  - `QueryExpression`
  - `NodeWire`
  - `NodeCollectionWire`
  - `QueryPathMapWire`
  - `DanceTypeWire::QueryMethod`
  - `RequestBodyWire::QueryExpression`
  - `ResponseBodyWire::NodeCollection`

- updated SDK command comments to reinforce the intended posture
  - canonical plural results prefer `HolonCollectionWire`
  - `getStagedHolonsByBaseKey` remains the deliberate plural exception
  - `dance(...)` remains the retained legacy ingress returning the transitional `DanceResponseWire` exception

- updated command fixtures and fixture generation annotations without renaming fixture files
  - preserved stable fixture paths
  - reworded retained legacy dance fixture content to read as compatibility examples
  - made the `DanceResponse` fixture explicitly represent a transitional result carrying a legacy query-shaped body

- tightened test intent in the SDK and command-adjacent test coverage
  - added explicit assertions for canonical `Collection` posture
  - added explicit assertions for the deliberate `References` exception
  - added explicit assertions for the transitional `DanceResponse` exception
  - updated command-facing sweetest wording to describe the retained compatibility path more clearly

## Testing

- npm test -- all pass
- npm start -- nominal


## Notes

- This PR is intentionally narrow and does not redesign the PRO2 adapter/runtime seam.
- No production runtime behavior changed.
- No wire format changed.
- No import/export or caller migration was introduced.
- No new `HolonCollection` accessor work was needed for this pass.
- No `map-dev-docs` update was required because the implementation remained aligned with the current authoritative wording.