### PR TITLE
545 dance pr4 command ingress and static execution alignment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+echo "[pre-push] Running npm run fmt:check"
+
+if ! npm run fmt:check; then
+  echo
+  echo "[pre-push] Push blocked: repository formatting checks did not pass."
+  echo "[pre-push] This usually means one or more Rust files need to be reformatted in host/, happ/, or tests/sweetests/."
+  echo "[pre-push] Recovery steps:"
+  echo "[pre-push]   1. Run: npm run fmt"
+  echo "[pre-push]   2. Review: git diff --stat"
+  echo "[pre-push]   3. Stage formatting changes: git add -A"
+  echo "[pre-push]   4. Commit them: git commit --amend --no-edit"
+  echo "[pre-push]      or create a follow-up commit if you do not want to amend."
+  echo "[pre-push]   5. Push again."
+  echo "[pre-push] Use --no-verify only if you intentionally need to bypass this guard."
+  exit 1
+fi
+
+echo "[pre-push] Formatting check passed."

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "derive-new",
  "quick_cache",
  "serde",
+ "serde_json",
  "sha2",
  "tracing",
  "type_names",

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "derive-new",
  "quick_cache",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "tracing",
  "type_names",

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use base_types::MapString;
 use core_types::{ContentSet, HolonId, LocalId};
 use holons_core::core_shared_objects::transactions::TransactionContext;
-use holons_core::dances::{DanceInvocationReference, DanceRequest};
+use holons_core::dances::{DanceInvocation, DanceRequest};
 use holons_core::reference_layer::{HolonReference, SmartReference, TransientReference};
 
 use super::{CommandLifecyclePolicy, MutationClassification};
@@ -50,7 +50,7 @@ pub enum TransactionAction {
     Dance(DanceRequest),
 
     /// Executes the canonical new-world dance ingress within this transaction.
-    DanceV2 { invocation: DanceInvocationReference },
+    DanceV2 { invocation: DanceInvocation },
 
     // ── Lookup actions (LookupFacade) ────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use base_types::MapString;
 use core_types::{ContentSet, HolonId, LocalId};
 use holons_core::core_shared_objects::transactions::TransactionContext;
-use holons_core::dances::DanceRequest;
+use holons_core::dances::{DanceInvocationReference, DanceRequest};
 use holons_core::reference_layer::{HolonReference, SmartReference, TransientReference};
 
 use super::{CommandLifecyclePolicy, MutationClassification};
@@ -48,6 +48,9 @@ pub enum TransactionAction {
     /// old-world query traversal dances, but is not the foundation for
     /// new command-surface work.
     Dance(DanceRequest),
+
+    /// Executes the canonical new-world dance ingress within this transaction.
+    DanceV2 { invocation: DanceInvocationReference },
 
     // ── Lookup actions (LookupFacade) ────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
@@ -107,7 +110,7 @@ impl TransactionAction {
                 CommandLifecyclePolicy::transaction_read_only()
             }
             TransactionAction::LoadHolons { .. } => CommandLifecyclePolicy::mutating_with_guard(),
-            TransactionAction::Dance(_) => CommandLifecyclePolicy {
+            TransactionAction::Dance(_) | TransactionAction::DanceV2 { .. } => CommandLifecyclePolicy {
                 mutation: MutationClassification::RuntimeDetected,
                 requires_open_tx: true,
                 requires_commit_guard: false,
@@ -143,6 +146,7 @@ impl TransactionAction {
             TransactionAction::RedoToMarker { .. } => "redo_to_marker",
             TransactionAction::LoadHolons { .. } => "load_holons",
             TransactionAction::Dance(_) => "dance",
+            TransactionAction::DanceV2 { .. } => "dance_v2",
             TransactionAction::GetAllHolons => "get_all_holons",
             TransactionAction::GetStagedHolonByBaseKey { .. } => "get_staged_holon_by_base_key",
             TransactionAction::GetStagedHolonsByBaseKey { .. } => "get_staged_holons_by_base_key",

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -110,11 +110,13 @@ impl TransactionAction {
                 CommandLifecyclePolicy::transaction_read_only()
             }
             TransactionAction::LoadHolons { .. } => CommandLifecyclePolicy::mutating_with_guard(),
-            TransactionAction::Dance(_) | TransactionAction::DanceV2 { .. } => CommandLifecyclePolicy {
-                mutation: MutationClassification::RuntimeDetected,
-                requires_open_tx: true,
-                requires_commit_guard: false,
-            },
+            TransactionAction::Dance(_) | TransactionAction::DanceV2 { .. } => {
+                CommandLifecyclePolicy {
+                    mutation: MutationClassification::RuntimeDetected,
+                    requires_open_tx: true,
+                    requires_commit_guard: false,
+                }
+            }
             // Lookups
             TransactionAction::GetAllHolons
             | TransactionAction::GetStagedHolonByBaseKey { .. }

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -464,9 +464,8 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
 async fn build_delete_holon_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
     let local_id = LocalId(vec![9, 8, 7]);
-    let invocation =
-        DanceInvocation::build_delete_holon(&context, HolonId::Local(local_id))
-            .expect("delete holon invocation");
+    let invocation = DanceInvocation::build_delete_holon(&context, HolonId::Local(local_id))
+        .expect("delete holon invocation");
 
     MapCommand::Transaction(TransactionCommand {
         context,

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -4,12 +4,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use base_types::{BaseValue, MapInteger, MapString};
-use core_types::{HolonError, HolonId, LocalId, RelationshipName};
+use core_types::{HolonError, HolonId, LocalId};
 use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
 use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
-use holons_core::core_shared_objects::{
-    Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
-};
+use holons_core::core_shared_objects::ServiceRoutingPolicy;
 use holons_core::dances::{build_dance_v2_invocation, DanceInvocation};
 use holons_core::reference_layer::{
     HolonReference, HolonServiceApi, StagedReference, TransientReference, WritableHolon,
@@ -67,7 +65,7 @@ impl HolonServiceApi for TestHolonService {
         &self,
         _context: &Arc<TransactionContext>,
         _source_id: &HolonId,
-    ) -> Result<RelationshipMap, HolonError> {
+    ) -> Result<holons_core::core_shared_objects::RelationshipMap, HolonError> {
         unreachable_in_handler_tests()
     }
 
@@ -75,7 +73,7 @@ impl HolonServiceApi for TestHolonService {
         &self,
         _context: &Arc<TransactionContext>,
         _id: &HolonId,
-    ) -> Result<Holon, HolonError> {
+    ) -> Result<holons_core::core_shared_objects::Holon, HolonError> {
         unreachable_in_handler_tests()
     }
 
@@ -83,15 +81,15 @@ impl HolonServiceApi for TestHolonService {
         &self,
         _context: &Arc<TransactionContext>,
         _source_id: &HolonId,
-        _relationship_name: &RelationshipName,
-    ) -> Result<HolonCollection, HolonError> {
+        _relationship_name: &core_types::RelationshipName,
+    ) -> Result<holons_core::core_shared_objects::HolonCollection, HolonError> {
         unreachable_in_handler_tests()
     }
 
     fn get_all_holons_internal(
         &self,
         _context: &Arc<TransactionContext>,
-    ) -> Result<HolonCollection, HolonError> {
+    ) -> Result<holons_core::core_shared_objects::HolonCollection, HolonError> {
         unreachable_in_handler_tests()
     }
 
@@ -466,9 +464,9 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
 async fn build_delete_holon_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
     let local_id = LocalId(vec![9, 8, 7]);
-    let target = HolonReference::smart_from_id(context.context_handle(), HolonId::Local(local_id));
     let invocation =
-        DanceInvocation::build_delete_holon(&context, target).expect("delete holon invocation");
+        DanceInvocation::build_delete_holon(&context, HolonId::Local(local_id))
+            .expect("delete holon invocation");
 
     MapCommand::Transaction(TransactionCommand {
         context,
@@ -514,6 +512,28 @@ async fn dance_v2_delete_holon_returns_reference_result() {
         .expect("delete holon v2 should succeed");
 
     assert!(matches!(result, MapResult::Reference(_)));
+}
+
+#[tokio::test]
+async fn built_delete_holon_invocation_uses_request_and_not_target() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+    let command = build_delete_holon_dance_v2_command(&runtime, &tx_id).await;
+
+    let invocation = match command {
+        MapCommand::Transaction(TransactionCommand {
+            action: TransactionAction::DanceV2 { invocation },
+            ..
+        }) => invocation,
+        other => panic!("expected DanceV2 transaction command, got {:?}", other),
+    };
+
+    let bound = invocation.bind().expect("bind delete holon invocation");
+    assert!(bound.request().is_some(), "delete holon should carry request parameters");
+    assert!(
+        bound.affording_holon().is_none(),
+        "delete holon should not resolve a target holon at ingress"
+    );
 }
 
 #[tokio::test]

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -13,7 +13,7 @@ use holons_core::core_shared_objects::{
 use holons_core::reference_layer::{
     HolonReference, HolonServiceApi, StagedReference, TransientReference, WritableHolon,
 };
-use holons_core::dances::build_dance_v2_invocation;
+use holons_core::dances::{build_dance_v2_invocation, DanceInvocation};
 
 use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
 use holons_client::LocalRecoveryReceptor;
@@ -43,10 +43,17 @@ impl HolonServiceApi for TestHolonService {
 
     fn commit_internal(
         &self,
-        _context: &Arc<TransactionContext>,
+        context: &Arc<TransactionContext>,
         _staged_references: &[StagedReference],
     ) -> Result<TransientReference, HolonError> {
-        unreachable_in_handler_tests()
+        let mut response = context
+            .mutation()
+            .new_holon(Some(MapString::from("commit-response")))?;
+        response.with_property_value("TypeName", "CommitResponseType")?;
+        response.with_property_value("IsAbstractType", false)?;
+        response.with_property_value("InstanceTypeKind", "Holon")?;
+        response.with_property_value("CommitRequestStatus", "Complete")?;
+        Ok(response)
     }
 
     fn delete_holon_internal(
@@ -54,7 +61,7 @@ impl HolonServiceApi for TestHolonService {
         _context: &Arc<TransactionContext>,
         _local_id: &LocalId,
     ) -> Result<(), HolonError> {
-        unreachable_in_handler_tests()
+        Ok(())
     }
 
     fn fetch_all_related_holons_internal(
@@ -394,7 +401,7 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let mut request_type =
         context.mutation().new_holon(Some(MapString::from("request-type"))).expect("request type");
     request_type
-        .with_property_value("TypeName", "ProjectionRequest")
+        .with_property_value("TypeName", "SummarizeRequest")
         .expect("request type name");
     request_type
         .with_property_value("IsAbstractType", false)
@@ -418,7 +425,7 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let mut implementation =
         context.mutation().new_holon(Some(MapString::from("implementation"))).expect("implementation");
     implementation
-        .with_property_value("TypeName", "DanceImplementation")
+        .with_property_value("TypeName", "HostSummarizeV1")
         .expect("implementation type");
     implementation
         .with_property_value("IsAbstractType", false)
@@ -430,7 +437,7 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let mut dance_descriptor =
         context.mutation().new_holon(Some(MapString::from("dance"))).expect("dance descriptor");
     dance_descriptor
-        .with_property_value("TypeName", "Projection")
+        .with_property_value("TypeName", "Summarize")
         .expect("dance type");
     dance_descriptor
         .with_property_value("IsAbstractType", false)
@@ -439,7 +446,7 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
         .with_property_value("InstanceTypeKind", "Holon")
         .expect("dance kind");
     dance_descriptor
-        .add_related_holons("RequestType", vec![request_type.into()])
+        .add_related_holons("RequestType", vec![request_type.clone().into()])
         .expect("request edge");
     dance_descriptor
         .add_related_holons("Response", vec![response_type.into()])
@@ -451,7 +458,7 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let mut request =
         context.mutation().new_holon(Some(MapString::from("request"))).expect("request holon");
     request
-        .with_property_value("TypeName", "ProjectionRequest")
+        .with_property_value("TypeName", "SummarizeRequest")
         .expect("request type");
     request
         .with_property_value("IsAbstractType", false)
@@ -459,7 +466,9 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     request
         .with_property_value("InstanceTypeKind", "Holon")
         .expect("request kind");
-
+    request
+        .with_descriptor(request_type.into())
+        .expect("request described_by");
     let mut invocation =
         context.mutation().new_holon(Some(MapString::from("invocation"))).expect("invocation holon");
     invocation
@@ -489,21 +498,109 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     })
 }
 
+async fn build_delete_holon_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
+    let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
+    let local_id = LocalId(vec![9, 8, 7]);
+    let target = HolonReference::smart_from_id(context.context_handle(), HolonId::Local(local_id));
+    let invocation = DanceInvocation::build_delete_holon(&context, target)
+        .expect("delete holon invocation");
+
+    MapCommand::Transaction(TransactionCommand {
+        context,
+        action: TransactionAction::DanceV2 { invocation },
+    })
+}
+
+async fn build_commit_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
+    let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
+    let invocation = DanceInvocation::build_commit(&context).expect("commit invocation");
+
+    MapCommand::Transaction(TransactionCommand {
+        context,
+        action: TransactionAction::DanceV2 { invocation },
+    })
+}
+
 #[tokio::test]
-async fn dance_v2_returns_reference_result() {
+async fn dance_v2_returns_not_implemented_for_host_binding_without_runtime_adapter() {
     let runtime = build_test_runtime();
     let tx_id = begin_tx(&runtime).await;
     let command = build_dance_v2_command(&runtime, &tx_id).await;
 
+    let error = runtime
+        .execute_command(command, ExecutionPolicy::default())
+        .await
+        .expect_err("execute_command should surface missing host implementation adapter");
+
+    assert!(
+        matches!(error, HolonError::NotImplemented(message) if message.contains("HostSummarizeV1"))
+    );
+}
+
+#[tokio::test]
+async fn dance_v2_delete_holon_returns_reference_result() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+    let command = build_delete_holon_dance_v2_command(&runtime, &tx_id).await;
+
     let result = runtime
         .execute_command(command, ExecutionPolicy::default())
         .await
-        .expect("execute_command should succeed");
+        .expect("delete holon v2 should succeed");
 
-    match result {
-        MapResult::Reference(HolonReference::Transient(_)) => {}
-        other => panic!("expected transient reference result, got {:?}", other),
-    }
+    assert!(matches!(result, MapResult::Reference(_)));
+}
+
+#[tokio::test]
+async fn dance_v2_commit_returns_reference_result() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+    let command = build_commit_dance_v2_command(&runtime, &tx_id).await;
+
+    let result = runtime
+        .execute_command(command, ExecutionPolicy::default())
+        .await
+        .expect("commit v2 should succeed");
+
+    assert!(matches!(result, MapResult::Reference(_)));
+}
+
+#[tokio::test]
+async fn delete_holon_command_returns_none_after_internal_dance_execution() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+
+    let result = runtime
+        .execute_command(
+            tx_cmd(
+                &runtime,
+                &tx_id,
+                TransactionAction::DeleteHolon {
+                    local_id: LocalId(vec![9, 8, 7]),
+                },
+            ),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("delete holon command should succeed through internal dance execution");
+
+    assert!(matches!(result, MapResult::None));
+}
+
+#[tokio::test]
+async fn commit_command_returns_reference_after_internal_dance_execution() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+
+    let result = runtime
+        .execute_command(
+            tx_cmd(&runtime, &tx_id, TransactionAction::Commit),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("commit command should succeed through internal dance execution");
+
+    assert!(matches!(result, MapResult::Reference(HolonReference::Transient(_))));
 }
 
 // ── Undo/redo handler tests ─────────────────────────────────────────

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -10,10 +10,10 @@ use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
 use holons_core::core_shared_objects::{
     Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
 };
+use holons_core::dances::{build_dance_v2_invocation, DanceInvocation};
 use holons_core::reference_layer::{
     HolonReference, HolonServiceApi, StagedReference, TransientReference, WritableHolon,
 };
-use holons_core::dances::{build_dance_v2_invocation, DanceInvocation};
 
 use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
 use holons_client::LocalRecoveryReceptor;
@@ -46,9 +46,8 @@ impl HolonServiceApi for TestHolonService {
         context: &Arc<TransactionContext>,
         _staged_references: &[StagedReference],
     ) -> Result<TransientReference, HolonError> {
-        let mut response = context
-            .mutation()
-            .new_holon(Some(MapString::from("commit-response")))?;
+        let mut response =
+            context.mutation().new_holon(Some(MapString::from("commit-response")))?;
         response.with_property_value("TypeName", "CommitResponseType")?;
         response.with_property_value("IsAbstractType", false)?;
         response.with_property_value("InstanceTypeKind", "Holon")?;
@@ -386,8 +385,10 @@ async fn staged_count(runtime: &Runtime, tx_id: &TxId) -> i64 {
 async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
     let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
 
-    let mut invocation_descriptor =
-        context.mutation().new_holon(Some(MapString::from("invocation-descriptor"))).expect("invocation descriptor");
+    let mut invocation_descriptor = context
+        .mutation()
+        .new_holon(Some(MapString::from("invocation-descriptor")))
+        .expect("invocation descriptor");
     invocation_descriptor
         .with_property_value("TypeName", "DanceInvocation")
         .expect("invocation type");
@@ -400,51 +401,31 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
 
     let mut request_type =
         context.mutation().new_holon(Some(MapString::from("request-type"))).expect("request type");
-    request_type
-        .with_property_value("TypeName", "SummarizeRequest")
-        .expect("request type name");
-    request_type
-        .with_property_value("IsAbstractType", false)
-        .expect("request abstract");
-    request_type
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("request kind");
+    request_type.with_property_value("TypeName", "SummarizeRequest").expect("request type name");
+    request_type.with_property_value("IsAbstractType", false).expect("request abstract");
+    request_type.with_property_value("InstanceTypeKind", "Holon").expect("request kind");
 
-    let mut response_type =
-        context.mutation().new_holon(Some(MapString::from("response-type"))).expect("response type");
-    response_type
-        .with_property_value("TypeName", "DanceResponseType")
-        .expect("response type name");
-    response_type
-        .with_property_value("IsAbstractType", false)
-        .expect("response abstract");
-    response_type
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("response kind");
+    let mut response_type = context
+        .mutation()
+        .new_holon(Some(MapString::from("response-type")))
+        .expect("response type");
+    response_type.with_property_value("TypeName", "DanceResponseType").expect("response type name");
+    response_type.with_property_value("IsAbstractType", false).expect("response abstract");
+    response_type.with_property_value("InstanceTypeKind", "Holon").expect("response kind");
 
-    let mut implementation =
-        context.mutation().new_holon(Some(MapString::from("implementation"))).expect("implementation");
-    implementation
-        .with_property_value("TypeName", "HostSummarizeV1")
-        .expect("implementation type");
-    implementation
-        .with_property_value("IsAbstractType", false)
-        .expect("implementation abstract");
-    implementation
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("implementation kind");
+    let mut implementation = context
+        .mutation()
+        .new_holon(Some(MapString::from("implementation")))
+        .expect("implementation");
+    implementation.with_property_value("TypeName", "HostSummarizeV1").expect("implementation type");
+    implementation.with_property_value("IsAbstractType", false).expect("implementation abstract");
+    implementation.with_property_value("InstanceTypeKind", "Holon").expect("implementation kind");
 
     let mut dance_descriptor =
         context.mutation().new_holon(Some(MapString::from("dance"))).expect("dance descriptor");
-    dance_descriptor
-        .with_property_value("TypeName", "Summarize")
-        .expect("dance type");
-    dance_descriptor
-        .with_property_value("IsAbstractType", false)
-        .expect("dance abstract");
-    dance_descriptor
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("dance kind");
+    dance_descriptor.with_property_value("TypeName", "Summarize").expect("dance type");
+    dance_descriptor.with_property_value("IsAbstractType", false).expect("dance abstract");
+    dance_descriptor.with_property_value("InstanceTypeKind", "Holon").expect("dance kind");
     dance_descriptor
         .add_related_holons("RequestType", vec![request_type.clone().into()])
         .expect("request edge");
@@ -457,38 +438,22 @@ async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
 
     let mut request =
         context.mutation().new_holon(Some(MapString::from("request"))).expect("request holon");
-    request
-        .with_property_value("TypeName", "SummarizeRequest")
-        .expect("request type");
-    request
-        .with_property_value("IsAbstractType", false)
-        .expect("request abstract");
-    request
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("request kind");
-    request
-        .with_descriptor(request_type.into())
-        .expect("request described_by");
-    let mut invocation =
-        context.mutation().new_holon(Some(MapString::from("invocation"))).expect("invocation holon");
-    invocation
-        .with_property_value("TypeName", "DanceInvocation")
-        .expect("invocation type");
-    invocation
-        .with_property_value("IsAbstractType", false)
-        .expect("invocation abstract");
-    invocation
-        .with_property_value("InstanceTypeKind", "Holon")
-        .expect("invocation kind");
-    invocation
-        .with_descriptor(invocation_descriptor.into())
-        .expect("invocation described_by");
+    request.with_property_value("TypeName", "SummarizeRequest").expect("request type");
+    request.with_property_value("IsAbstractType", false).expect("request abstract");
+    request.with_property_value("InstanceTypeKind", "Holon").expect("request kind");
+    request.with_descriptor(request_type.into()).expect("request described_by");
+    let mut invocation = context
+        .mutation()
+        .new_holon(Some(MapString::from("invocation")))
+        .expect("invocation holon");
+    invocation.with_property_value("TypeName", "DanceInvocation").expect("invocation type");
+    invocation.with_property_value("IsAbstractType", false).expect("invocation abstract");
+    invocation.with_property_value("InstanceTypeKind", "Holon").expect("invocation kind");
+    invocation.with_descriptor(invocation_descriptor.into()).expect("invocation described_by");
     invocation
         .add_related_holons("InvokesDance", vec![dance_descriptor.into()])
         .expect("invokes dance");
-    invocation
-        .add_related_holons("Request", vec![request.into()])
-        .expect("request edge");
+    invocation.add_related_holons("Request", vec![request.into()]).expect("request edge");
 
     MapCommand::Transaction(TransactionCommand {
         context,
@@ -502,8 +467,8 @@ async fn build_delete_holon_dance_v2_command(runtime: &Runtime, tx_id: &TxId) ->
     let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
     let local_id = LocalId(vec![9, 8, 7]);
     let target = HolonReference::smart_from_id(context.context_handle(), HolonId::Local(local_id));
-    let invocation = DanceInvocation::build_delete_holon(&context, target)
-        .expect("delete holon invocation");
+    let invocation =
+        DanceInvocation::build_delete_holon(&context, target).expect("delete holon invocation");
 
     MapCommand::Transaction(TransactionCommand {
         context,
@@ -575,9 +540,7 @@ async fn delete_holon_command_returns_none_after_internal_dance_execution() {
             tx_cmd(
                 &runtime,
                 &tx_id,
-                TransactionAction::DeleteHolon {
-                    local_id: LocalId(vec![9, 8, 7]),
-                },
+                TransactionAction::DeleteHolon { local_id: LocalId(vec![9, 8, 7]) },
             ),
             ExecutionPolicy::default(),
         )

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -11,8 +11,9 @@ use holons_core::core_shared_objects::{
     Holon, HolonCollection, RelationshipMap, ServiceRoutingPolicy,
 };
 use holons_core::reference_layer::{
-    HolonReference, HolonServiceApi, StagedReference, TransientReference,
+    HolonReference, HolonServiceApi, StagedReference, TransientReference, WritableHolon,
 };
+use holons_core::dances::build_dance_v2_invocation;
 
 use client_shared_types::base_receptor::{BaseReceptor, ReceptorType};
 use holons_client::LocalRecoveryReceptor;
@@ -372,6 +373,136 @@ async fn staged_count(runtime: &Runtime, tx_id: &TxId) -> i64 {
     match result {
         MapResult::Value(BaseValue::IntegerValue(MapInteger(n))) => n,
         other => panic!("expected IntegerValue, got {:?}", other),
+    }
+}
+
+async fn build_dance_v2_command(runtime: &Runtime, tx_id: &TxId) -> MapCommand {
+    let context = runtime.session().get_transaction(tx_id).expect("tx should exist");
+
+    let mut invocation_descriptor =
+        context.mutation().new_holon(Some(MapString::from("invocation-descriptor"))).expect("invocation descriptor");
+    invocation_descriptor
+        .with_property_value("TypeName", "DanceInvocation")
+        .expect("invocation type");
+    invocation_descriptor
+        .with_property_value("IsAbstractType", false)
+        .expect("invocation abstract");
+    invocation_descriptor
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("invocation kind");
+
+    let mut request_type =
+        context.mutation().new_holon(Some(MapString::from("request-type"))).expect("request type");
+    request_type
+        .with_property_value("TypeName", "ProjectionRequest")
+        .expect("request type name");
+    request_type
+        .with_property_value("IsAbstractType", false)
+        .expect("request abstract");
+    request_type
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("request kind");
+
+    let mut response_type =
+        context.mutation().new_holon(Some(MapString::from("response-type"))).expect("response type");
+    response_type
+        .with_property_value("TypeName", "DanceResponseType")
+        .expect("response type name");
+    response_type
+        .with_property_value("IsAbstractType", false)
+        .expect("response abstract");
+    response_type
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("response kind");
+
+    let mut implementation =
+        context.mutation().new_holon(Some(MapString::from("implementation"))).expect("implementation");
+    implementation
+        .with_property_value("TypeName", "DanceImplementation")
+        .expect("implementation type");
+    implementation
+        .with_property_value("IsAbstractType", false)
+        .expect("implementation abstract");
+    implementation
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("implementation kind");
+
+    let mut dance_descriptor =
+        context.mutation().new_holon(Some(MapString::from("dance"))).expect("dance descriptor");
+    dance_descriptor
+        .with_property_value("TypeName", "Projection")
+        .expect("dance type");
+    dance_descriptor
+        .with_property_value("IsAbstractType", false)
+        .expect("dance abstract");
+    dance_descriptor
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("dance kind");
+    dance_descriptor
+        .add_related_holons("RequestType", vec![request_type.into()])
+        .expect("request edge");
+    dance_descriptor
+        .add_related_holons("Response", vec![response_type.into()])
+        .expect("response edge");
+    dance_descriptor
+        .add_related_holons("ForDance", vec![implementation.into()])
+        .expect("implementation edge");
+
+    let mut request =
+        context.mutation().new_holon(Some(MapString::from("request"))).expect("request holon");
+    request
+        .with_property_value("TypeName", "ProjectionRequest")
+        .expect("request type");
+    request
+        .with_property_value("IsAbstractType", false)
+        .expect("request abstract");
+    request
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("request kind");
+
+    let mut invocation =
+        context.mutation().new_holon(Some(MapString::from("invocation"))).expect("invocation holon");
+    invocation
+        .with_property_value("TypeName", "DanceInvocation")
+        .expect("invocation type");
+    invocation
+        .with_property_value("IsAbstractType", false)
+        .expect("invocation abstract");
+    invocation
+        .with_property_value("InstanceTypeKind", "Holon")
+        .expect("invocation kind");
+    invocation
+        .with_descriptor(invocation_descriptor.into())
+        .expect("invocation described_by");
+    invocation
+        .add_related_holons("InvokesDance", vec![dance_descriptor.into()])
+        .expect("invokes dance");
+    invocation
+        .add_related_holons("Request", vec![request.into()])
+        .expect("request edge");
+
+    MapCommand::Transaction(TransactionCommand {
+        context,
+        action: TransactionAction::DanceV2 {
+            invocation: build_dance_v2_invocation(invocation.into()).expect("typed invocation"),
+        },
+    })
+}
+
+#[tokio::test]
+async fn dance_v2_returns_reference_result() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+    let command = build_dance_v2_command(&runtime, &tx_id).await;
+
+    let result = runtime
+        .execute_command(command, ExecutionPolicy::default())
+        .await
+        .expect("execute_command should succeed");
+
+    match result {
+        MapResult::Reference(HolonReference::Transient(_)) => {}
+        other => panic!("expected transient reference result, got {:?}", other),
     }
 }
 

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -16,8 +16,9 @@ pub async fn handle_transaction(
 
     match command.action {
         TransactionAction::Commit => {
-            let transient_ref = session.commit_transaction(&command.context.tx_id()).await?;
-            Ok(MapResult::Reference(HolonReference::Transient(transient_ref)))
+            let invocation = holons_core::dances::DanceInvocation::build_commit(context)?;
+            let response = execute_dance_v2(context, invocation).await?;
+            Ok(MapResult::Reference(response.require_response_body()?))
         }
         TransactionAction::UndoLast => {
             session.undo_last(&command.context.tx_id()).await?;
@@ -106,7 +107,14 @@ pub async fn handle_transaction(
             Ok(MapResult::Reference(HolonReference::Staged(staged)))
         }
         TransactionAction::DeleteHolon { local_id } => {
-            context.mutation().delete_holon(local_id)?;
+            let invocation = holons_core::dances::DanceInvocation::build_delete_holon(
+                context,
+                HolonReference::smart_from_id(
+                    context.context_handle(),
+                    core_types::HolonId::Local(local_id),
+                ),
+            )?;
+            execute_dance_v2(context, invocation).await?;
             Ok(MapResult::None)
         }
     }

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -1,6 +1,7 @@
 use base_types::{BaseValue, MapInteger};
 use core_types::HolonError;
 use holons_core::reference_layer::HolonReference;
+use holons_core::dances::execute_dance_v2;
 
 use map_commands_contract::{MapResult, TransactionAction, TransactionCommand};
 
@@ -40,6 +41,10 @@ pub async fn handle_transaction(
             // a `DanceResponse` instead of projecting onto the canonical
             // command result family.
             Ok(MapResult::DanceResponse(response))
+        }
+        TransactionAction::DanceV2 { invocation } => {
+            let response = execute_dance_v2(context, invocation).await?;
+            Ok(MapResult::Reference(HolonReference::from(response)))
         }
         TransactionAction::LoadHolons { content_set } => {
             let response =

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -1,8 +1,7 @@
 use base_types::{BaseValue, MapInteger};
 use core_types::HolonError;
 use holons_core::dances::execute_dance_v2;
-use holons_core::reference_layer::HolonReference;
-
+use holons_core::HolonReference;
 use map_commands_contract::{MapResult, TransactionAction, TransactionCommand};
 
 use super::runtime_session::RuntimeSession;
@@ -109,10 +108,7 @@ pub async fn handle_transaction(
         TransactionAction::DeleteHolon { local_id } => {
             let invocation = holons_core::dances::DanceInvocation::build_delete_holon(
                 context,
-                HolonReference::smart_from_id(
-                    context.context_handle(),
-                    core_types::HolonId::Local(local_id),
-                ),
+                core_types::HolonId::Local(local_id),
             )?;
             execute_dance_v2(context, invocation).await?;
             Ok(MapResult::None)

--- a/host/crates/map_commands_runtime/src/transaction_handler.rs
+++ b/host/crates/map_commands_runtime/src/transaction_handler.rs
@@ -1,7 +1,7 @@
 use base_types::{BaseValue, MapInteger};
 use core_types::HolonError;
-use holons_core::reference_layer::HolonReference;
 use holons_core::dances::execute_dance_v2;
+use holons_core::reference_layer::HolonReference;
 
 use map_commands_contract::{MapResult, TransactionAction, TransactionCommand};
 

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use base_types::MapString;
 use core_types::{ContentSet, HolonError, HolonId, LocalId};
 use holons_boundary::{
-    DanceRequestWire, HolonReferenceWire, SmartReferenceWire, TransientReferenceWire,
+    DanceRequestWire, DanceV2InvocationWire, HolonReferenceWire, SmartReferenceWire,
+    TransientReferenceWire,
 };
 use holons_core::core_shared_objects::transactions::{TransactionContext, TxId};
 use serde::{Deserialize, Serialize};
@@ -49,6 +50,9 @@ pub enum TransactionActionWire {
     /// old-world query traversal dances, but is not the preferred
     /// foundation for new command-surface work.
     Dance(DanceRequestWire),
+
+    /// Executes the canonical new-world dance ingress within this transaction.
+    DanceV2 { invocation: DanceV2InvocationWire },
 
     // ── Lookup actions ───────────────────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
@@ -127,6 +131,9 @@ impl TransactionActionWire {
             }
             TransactionActionWire::Dance(request_wire) => {
                 Ok(TransactionAction::Dance(request_wire.bind(context)?))
+            }
+            TransactionActionWire::DanceV2 { invocation } => {
+                Ok(TransactionAction::DanceV2 { invocation: invocation.bind(context)? })
             }
             // Lookup actions — no context binding needed
             TransactionActionWire::GetAllHolons => Ok(TransactionAction::GetAllHolons),

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -1,33 +1,15 @@
 import type { RequestOptionsOverrides } from '../request-context';
 import { buildRequest } from '../request-context';
 import {
-  expectCollection,
-  expectDanceResponse,
-  expectNone,
-  expectRedoComplete,
-  expectRedoToMarkerComplete,
-  expectReference,
-  expectReferences,
-  expectUndoComplete,
-  expectUndoToMarkerComplete,
-  expectValue,
+  expectCollection, expectDanceResponse, expectNone, expectRedoComplete,
+  expectRedoToMarkerComplete, expectReference, expectReferences, expectUndoComplete,
+  expectUndoToMarkerComplete, expectValue,
 } from '../result-decoders';
 import { invokeMapCommand, unwrapMapResponse } from '../transport';
 import type {
-  BaseValue,
-  ContentSet,
-  DanceRequestWire,
-  DanceV2InvocationWire,
-  DanceResponseWire,
-  HolonCollectionWire,
-  HolonId,
-  HolonReferenceWire,
-  LocalId,
-  MapResultWire,
-  SmartReferenceWire,
-  TransactionActionWire,
-  TransientReferenceWire,
-  TxId,
+  BaseValue, ContentSet, DanceRequestWire, DanceV2InvocationWire, DanceResponseWire,
+  HolonCollectionWire, HolonId, HolonReferenceWire, LocalId, MapResultWire,
+  SmartReferenceWire, TransactionActionWire, TransientReferenceWire, TxId,
 } from '../wire-types';
 
 // ===========================================

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -17,6 +17,7 @@ import type {
   BaseValue,
   ContentSet,
   DanceRequestWire,
+  DanceV2InvocationWire,
   DanceResponseWire,
   HolonCollectionWire,
   HolonId,
@@ -402,4 +403,15 @@ export function dance(
     expectDanceResponse,
     options,
   );
+}
+
+/**
+ * Execute a transaction-scoped canonical DanceV2 invocation.
+ */
+export function danceV2(
+  txId: TxId,
+  invocation: DanceV2InvocationWire,
+  options?: RequestOptionsOverrides,
+): Promise<HolonReferenceWire> {
+  return runTransactionCommand(txId, { DanceV2: invocation }, expectReference, options);
 }

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -1,5 +1,6 @@
 import {
   type DanceRequestWire,
+  type DanceV2InvocationWire,
   type HolonReferenceWire,
   type BaseValue,
   type PropertyName,
@@ -13,6 +14,7 @@ import {
   hasSingleKey,
   isBaseValue,
   isDanceRequestWire,
+  isDanceV2InvocationWire,
   isHolonId,
   isHolonReferenceWire,
   isLocalId,
@@ -72,6 +74,7 @@ export type TransactionActionWire =
   // Retained legacy dance ingress. Keep operational, but do not treat as the
   // foundation for new command-surface work.
   | { Dance: DanceRequestWire }
+  | { DanceV2: DanceV2InvocationWire }
   | 'GetAllHolons'
   | { GetStagedHolonByBaseKey: { key: string } }
   // Deliberate exception: duplicate-base-key staging lookup stays
@@ -250,6 +253,8 @@ export function isTransactionActionWire(
       isRecord(value.LoadHolons) &&
       isContentSet(value.LoadHolons['content_set'])) ||
     (hasSingleKey(value, 'Dance') && isDanceRequestWire(value.Dance)) ||
+    (hasSingleKey(value, 'DanceV2') &&
+      isDanceV2InvocationWire(value.DanceV2)) ||
     (hasSingleKey(value, 'GetStagedHolonByBaseKey') &&
       isStringFieldObject(value.GetStagedHolonByBaseKey, 'key')) ||
     (hasSingleKey(value, 'GetStagedHolonsByBaseKey') &&

--- a/host/map-sdk/src/internal/wire-types/references.ts
+++ b/host/map-sdk/src/internal/wire-types/references.ts
@@ -215,6 +215,13 @@ export interface DanceRequestWire {
   body: RequestBodyWire;
 }
 
+/**
+ * Wire wrapper carrying a `HolonReferenceWire` to a canonical DanceInvocation holon.
+ */
+export interface DanceV2InvocationWire {
+  invocation: HolonReferenceWire;
+}
+
 export type ResponseStatusCode =
   | 'OK'
   | 'Accepted'
@@ -820,6 +827,12 @@ export function isDanceRequestWire(value: unknown): value is DanceRequestWire {
     isDanceTypeWire(value['dance_type']) &&
     isRequestBodyWire(value['body'])
   );
+}
+
+export function isDanceV2InvocationWire(
+  value: unknown,
+): value is DanceV2InvocationWire {
+  return isRecord(value) && isHolonReferenceWire(value['invocation']);
 }
 
 export function isResponseStatusCode(value: unknown): value is ResponseStatusCode {

--- a/host/map-sdk/src/sdk/transaction.ts
+++ b/host/map-sdk/src/sdk/transaction.ts
@@ -189,6 +189,14 @@ export class MapTransaction {
     return extractNumber(value);
   }
 
+  async danceV2(invocation: HolonReference): Promise<HolonReference> {
+    const txId = txIdFor(this);
+    const wireRef = await internalTransaction.danceV2(txId, {
+      invocation: unwrapHolonReference(invocation),
+    });
+    return createHolonReference(txId, wireRef);
+  }
+
 }
 
 // ===========================================

--- a/host/map-sdk/tests/commands/transaction.test.ts
+++ b/host/map-sdk/tests/commands/transaction.test.ts
@@ -213,20 +213,20 @@ const transactionCases: TransactionCase<unknown>[] = [
     wrongResult: 'None',
   },
   {
-    name: 'deleteHolon',
-    run: () => deleteHolon(txId, localId),
-    action: { DeleteHolon: { local_id: localId } },
-    okResult: 'None',
-    expected: undefined,
-    wrongResult: { Reference: stagedReference },
-  },
-  {
     name: 'loadHolons',
     run: () => loadHolons(txId, contentSet),
     action: { LoadHolons: { content_set: contentSet } },
     okResult: { Reference: transientReference },
     expected: transientReference,
     wrongResult: 'None',
+  },
+  {
+    name: 'deleteHolon',
+    run: () => deleteHolon(txId, localId),
+    action: { DeleteHolon: { local_id: localId } },
+    okResult: 'None',
+    expected: undefined,
+    wrongResult: { Reference: transientReference },
   },
   {
     name: 'getAllHolons',

--- a/host/package.json
+++ b/host/package.json
@@ -21,7 +21,7 @@
     "web:dev": "npm run web:build",
     "web:prod": "npm run web:build -- -c production",
     "tauri": "tauri",
-    "tauri:serve": "tauri dev",
+    "tauri:serve": "bash ./scripts/tauri-dev.sh",
     "clean": "npm run clean:hc:deep && npm run clean:rust:deep && npm run clean:ui",
     "clean:rust": "cargo clean",
     "clean:rust:deep": "npx rimraf target .cargo && cargo clean",

--- a/host/scripts/tauri-dev.sh
+++ b/host/scripts/tauri-dev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+saved_tty_state=""
+
+if [[ -t 0 ]]; then
+  saved_tty_state="$(stty -g)"
+fi
+
+restore_tty() {
+  if [[ -n "${saved_tty_state}" ]] && [[ -t 0 ]]; then
+    stty "${saved_tty_state}" || stty sane || true
+  fi
+}
+
+trap restore_tty EXIT INT TERM HUP
+
+tauri dev "$@"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sweet:test:nocapture": "cargo test --manifest-path tests/sweetests/Cargo.toml -- --nocapture",
 
     "regen:sdk-fixtures": "npm run regen:sdk-fixtures -w map-host",
+    "hooks:install": "bash ./scripts/install-git-hooks.sh",
 
     "clean": "npm run clean:rust:deep && npm run clean:hc:deep -w map-host && npm run clean:ui",
     "clean:rust": "npm run clean:rust -w map-host && npm run clean:rust -w map-happ",

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+
+echo "Configured Git hooks path:"
+echo "  core.hooksPath=.githooks"
+echo
+echo "Git will now run the tracked pre-push hook from .githooks/pre-push"

--- a/shared_crates/holons_boundary/src/context_binding/dance_v2_invocation_wire.rs
+++ b/shared_crates/holons_boundary/src/context_binding/dance_v2_invocation_wire.rs
@@ -1,0 +1,24 @@
+use crate::HolonReferenceWire;
+use holons_core::core_shared_objects::transactions::TransactionContext;
+use holons_core::dances::DanceInvocationReference;
+use holons_core::HolonError;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// IPC-safe wire wrapper for a new-world `DanceInvocation` holon reference.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DanceV2InvocationWire {
+    pub invocation: HolonReferenceWire,
+}
+
+impl DanceV2InvocationWire {
+    pub fn bind(self, context: &Arc<TransactionContext>) -> Result<DanceInvocationReference, HolonError> {
+        DanceInvocationReference::new(self.invocation.bind(context)?)
+    }
+}
+
+impl From<&DanceInvocationReference> for DanceV2InvocationWire {
+    fn from(invocation: &DanceInvocationReference) -> Self {
+        Self { invocation: HolonReferenceWire::from(invocation.as_holon_reference()) }
+    }
+}

--- a/shared_crates/holons_boundary/src/context_binding/dance_v2_invocation_wire.rs
+++ b/shared_crates/holons_boundary/src/context_binding/dance_v2_invocation_wire.rs
@@ -1,6 +1,6 @@
 use crate::HolonReferenceWire;
 use holons_core::core_shared_objects::transactions::TransactionContext;
-use holons_core::dances::DanceInvocationReference;
+use holons_core::dances::DanceInvocation;
 use holons_core::HolonError;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -12,13 +12,13 @@ pub struct DanceV2InvocationWire {
 }
 
 impl DanceV2InvocationWire {
-    pub fn bind(self, context: &Arc<TransactionContext>) -> Result<DanceInvocationReference, HolonError> {
-        DanceInvocationReference::new(self.invocation.bind(context)?)
+    pub fn bind(self, context: &Arc<TransactionContext>) -> Result<DanceInvocation, HolonError> {
+        DanceInvocation::new(self.invocation.bind(context)?)
     }
 }
 
-impl From<&DanceInvocationReference> for DanceV2InvocationWire {
-    fn from(invocation: &DanceInvocationReference) -> Self {
+impl From<&DanceInvocation> for DanceV2InvocationWire {
+    fn from(invocation: &DanceInvocation) -> Self {
         Self { invocation: HolonReferenceWire::from(invocation.as_holon_reference()) }
     }
 }

--- a/shared_crates/holons_boundary/src/context_binding/mod.rs
+++ b/shared_crates/holons_boundary/src/context_binding/mod.rs
@@ -1,4 +1,5 @@
 pub mod dance_request_wire;
+pub mod dance_v2_invocation_wire;
 pub mod dance_response_wire;
 pub mod holon_collection_wire;
 pub mod holon_reference_wire;
@@ -13,6 +14,7 @@ pub mod transient_relationship_wire;
 pub mod transient_wire;
 
 pub use dance_request_wire::{DanceRequestWire, DanceTypeWire, RequestBodyWire};
+pub use dance_v2_invocation_wire::DanceV2InvocationWire;
 pub use dance_response_wire::{DanceResponseWire, ResponseBodyWire};
 pub use holon_collection_wire::HolonCollectionWire;
 pub use holon_wire::HolonWire;

--- a/shared_crates/holons_boundary/src/context_binding/mod.rs
+++ b/shared_crates/holons_boundary/src/context_binding/mod.rs
@@ -1,6 +1,6 @@
 pub mod dance_request_wire;
-pub mod dance_v2_invocation_wire;
 pub mod dance_response_wire;
+pub mod dance_v2_invocation_wire;
 pub mod holon_collection_wire;
 pub mod holon_reference_wire;
 pub mod holon_wire;
@@ -14,8 +14,8 @@ pub mod transient_relationship_wire;
 pub mod transient_wire;
 
 pub use dance_request_wire::{DanceRequestWire, DanceTypeWire, RequestBodyWire};
-pub use dance_v2_invocation_wire::DanceV2InvocationWire;
 pub use dance_response_wire::{DanceResponseWire, ResponseBodyWire};
+pub use dance_v2_invocation_wire::DanceV2InvocationWire;
 pub use holon_collection_wire::HolonCollectionWire;
 pub use holon_wire::HolonWire;
 pub use query_wire::{NodeCollectionWire, NodeWire, QueryPathMapWire};

--- a/shared_crates/holons_boundary/src/lib.rs
+++ b/shared_crates/holons_boundary/src/lib.rs
@@ -24,7 +24,9 @@ pub mod core_shared_objects {
 }
 
 pub mod dances {
-    pub use crate::context_binding::{DanceRequestWire, DanceTypeWire, RequestBodyWire};
+    pub use crate::context_binding::{
+        DanceRequestWire, DanceTypeWire, DanceV2InvocationWire, RequestBodyWire,
+    };
     pub use crate::context_binding::{DanceResponseWire, ResponseBodyWire};
     pub use crate::session_state::SessionStateWire;
 }

--- a/shared_crates/holons_core/Cargo.toml
+++ b/shared_crates/holons_core/Cargo.toml
@@ -10,6 +10,7 @@ name = "holons_core"
 [dependencies]
 # only used by holons_core
 quick_cache = { version = "0.6.14", default-features = false }
+serde_json = { workspace = true }
 
 
 # General dev-dependencies (platform-agnostic)
@@ -32,5 +33,3 @@ path = "../type_system/base_types"
 path = "../type_system/type_names"
 
 [dev-dependencies]
-serde_json = { workspace = true }
-

--- a/shared_crates/holons_core/src/dances/contract.rs
+++ b/shared_crates/holons_core/src/dances/contract.rs
@@ -1,43 +1,28 @@
 use crate::core_shared_objects::Holon;
-use crate::reference_layer::{HolonReference, ReadableHolon};
-use base_types::MapString;
-use core_types::HolonError;
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::descriptors::{accessor_helpers, DanceDescriptor, DanceResponseDescriptor, HolonDescriptor};
+use crate::reference_layer::{HolonReference, ReadableHolon, WritableHolon};
+use base_types::{BaseValue, MapString};
+use core_types::{HolonError, TypeKind};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
+use type_names::CoreDanceImplementationName;
 
-/// Canonical runtime result for dance execution in PRO1.
+/// Runtime result for dance execution within a transaction.
 ///
-/// This is the schema-aligned tx-bound success/error contract for the new-world
-/// dance model. It stays intentionally separate from any IPC-safe wire form
-/// because it may contain tx-bound references.
+/// This contract stays separate from transport-safe wire types because it may
+/// contain transaction-bound references that only make sense inside the current
+/// runtime session. See `dances-design-spec` for the descriptor-driven dance
+/// execution model that this result supports.
 pub type DanceExecutionResult = Result<DanceOutcome, HolonError>;
 
-/// Canonical runtime invocation envelope for dances in PRO1.
-///
-/// This type must not be serialized across IPC boundaries because it may
-/// contain tx-bound references.
-#[derive(Debug, Clone)]
-pub struct DanceInvocation {
-    pub dance: DanceIdentity,
-    pub target: DanceTarget,
-    pub request: DanceRequestState,
-    pub context: DanceContext,
-}
-
-impl DanceInvocation {
-    pub fn new(
-        dance: DanceIdentity,
-        target: DanceTarget,
-        request: DanceRequestState,
-        context: DanceContext,
-    ) -> Self {
-        Self { dance, target, request, context }
-    }
-}
-
-/// Canonical semantic identity for a dance invocation in PRO1.
+/// Semantic identity for the dance being invoked.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DanceIdentity {
+    /// The schema-level name of the dance.
     pub dance_name: MapString,
+    /// Optional direct reference to the dance descriptor holon.
     pub dance_descriptor_ref: Option<HolonReference>,
 }
 
@@ -51,10 +36,12 @@ impl DanceIdentity {
     }
 }
 
-/// Invocation-time target selection for a dance in PRO1.
+/// The holon, if any, that a dance is being performed on.
 #[derive(Debug, Clone)]
 pub enum DanceTarget {
+    /// The invocation has no subject holon.
     None,
+    /// The invocation is scoped to one subject holon.
     One(HolonReference),
 }
 
@@ -64,12 +51,17 @@ impl DanceTarget {
     }
 }
 
-/// Structured request-state contract for PRO1 dance invocation.
+/// Request payload state for a dance invocation.
 ///
-/// The canonical PR2 posture is a reference to a transient request holon.
+/// The request is modeled as a holon reference so descriptor-backed validation
+/// can inspect it structurally. Request holons are currently expected to be
+/// transient because they are invocation-scoped inputs, not persisted domain
+/// state.
 #[derive(Debug, Clone)]
 pub enum DanceRequestState {
+    /// The invocation carries no request holon.
     None,
+    /// The invocation carries one request holon.
     RequestHolon(HolonReference),
 }
 
@@ -103,11 +95,14 @@ impl DanceRequestState {
 
 pub type DanceParameters = DanceRequestState;
 
-/// Invocation-time execution metadata for a dance.
+/// Execution context attached to a dance invocation.
 #[derive(Debug, Clone)]
 pub struct DanceContext {
+    /// Records which ingress surface initiated the dance.
     pub invocation_source: InvocationSource,
+    /// Optional capability reference associated with the invocation.
     pub capability_ref: Option<HolonReference>,
+    /// Optional descriptor reference describing the affording holon type.
     pub affording_type_ref: Option<HolonReference>,
 }
 
@@ -133,23 +128,88 @@ impl DanceContext {
     }
 }
 
-/// Distinguishes the ingress posture of a dance invocation.
+/// Identifies which runtime surface initiated the invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InvocationSource {
+    /// The invocation entered through the host command surface.
     ClientCommand,
+    /// The invocation entered through a trust channel.
     TrustChannel,
+    /// The invocation originated inside the runtime itself.
     Internal,
 }
 
 pub type DanceInvocationSource = InvocationSource;
 
-/// Canonical execution-boundary reference to a `DanceInvocation` holon.
+/// Resolved invocation context assembled for execution.
+///
+/// Binding follows the typed invocation reference, resolves the descriptor
+/// relationships needed for execution, and keeps them together so the executor
+/// and implementation layer do not need to rediscover invocation structure.
+pub struct BoundDanceInvocation {
+    invocation: DanceInvocation,
+    dance_descriptor: DanceDescriptor,
+    request: Option<HolonReference>,
+    request_type: Option<HolonDescriptor>,
+    affording_holon: Option<HolonReference>,
+    affording_holon_descriptor: Option<HolonDescriptor>,
+    invocation_source: Option<InvocationSource>,
+}
+
+impl BoundDanceInvocation {
+    /// Returns the typed invocation reference that was bound.
+    pub fn invocation(&self) -> &DanceInvocation {
+        &self.invocation
+    }
+
+    /// Returns the descriptor of the dance being invoked.
+    pub fn dance_descriptor(&self) -> &DanceDescriptor {
+        &self.dance_descriptor
+    }
+
+    /// Returns the request holon, if one was supplied.
+    pub fn request(&self) -> Option<&HolonReference> {
+        self.request.as_ref()
+    }
+
+    /// Returns the request descriptor declared by the dance, if any.
+    pub fn request_type(&self) -> Option<&HolonDescriptor> {
+        self.request_type.as_ref()
+    }
+
+    /// Returns the response descriptor declared by the dance.
+    pub fn response_type(&self) -> Result<DanceResponseDescriptor, HolonError> {
+        self.dance_descriptor.response_type()
+    }
+
+    /// Returns the holon the dance is being performed on, if any.
+    pub fn affording_holon(&self) -> Option<&HolonReference> {
+        self.affording_holon.as_ref()
+    }
+
+    /// Returns the descriptor of the affording holon, if one is present.
+    pub fn affording_holon_descriptor(&self) -> Option<&HolonDescriptor> {
+        self.affording_holon_descriptor.as_ref()
+    }
+
+    /// Returns the invocation source if it was recorded on the invocation holon.
+    pub fn invocation_source(&self) -> Option<InvocationSource> {
+        self.invocation_source
+    }
+}
+
+/// Typed reference to a `DanceInvocation` holon at the execution boundary.
+///
+/// This wrapper keeps dance-ingress signatures explicit while still using the
+/// ordinary reference layer underneath.
 #[derive(Debug, Clone, PartialEq)]
-pub struct DanceInvocationReference {
+pub struct DanceInvocation {
     invocation: HolonReference,
 }
 
-impl DanceInvocationReference {
+impl DanceInvocation {
+    /// Constructs a typed invocation reference after verifying the holon is
+    /// described as `DanceInvocation`.
     pub fn new(invocation: HolonReference) -> Result<Self, HolonError> {
         let descriptor = invocation.holon_descriptor()?;
         let found = descriptor.header().type_name()?;
@@ -166,40 +226,284 @@ impl DanceInvocationReference {
         Ok(Self { invocation })
     }
 
+    /// Returns the underlying reference.
     pub fn as_holon_reference(&self) -> &HolonReference {
         &self.invocation
     }
 
+    /// Consumes the wrapper and returns the underlying reference.
     pub fn into_inner(self) -> HolonReference {
         self.invocation
     }
+
+    /// Follows `InvokesDance` and returns the referenced dance descriptor.
+    pub fn dance_descriptor(&self) -> Result<DanceDescriptor, HolonError> {
+        let descriptor = accessor_helpers::require_single_related(
+            self.as_holon_reference(),
+            CoreRelationshipTypeName::InvokesDance,
+        )?;
+        Ok(DanceDescriptor::from_holon(descriptor))
+    }
+
+    /// Follows `Request` and returns the request holon, if present.
+    pub fn request(&self) -> Result<Option<HolonReference>, HolonError> {
+        accessor_helpers::optional_single_related(
+            self.as_holon_reference(),
+            CoreRelationshipTypeName::Request,
+        )
+    }
+
+    /// Returns the request holon or reports a missing required relationship.
+    pub fn require_request(&self) -> Result<HolonReference, HolonError> {
+        self.request()?.ok_or_else(|| HolonError::MissingRequiredRelationship {
+            relationship: "Request".to_string(),
+            descriptor: self
+                .as_holon_reference()
+                .summarize()
+                .unwrap_or_else(|_| "DanceInvocation".to_string()),
+        })
+    }
+
+    /// Follows `Target` and returns the holon the dance is being performed on,
+    /// if present.
+    pub fn affording_holon(&self) -> Result<Option<HolonReference>, HolonError> {
+        accessor_helpers::optional_single_related(
+            self.as_holon_reference(),
+            CoreRelationshipTypeName::Target,
+        )
+    }
+
+    /// Returns the invocation source recorded on the invocation holon, if any.
+    pub fn invocation_source(&self) -> Result<Option<InvocationSource>, HolonError> {
+        match self.as_holon_reference().property_value("InvocationSource")? {
+            Some(BaseValue::StringValue(value)) => {
+                parse_invocation_source(&value).map(Some)
+            }
+            Some(BaseValue::EnumValue(value)) => {
+                parse_invocation_source(&value.0).map(Some)
+            }
+            Some(other) => Err(HolonError::UnexpectedValueType(
+                format!("{other:?}"),
+                "Enum".to_string(),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Resolves the descriptor-backed execution context needed by the executor.
+    pub fn bind(self) -> Result<BoundDanceInvocation, HolonError> {
+        let dance_descriptor = self.dance_descriptor()?;
+        let request_type = dance_descriptor.request_type()?;
+        let affording_holon = self.affording_holon()?;
+        let affording_holon_descriptor = match affording_holon.as_ref() {
+            Some(holon) => Some(holon.holon_descriptor()?),
+            None => None,
+        };
+
+        Ok(BoundDanceInvocation {
+            request: self.request()?,
+            invocation_source: self.invocation_source()?,
+            invocation: self,
+            dance_descriptor,
+            request_type,
+            affording_holon,
+            affording_holon_descriptor,
+        })
+    }
+
+    /// Builds a canonical invocation holon for the host-side `DeleteHolon`
+    /// dance surface.
+    ///
+    /// The invocation carries no subject holon. Instead, it carries a typed
+    /// request holon that points at the holon to delete through
+    /// `ReferenceTarget`, which keeps the invocation structurally valid without
+    /// requiring the target's descriptor to advertise delete as an afforded
+    /// dance.
+    pub fn build_delete_holon(
+        context: &Arc<TransactionContext>,
+        target: HolonReference,
+    ) -> Result<Self, HolonError> {
+        let invocation_descriptor = new_runtime_descriptor_holon(
+            context,
+            "dance-invocation-descriptor",
+            "DanceInvocation",
+        )?;
+        let request_type = new_runtime_descriptor_holon(
+            context,
+            "delete-holon-request-type",
+            "DeleteHolonRequest",
+        )?;
+        let response_type = new_runtime_descriptor_holon(
+            context,
+            "delete-holon-response-type",
+            "DanceResponseType",
+        )?;
+        let implementation = new_runtime_descriptor_holon(
+            context,
+            "delete-holon-implementation",
+            CoreDanceImplementationName::DeleteHolon.as_command_name().0,
+        )?;
+
+        let mut dance_descriptor =
+            context.mutation().new_holon(Some(MapString::from("delete-holon-dance")))?;
+        initialize_runtime_descriptor_holon(&mut dance_descriptor, "DeleteHolon")?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::RequestType,
+            vec![request_type.clone().into()],
+        )?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::Response,
+            vec![response_type.into()],
+        )?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::ForDance,
+            vec![implementation.into()],
+        )?;
+
+        let mut request = context
+            .mutation()
+            .new_holon(Some(MapString::from("delete-holon-request")))?;
+        request.with_descriptor(request_type.into())?;
+        request.add_related_holons(
+            CoreRelationshipTypeName::ReferenceTarget,
+            vec![HolonReference::smart_with_key(
+                context.context_handle(),
+                target.holon_id()?,
+                MapString("delete-holon-target".to_string()),
+            )],
+        )?;
+
+        let mut invocation =
+            context.mutation().new_holon(Some(MapString::from("delete-holon-invocation")))?;
+        invocation.with_descriptor(invocation_descriptor.into())?;
+        invocation.with_property_value(
+            "InvocationSource",
+            MapString("ClientCommand".to_string()),
+        )?;
+        invocation.add_related_holons(
+            CoreRelationshipTypeName::InvokesDance,
+            vec![dance_descriptor.into()],
+        )?;
+        invocation.add_related_holons(
+            CoreRelationshipTypeName::Request,
+            vec![request.into()],
+        )?;
+
+        Self::new(invocation.into())
+    }
+
+    /// Builds a canonical invocation holon for the host-side `Commit`
+    /// dance surface.
+    ///
+    /// Commit has no request holon and no affording holon. The transaction
+    /// context itself provides the state being committed.
+    pub fn build_commit(
+        context: &Arc<TransactionContext>,
+    ) -> Result<Self, HolonError> {
+        let invocation_descriptor = new_runtime_descriptor_holon(
+            context,
+            "dance-invocation-descriptor",
+            "DanceInvocation",
+        )?;
+        let response_type = new_runtime_descriptor_holon(
+            context,
+            "commit-response-type",
+            "DanceResponseType",
+        )?;
+        let implementation = new_runtime_descriptor_holon(
+            context,
+            "commit-implementation",
+            CoreDanceImplementationName::Commit.as_command_name().0,
+        )?;
+
+        let mut dance_descriptor =
+            context.mutation().new_holon(Some(MapString::from("commit-dance")))?;
+        initialize_runtime_descriptor_holon(&mut dance_descriptor, "Commit")?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::Response,
+            vec![response_type.into()],
+        )?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::ForDance,
+            vec![implementation.into()],
+        )?;
+
+        let mut invocation = context.mutation().new_holon(Some(MapString::from("commit-invocation")))?;
+        invocation.with_descriptor(invocation_descriptor.into())?;
+        invocation.with_property_value(
+            "InvocationSource",
+            MapString("ClientCommand".to_string()),
+        )?;
+        invocation.add_related_holons(
+            CoreRelationshipTypeName::InvokesDance,
+            vec![dance_descriptor.into()],
+        )?;
+
+        Self::new(invocation.into())
+    }
 }
 
-impl From<DanceInvocationReference> for HolonReference {
-    fn from(invocation: DanceInvocationReference) -> Self {
+fn new_runtime_descriptor_holon(
+    context: &Arc<TransactionContext>,
+    key: &str,
+    type_name: impl Into<MapString>,
+) -> Result<HolonReference, HolonError> {
+    let mut descriptor = context.mutation().new_holon(Some(MapString::from(key)))?;
+    initialize_runtime_descriptor_holon(&mut descriptor, type_name)?;
+    Ok(descriptor.into())
+}
+
+fn initialize_runtime_descriptor_holon<T: WritableHolon>(
+    descriptor: &mut T,
+    type_name: impl Into<MapString>,
+) -> Result<(), HolonError> {
+    descriptor.with_property_value(CorePropertyTypeName::TypeName, type_name.into())?;
+    descriptor.with_property_value(CorePropertyTypeName::IsAbstractType, false)?;
+    descriptor.with_property_value(
+        CorePropertyTypeName::InstanceTypeKind,
+        MapString(TypeKind::Holon.as_schema_key()),
+    )?;
+    Ok(())
+}
+
+fn parse_invocation_source(value: &MapString) -> Result<InvocationSource, HolonError> {
+    match value.0.as_str() {
+        "ClientCommand" => Ok(InvocationSource::ClientCommand),
+        "TrustChannel" => Ok(InvocationSource::TrustChannel),
+        "Internal" => Ok(InvocationSource::Internal),
+        other => Err(HolonError::InvalidParameter(format!(
+            "Unsupported InvocationSource value: {other}"
+        ))),
+    }
+}
+
+impl From<DanceInvocation> for HolonReference {
+    fn from(invocation: DanceInvocation) -> Self {
         invocation.into_inner()
     }
 }
 
-impl From<&DanceInvocationReference> for HolonReference {
-    fn from(invocation: &DanceInvocationReference) -> Self {
+impl From<&DanceInvocation> for HolonReference {
+    fn from(invocation: &DanceInvocation) -> Self {
         invocation.as_holon_reference().clone()
     }
 }
 
 pub fn build_dance_v2_invocation(
     invocation: HolonReference,
-) -> Result<DanceInvocationReference, HolonError> {
-    DanceInvocationReference::new(invocation)
+) -> Result<DanceInvocation, HolonError> {
+    DanceInvocation::new(invocation)
 }
 
-/// Canonical execution-boundary reference to a `DanceResponseType` holon.
+/// Typed reference to a response holon described by `DanceResponseType`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DanceResponseReference {
     response: HolonReference,
 }
 
 impl DanceResponseReference {
+    /// Constructs a typed response reference after verifying the response
+    /// holon is described as `DanceResponseType`.
     pub fn new(response: HolonReference) -> Result<Self, HolonError> {
         let descriptor = response.holon_descriptor()?;
         let found = descriptor.header().type_name()?;
@@ -216,12 +520,33 @@ impl DanceResponseReference {
         Ok(Self { response })
     }
 
+    /// Returns the underlying reference.
     pub fn as_holon_reference(&self) -> &HolonReference {
         &self.response
     }
 
+    /// Consumes the wrapper and returns the underlying reference.
     pub fn into_inner(self) -> HolonReference {
         self.response
+    }
+
+    /// Returns the related response-body holon, if one is present.
+    pub fn response_body(&self) -> Result<Option<HolonReference>, HolonError> {
+        accessor_helpers::optional_single_related(
+            self.as_holon_reference(),
+            CoreRelationshipTypeName::ResponseBody,
+        )
+    }
+
+    /// Returns the related response-body holon or reports a missing body.
+    pub fn require_response_body(&self) -> Result<HolonReference, HolonError> {
+        self.response_body()?.ok_or_else(|| HolonError::MissingRequiredRelationship {
+            relationship: "ResponseBody".to_string(),
+            descriptor: self
+                .as_holon_reference()
+                .summarize()
+                .unwrap_or_else(|_| "DanceResponseType".to_string()),
+        })
     }
 }
 
@@ -243,11 +568,14 @@ pub fn build_dance_v2_response(
     DanceResponseReference::new(response)
 }
 
-/// Canonical successful outcome envelope for a dance in PRO1.
+/// Successful dance outcome with optional diagnostics and events.
 #[derive(Debug, Clone)]
 pub struct DanceOutcome {
+    /// The primary result of execution.
     pub result: DanceResult,
+    /// Non-fatal diagnostics emitted during execution.
     pub diagnostics: Vec<DanceDiagnostic>,
+    /// Execution-side events associated with the outcome.
     pub events: Vec<DanceEvent>,
 }
 
@@ -265,19 +593,25 @@ impl DanceOutcome {
     }
 }
 
-/// Canonical structured success result family for PRO1.
+/// Primary result payload returned by a successful dance.
 #[derive(Debug, Clone)]
 pub enum DanceResult {
+    /// The dance completed without a result payload.
     None,
+    /// The dance returned a fully materialized holon.
     Holon(Holon),
+    /// The dance returned a holon by reference.
     HolonReference(HolonReference),
 }
 
-/// Non-fatal execution diagnostics returned with a successful outcome.
+/// Non-fatal diagnostic emitted during dance execution.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DanceDiagnostic {
+    /// The severity of the diagnostic.
     pub severity: DanceDiagnosticSeverity,
+    /// A stable diagnostic code.
     pub code: String,
+    /// Human-readable diagnostic text.
     pub message: String,
 }
 
@@ -299,17 +633,21 @@ impl DanceDiagnostic {
     }
 }
 
-/// Severity of a non-fatal dance diagnostic.
+/// Severity level for a non-fatal diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DanceDiagnosticSeverity {
+    /// Informational note.
     Info,
+    /// Warning that execution succeeded but surfaced a concern.
     Warning,
 }
 
-/// Execution-side event returned with a successful outcome.
+/// Event emitted alongside a successful dance outcome.
 #[derive(Debug, Clone)]
 pub struct DanceEvent {
+    /// Event name for downstream consumers.
     pub event_name: String,
+    /// Optional holon payload associated with the event.
     pub payload: Option<HolonReference>,
 }
 

--- a/shared_crates/holons_core/src/dances/contract.rs
+++ b/shared_crates/holons_core/src/dances/contract.rs
@@ -1,11 +1,11 @@
 use crate::core_shared_objects::transactions::TransactionContext;
 use crate::core_shared_objects::Holon;
 use crate::descriptors::{
-    accessor_helpers, DanceDescriptor, DanceResponseDescriptor, HolonDescriptor,
+    accessor_helpers, DanceDescriptor, DanceResponseDescriptor, Descriptor, HolonDescriptor,
 };
 use crate::reference_layer::{HolonReference, ReadableHolon, WritableHolon};
 use base_types::{BaseValue, MapString};
-use core_types::{HolonError, TypeKind};
+use core_types::{HolonError, HolonId, TypeKind};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use type_names::CoreDanceImplementationName;
@@ -311,29 +311,38 @@ impl DanceInvocation {
     /// Builds a canonical invocation holon for the host-side `DeleteHolon`
     /// dance surface.
     ///
-    /// The invocation carries no subject holon. Instead, it carries a typed
-    /// request holon that points at the holon to delete through
-    /// `ReferenceTarget`, which keeps the invocation structurally valid without
-    /// requiring the target's descriptor to advertise delete as an afforded
-    /// dance.
+    /// `DeleteHolon` is request-driven: the holon id to delete is carried in a
+    /// transient request holon rather than by resolving a target holon up
+    /// front.
     pub fn build_delete_holon(
         context: &Arc<TransactionContext>,
-        target: HolonReference,
+        holon_id: HolonId,
     ) -> Result<Self, HolonError> {
         let invocation_descriptor = new_runtime_descriptor_holon(
             context,
             "dance-invocation-descriptor",
             "DanceInvocation",
         )?;
-        let request_type = new_runtime_descriptor_holon(
+        let holon_id_property_type = new_runtime_property_descriptor_holon(
             context,
-            "delete-holon-request-type",
-            "DeleteHolonRequest",
+            "delete-holon-parameter-holon-id-property",
+            CorePropertyTypeName::HolonId,
         )?;
-        let response_type = new_runtime_descriptor_holon(
+        let mut request_type = new_runtime_descriptor_holon(
             context,
-            "delete-holon-response-type",
+            "delete-holon-parameters-type",
+            "DeleteHolonParameters",
+        )?;
+        request_type.add_related_holons(
+            CoreRelationshipTypeName::Properties,
+            vec![holon_id_property_type.clone()],
+        )?;
+        let response_type = new_runtime_response_descriptor_holon(
+            context,
+            "delete-holon-response-type-family",
             "DanceResponseType",
+            "delete-holon-response-type",
+            "DeleteHolonResponse",
         )?;
         let implementation = new_runtime_descriptor_holon(
             context,
@@ -344,25 +353,22 @@ impl DanceInvocation {
         let mut dance_descriptor =
             context.mutation().new_holon(Some(MapString::from("delete-holon-dance")))?;
         initialize_runtime_descriptor_holon(&mut dance_descriptor, "DeleteHolon")?;
-        dance_descriptor.add_related_holons(
-            CoreRelationshipTypeName::RequestType,
-            vec![request_type.clone().into()],
-        )?;
+        dance_descriptor
+            .add_related_holons(CoreRelationshipTypeName::RequestType, vec![request_type.clone()])?;
         dance_descriptor
             .add_related_holons(CoreRelationshipTypeName::Response, vec![response_type.into()])?;
         dance_descriptor
             .add_related_holons(CoreRelationshipTypeName::ForDance, vec![implementation.into()])?;
 
         let mut request =
-            context.mutation().new_holon(Some(MapString::from("delete-holon-request")))?;
-        request.with_descriptor(request_type.into())?;
-        request.add_related_holons(
-            CoreRelationshipTypeName::ReferenceTarget,
-            vec![HolonReference::smart_with_key(
-                context.context_handle(),
-                target.holon_id()?,
-                MapString("delete-holon-target".to_string()),
-            )],
+            context.mutation().new_holon(Some(MapString::from("delete-holon-parameters")))?;
+        request.with_descriptor(request_type)?;
+        request.with_property_value(
+            CorePropertyTypeName::HolonId,
+            MapString(
+                serde_json::to_string(&holon_id)
+                    .map_err(|error| HolonError::InvalidParameter(error.to_string()))?,
+            ),
         )?;
 
         let mut invocation =
@@ -390,8 +396,13 @@ impl DanceInvocation {
             "dance-invocation-descriptor",
             "DanceInvocation",
         )?;
-        let response_type =
-            new_runtime_descriptor_holon(context, "commit-response-type", "DanceResponseType")?;
+        let response_type = new_runtime_response_descriptor_holon(
+            context,
+            "commit-response-type-family",
+            "DanceResponseType",
+            "commit-response-type",
+            "CommitDanceResponse",
+        )?;
         let implementation = new_runtime_descriptor_holon(
             context,
             "commit-implementation",
@@ -428,6 +439,31 @@ fn new_runtime_descriptor_holon(
     let mut descriptor = context.mutation().new_holon(Some(MapString::from(key)))?;
     initialize_runtime_descriptor_holon(&mut descriptor, type_name)?;
     Ok(descriptor.into())
+}
+
+fn new_runtime_property_descriptor_holon(
+    context: &Arc<TransactionContext>,
+    key: &str,
+    property_name: CorePropertyTypeName,
+) -> Result<HolonReference, HolonError> {
+    let mut descriptor = context.mutation().new_holon(Some(MapString::from(key)))?;
+    initialize_runtime_descriptor_holon(&mut descriptor, property_name.as_property_name().0)?;
+    Ok(descriptor.into())
+}
+
+fn new_runtime_response_descriptor_holon(
+    context: &Arc<TransactionContext>,
+    family_key: &str,
+    family_type_name: impl Into<MapString>,
+    response_key: &str,
+    response_type_name: impl Into<MapString>,
+) -> Result<HolonReference, HolonError> {
+    let family = new_runtime_descriptor_holon(context, family_key, family_type_name)?;
+    let mut response_descriptor =
+        context.mutation().new_holon(Some(MapString::from(response_key)))?;
+    initialize_runtime_descriptor_holon(&mut response_descriptor, response_type_name)?;
+    response_descriptor.add_related_holons(CoreRelationshipTypeName::Extends, vec![family])?;
+    Ok(response_descriptor.into())
 }
 
 fn initialize_runtime_descriptor_holon<T: WritableHolon>(
@@ -472,6 +508,69 @@ pub fn build_dance_v2_invocation(
     DanceInvocation::new(invocation)
 }
 
+/// Typed wrapper over the request holon used by the `DeleteHolon` dance.
+///
+/// `DeleteHolon` is parameterized by a holon id rather than an affording
+/// subject holon. This wrapper keeps that input shape explicit at the
+/// execution boundary and hides the raw property access needed to extract the
+/// requested id from the request holon.
+///
+/// The current bridge stores the id as JSON text in a string-valued property.
+/// That is intentionally temporary: the imported schema models `HolonId` as a
+/// distinct value family, and this wrapper is the seam that should absorb that
+/// future alignment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteHolonParameters {
+    request: HolonReference,
+}
+
+impl DeleteHolonParameters {
+    /// Wraps the request holon after verifying that it is described by the
+    /// dance's declared request type.
+    pub fn new(
+        request: HolonReference,
+        expected_type: &HolonDescriptor,
+    ) -> Result<Self, HolonError> {
+        let request_descriptor = request.holon_descriptor()?;
+        let expected = expected_type.header().type_name()?;
+        let found = request_descriptor.header().type_name()?;
+
+        if found != expected {
+            return Err(HolonError::WrongDescriptorKind {
+                expected: expected.to_string(),
+                found: found.to_string(),
+                descriptor: found.to_string(),
+            });
+        }
+
+        Ok(Self { request })
+    }
+
+    pub fn as_holon_reference(&self) -> &HolonReference {
+        &self.request
+    }
+
+    /// Returns the holon id requested for deletion.
+    pub fn holon_id(&self) -> Result<HolonId, HolonError> {
+        match self.request.property_value(CorePropertyTypeName::HolonId)? {
+            Some(BaseValue::StringValue(value)) => serde_json::from_str(&value.0)
+                .map_err(|error| HolonError::InvalidParameter(format!("Invalid HolonId: {error}"))),
+            Some(other) => {
+                // TODO: replace this JSON-string bridge when runtime value
+                // support catches up with the imported schema's intended
+                // `HolonId` value family.
+                Err(HolonError::UnexpectedValueType(
+                    format!("{other:?}"),
+                    "String".to_string(),
+                ))
+            }
+            None => Err(HolonError::InvalidParameter(
+                "DeleteHolonParameters requires a HolonId property".to_string(),
+            )),
+        }
+    }
+}
+
 /// Typed reference to a response holon described by `DanceResponseType`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DanceResponseReference {
@@ -483,16 +582,8 @@ impl DanceResponseReference {
     /// holon is described as `DanceResponseType`.
     pub fn new(response: HolonReference) -> Result<Self, HolonError> {
         let descriptor = response.holon_descriptor()?;
-        let found = descriptor.header().type_name()?;
         let expected = MapString("DanceResponseType".to_string());
-
-        if found != expected {
-            return Err(HolonError::WrongDescriptorKind {
-                expected: expected.to_string(),
-                found: found.to_string(),
-                descriptor: found.to_string(),
-            });
-        }
+        accessor_helpers::validate_extends_chain_reaches(descriptor.holon(), &expected)?;
 
         Ok(Self { response })
     }
@@ -638,12 +729,13 @@ impl DanceEvent {
 mod tests {
     use super::{
         DanceContext, DanceDiagnostic, DanceDiagnosticSeverity, DanceEvent, DanceIdentity,
-        DanceOutcome, DanceRequestState, DanceResult, InvocationSource,
+        DanceInvocation, DanceOutcome, DanceRequestState, DanceResult, DeleteHolonParameters,
+        InvocationSource,
     };
     use crate::descriptors::test_support::{build_context, new_test_holon};
     use crate::HolonReference;
     use base_types::MapString;
-    use core_types::HolonError;
+    use core_types::{HolonError, HolonId, LocalId};
     use serde_json::{json, to_value};
 
     #[test]
@@ -747,5 +839,22 @@ mod tests {
 
         assert_eq!(event.event_name, "validated");
         assert!(matches!(event.payload, Some(reference) if reference.is_transient()));
+    }
+
+    #[test]
+    fn delete_holon_builder_creates_request_parameters_holon() {
+        let context = build_context();
+        let expected_id = HolonId::Local(LocalId(vec![4, 5, 6]));
+
+        let invocation =
+            DanceInvocation::build_delete_holon(&context, expected_id.clone()).expect("invocation");
+        let bound = invocation.bind().expect("bind delete invocation");
+        let request = bound.request().cloned().expect("delete request");
+        let request_type = bound.request_type().expect("delete request type");
+        let parameters =
+            DeleteHolonParameters::new(request, request_type).expect("typed delete parameters");
+
+        assert_eq!(parameters.holon_id().expect("holon id"), expected_id);
+        assert!(bound.affording_holon().is_none());
     }
 }

--- a/shared_crates/holons_core/src/dances/contract.rs
+++ b/shared_crates/holons_core/src/dances/contract.rs
@@ -353,8 +353,10 @@ impl DanceInvocation {
         let mut dance_descriptor =
             context.mutation().new_holon(Some(MapString::from("delete-holon-dance")))?;
         initialize_runtime_descriptor_holon(&mut dance_descriptor, "DeleteHolon")?;
-        dance_descriptor
-            .add_related_holons(CoreRelationshipTypeName::RequestType, vec![request_type.clone()])?;
+        dance_descriptor.add_related_holons(
+            CoreRelationshipTypeName::RequestType,
+            vec![request_type.clone()],
+        )?;
         dance_descriptor
             .add_related_holons(CoreRelationshipTypeName::Response, vec![response_type.into()])?;
         dance_descriptor
@@ -559,10 +561,7 @@ impl DeleteHolonParameters {
                 // TODO: replace this JSON-string bridge when runtime value
                 // support catches up with the imported schema's intended
                 // `HolonId` value family.
-                Err(HolonError::UnexpectedValueType(
-                    format!("{other:?}"),
-                    "String".to_string(),
-                ))
+                Err(HolonError::UnexpectedValueType(format!("{other:?}"), "String".to_string()))
             }
             None => Err(HolonError::InvalidParameter(
                 "DeleteHolonParameters requires a HolonId property".to_string(),

--- a/shared_crates/holons_core/src/dances/contract.rs
+++ b/shared_crates/holons_core/src/dances/contract.rs
@@ -1,5 +1,5 @@
 use crate::core_shared_objects::Holon;
-use crate::reference_layer::HolonReference;
+use crate::reference_layer::{HolonReference, ReadableHolon};
 use base_types::MapString;
 use core_types::HolonError;
 use serde::{Deserialize, Serialize};
@@ -142,6 +142,106 @@ pub enum InvocationSource {
 }
 
 pub type DanceInvocationSource = InvocationSource;
+
+/// Canonical execution-boundary reference to a `DanceInvocation` holon.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DanceInvocationReference {
+    invocation: HolonReference,
+}
+
+impl DanceInvocationReference {
+    pub fn new(invocation: HolonReference) -> Result<Self, HolonError> {
+        let descriptor = invocation.holon_descriptor()?;
+        let found = descriptor.header().type_name()?;
+        let expected = MapString("DanceInvocation".to_string());
+
+        if found != expected {
+            return Err(HolonError::WrongDescriptorKind {
+                expected: expected.to_string(),
+                found: found.to_string(),
+                descriptor: found.to_string(),
+            });
+        }
+
+        Ok(Self { invocation })
+    }
+
+    pub fn as_holon_reference(&self) -> &HolonReference {
+        &self.invocation
+    }
+
+    pub fn into_inner(self) -> HolonReference {
+        self.invocation
+    }
+}
+
+impl From<DanceInvocationReference> for HolonReference {
+    fn from(invocation: DanceInvocationReference) -> Self {
+        invocation.into_inner()
+    }
+}
+
+impl From<&DanceInvocationReference> for HolonReference {
+    fn from(invocation: &DanceInvocationReference) -> Self {
+        invocation.as_holon_reference().clone()
+    }
+}
+
+pub fn build_dance_v2_invocation(
+    invocation: HolonReference,
+) -> Result<DanceInvocationReference, HolonError> {
+    DanceInvocationReference::new(invocation)
+}
+
+/// Canonical execution-boundary reference to a `DanceResponseType` holon.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DanceResponseReference {
+    response: HolonReference,
+}
+
+impl DanceResponseReference {
+    pub fn new(response: HolonReference) -> Result<Self, HolonError> {
+        let descriptor = response.holon_descriptor()?;
+        let found = descriptor.header().type_name()?;
+        let expected = MapString("DanceResponseType".to_string());
+
+        if found != expected {
+            return Err(HolonError::WrongDescriptorKind {
+                expected: expected.to_string(),
+                found: found.to_string(),
+                descriptor: found.to_string(),
+            });
+        }
+
+        Ok(Self { response })
+    }
+
+    pub fn as_holon_reference(&self) -> &HolonReference {
+        &self.response
+    }
+
+    pub fn into_inner(self) -> HolonReference {
+        self.response
+    }
+}
+
+impl From<DanceResponseReference> for HolonReference {
+    fn from(response: DanceResponseReference) -> Self {
+        response.into_inner()
+    }
+}
+
+impl From<&DanceResponseReference> for HolonReference {
+    fn from(response: &DanceResponseReference) -> Self {
+        response.as_holon_reference().clone()
+    }
+}
+
+pub fn build_dance_v2_response(
+    response: HolonReference,
+) -> Result<DanceResponseReference, HolonError> {
+    DanceResponseReference::new(response)
+}
 
 /// Canonical successful outcome envelope for a dance in PRO1.
 #[derive(Debug, Clone)]

--- a/shared_crates/holons_core/src/dances/contract.rs
+++ b/shared_crates/holons_core/src/dances/contract.rs
@@ -1,13 +1,15 @@
-use crate::core_shared_objects::Holon;
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::{accessor_helpers, DanceDescriptor, DanceResponseDescriptor, HolonDescriptor};
+use crate::core_shared_objects::Holon;
+use crate::descriptors::{
+    accessor_helpers, DanceDescriptor, DanceResponseDescriptor, HolonDescriptor,
+};
 use crate::reference_layer::{HolonReference, ReadableHolon, WritableHolon};
 use base_types::{BaseValue, MapString};
 use core_types::{HolonError, TypeKind};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 use type_names::CoreDanceImplementationName;
+use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 
 /// Runtime result for dance execution within a transaction.
 ///
@@ -276,16 +278,11 @@ impl DanceInvocation {
     /// Returns the invocation source recorded on the invocation holon, if any.
     pub fn invocation_source(&self) -> Result<Option<InvocationSource>, HolonError> {
         match self.as_holon_reference().property_value("InvocationSource")? {
-            Some(BaseValue::StringValue(value)) => {
-                parse_invocation_source(&value).map(Some)
+            Some(BaseValue::StringValue(value)) => parse_invocation_source(&value).map(Some),
+            Some(BaseValue::EnumValue(value)) => parse_invocation_source(&value.0).map(Some),
+            Some(other) => {
+                Err(HolonError::UnexpectedValueType(format!("{other:?}"), "Enum".to_string()))
             }
-            Some(BaseValue::EnumValue(value)) => {
-                parse_invocation_source(&value.0).map(Some)
-            }
-            Some(other) => Err(HolonError::UnexpectedValueType(
-                format!("{other:?}"),
-                "Enum".to_string(),
-            )),
             None => Ok(None),
         }
     }
@@ -351,18 +348,13 @@ impl DanceInvocation {
             CoreRelationshipTypeName::RequestType,
             vec![request_type.clone().into()],
         )?;
-        dance_descriptor.add_related_holons(
-            CoreRelationshipTypeName::Response,
-            vec![response_type.into()],
-        )?;
-        dance_descriptor.add_related_holons(
-            CoreRelationshipTypeName::ForDance,
-            vec![implementation.into()],
-        )?;
+        dance_descriptor
+            .add_related_holons(CoreRelationshipTypeName::Response, vec![response_type.into()])?;
+        dance_descriptor
+            .add_related_holons(CoreRelationshipTypeName::ForDance, vec![implementation.into()])?;
 
-        let mut request = context
-            .mutation()
-            .new_holon(Some(MapString::from("delete-holon-request")))?;
+        let mut request =
+            context.mutation().new_holon(Some(MapString::from("delete-holon-request")))?;
         request.with_descriptor(request_type.into())?;
         request.add_related_holons(
             CoreRelationshipTypeName::ReferenceTarget,
@@ -376,18 +368,13 @@ impl DanceInvocation {
         let mut invocation =
             context.mutation().new_holon(Some(MapString::from("delete-holon-invocation")))?;
         invocation.with_descriptor(invocation_descriptor.into())?;
-        invocation.with_property_value(
-            "InvocationSource",
-            MapString("ClientCommand".to_string()),
-        )?;
+        invocation
+            .with_property_value("InvocationSource", MapString("ClientCommand".to_string()))?;
         invocation.add_related_holons(
             CoreRelationshipTypeName::InvokesDance,
             vec![dance_descriptor.into()],
         )?;
-        invocation.add_related_holons(
-            CoreRelationshipTypeName::Request,
-            vec![request.into()],
-        )?;
+        invocation.add_related_holons(CoreRelationshipTypeName::Request, vec![request.into()])?;
 
         Self::new(invocation.into())
     }
@@ -397,19 +384,14 @@ impl DanceInvocation {
     ///
     /// Commit has no request holon and no affording holon. The transaction
     /// context itself provides the state being committed.
-    pub fn build_commit(
-        context: &Arc<TransactionContext>,
-    ) -> Result<Self, HolonError> {
+    pub fn build_commit(context: &Arc<TransactionContext>) -> Result<Self, HolonError> {
         let invocation_descriptor = new_runtime_descriptor_holon(
             context,
             "dance-invocation-descriptor",
             "DanceInvocation",
         )?;
-        let response_type = new_runtime_descriptor_holon(
-            context,
-            "commit-response-type",
-            "DanceResponseType",
-        )?;
+        let response_type =
+            new_runtime_descriptor_holon(context, "commit-response-type", "DanceResponseType")?;
         let implementation = new_runtime_descriptor_holon(
             context,
             "commit-implementation",
@@ -419,21 +401,16 @@ impl DanceInvocation {
         let mut dance_descriptor =
             context.mutation().new_holon(Some(MapString::from("commit-dance")))?;
         initialize_runtime_descriptor_holon(&mut dance_descriptor, "Commit")?;
-        dance_descriptor.add_related_holons(
-            CoreRelationshipTypeName::Response,
-            vec![response_type.into()],
-        )?;
-        dance_descriptor.add_related_holons(
-            CoreRelationshipTypeName::ForDance,
-            vec![implementation.into()],
-        )?;
+        dance_descriptor
+            .add_related_holons(CoreRelationshipTypeName::Response, vec![response_type.into()])?;
+        dance_descriptor
+            .add_related_holons(CoreRelationshipTypeName::ForDance, vec![implementation.into()])?;
 
-        let mut invocation = context.mutation().new_holon(Some(MapString::from("commit-invocation")))?;
+        let mut invocation =
+            context.mutation().new_holon(Some(MapString::from("commit-invocation")))?;
         invocation.with_descriptor(invocation_descriptor.into())?;
-        invocation.with_property_value(
-            "InvocationSource",
-            MapString("ClientCommand".to_string()),
-        )?;
+        invocation
+            .with_property_value("InvocationSource", MapString("ClientCommand".to_string()))?;
         invocation.add_related_holons(
             CoreRelationshipTypeName::InvokesDance,
             vec![dance_descriptor.into()],

--- a/shared_crates/holons_core/src/dances/dance_v2_executor.rs
+++ b/shared_crates/holons_core/src/dances/dance_v2_executor.rs
@@ -5,89 +5,133 @@ use core_types::HolonError;
 use type_names::CoreRelationshipTypeName;
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::{DanceDescriptor, DanceResponseDescriptor, Descriptor, HolonDescriptor};
-use crate::dances::{DanceInvocationReference, DanceResponseReference};
+use crate::descriptors::{
+    DanceDescriptor, DanceResponseDescriptor, Descriptor,
+};
+use crate::dances::{DanceImplementation, DanceInvocation, DanceResponseReference};
 use crate::reference_layer::{ReadableHolon, WritableHolon};
 
-/// Shared execution seam for canonical `DanceV2` ingress.
+/// Executes a descriptor-driven dance invocation and returns a typed response
+/// reference.
 ///
-/// PR4 keeps the implementation static and descriptor-backed. The executor
-/// validates the typed invocation boundary, request shape, target affordances,
-/// implementation cardinality, and response descriptor shape before minting a
-/// new typed response reference.
+/// The executor acts as a choreographer. It binds the invocation into a
+/// resolved execution context, validates the descriptor-backed contract,
+/// selects one implementation, invokes it, and mints a response holon
+/// described by the dance's declared response type. This behavior follows the
+/// host-side dance execution model described in `dances-design-spec`.
 pub async fn execute_dance_v2(
     context: &Arc<TransactionContext>,
-    invocation: DanceInvocationReference,
+    invocation: DanceInvocation,
 ) -> Result<DanceResponseReference, HolonError> {
-    let invocation_holon = invocation.as_holon_reference();
-    let dance_descriptor_ref = single_related(invocation_holon, CoreRelationshipTypeName::InvokesDance)?;
-    let dance_descriptor = DanceDescriptor::from_holon(dance_descriptor_ref.clone());
-    let request_type = dance_descriptor.request_type()?;
-    let response_descriptor = dance_descriptor.response()?;
+    let bound_invocation = invocation.bind()?;
+    validate_bound_invocation(&bound_invocation)?;
+    let implementation = select_implementation(bound_invocation.dance_descriptor())?;
+    let response_descriptor = bound_invocation.response_type()?;
+    let response_body = implementation.invoke(context, &bound_invocation)?;
+    build_response_reference(context, &response_descriptor, response_body)
+}
 
-    validate_request_shape(invocation_holon, request_type.as_ref())?;
+fn select_implementation(
+    dance_descriptor: &DanceDescriptor,
+) -> Result<DanceImplementation, HolonError> {
+    // Static execution currently requires exactly one `ForDance`
+    // implementation. Broader activation and selection policy can be layered
+    // onto this seam later without changing the executor entry point.
+    let implementations = dance_descriptor.implementation_candidates()?;
 
-    if let Some(target) = single_related_opt(invocation_holon, CoreRelationshipTypeName::Target)? {
-        validate_target_affords_dance(&target, dance_descriptor.header().type_name()?)?;
-    }
-
-    let implementations = dance_descriptor_ref
-        .related_holons(&CoreRelationshipTypeName::ForDance)?
-        .read()
-        .map_err(|error| HolonError::FailedToAcquireLock(format!("{error}")))?
-        .get_members()
-        .len();
-
-    if implementations == 0 {
-        return Err(HolonError::DescriptorDeclarationNotFound {
+    match implementations.as_slice() {
+        [] => Err(HolonError::DescriptorDeclarationNotFound {
             kind: "dance implementation".to_string(),
             name: dance_descriptor.header().type_name()?.to_string(),
-            descriptor: dance_descriptor_ref.summarize()?,
-        });
-    }
-
-    if implementations > 1 {
-        return Err(HolonError::DuplicateInheritedDeclaration {
+            descriptor: dance_descriptor.holon().summarize()?,
+        }),
+        [single] => Ok(single.clone()),
+        many => Err(HolonError::DuplicateInheritedDeclaration {
             kind: "dance implementation".to_string(),
             name: dance_descriptor.header().type_name()?.to_string(),
-            descriptor: dance_descriptor_ref.summarize()?,
-        });
+            descriptor: format!(
+                "{} ({} candidates)",
+                dance_descriptor.holon().summarize()?,
+                many.len()
+            ),
+        }),
     }
+}
 
-    validate_response_descriptor(&response_descriptor)?;
-
+fn build_response_reference(
+    context: &Arc<TransactionContext>,
+    response_descriptor: &DanceResponseDescriptor,
+    body: Option<crate::reference_layer::HolonReference>,
+) -> Result<DanceResponseReference, HolonError> {
     let mut response = context
         .mutation()
         .new_holon(Some(MapString("dance-response".to_string())))?;
     response.with_descriptor(response_descriptor.holon().clone())?;
-
+    if let Some(body_ref) = body {
+        response_descriptor.attach_response_body(&mut response, body_ref)?;
+    }
     DanceResponseReference::new(response.into())
 }
 
-fn validate_request_shape(
-    invocation_holon: &crate::reference_layer::HolonReference,
-    request_type: Option<&HolonDescriptor>,
+fn validate_bound_invocation(
+    bound_invocation: &crate::dances::BoundDanceInvocation,
 ) -> Result<(), HolonError> {
-    let request = single_related_opt(invocation_holon, CoreRelationshipTypeName::Request)?;
-    match (request_type, request) {
+    validate_request_contract(bound_invocation)?;
+    validate_affording_holon_contract(bound_invocation)?;
+    validate_invocation_source(bound_invocation)?;
+    validate_response_descriptor(&bound_invocation.response_type()?)?;
+    Ok(())
+}
+
+fn validate_request_contract(
+    bound_invocation: &crate::dances::BoundDanceInvocation,
+) -> Result<(), HolonError> {
+    match (bound_invocation.request_type(), bound_invocation.request()) {
         (Some(_), None) => Err(HolonError::MissingRequiredRelationship {
             relationship: "Request".to_string(),
-            descriptor: invocation_holon.summarize()?,
+            descriptor: bound_invocation.invocation().as_holon_reference().summarize()?,
         }),
         (None, Some(_)) => Err(HolonError::InvalidRelationship(
             "Request".to_string(),
-            invocation_holon.summarize()?,
+            bound_invocation.invocation().as_holon_reference().summarize()?,
         )),
-        _ => Ok(()),
+        (Some(expected_type), Some(request_holon)) => {
+            let request_descriptor = request_holon.holon_descriptor()?;
+            if request_descriptor.header().type_name()? != expected_type.header().type_name()? {
+                return Err(HolonError::WrongDescriptorKind {
+                    expected: expected_type.header().type_name()?.to_string(),
+                    found: request_descriptor.header().type_name()?.to_string(),
+                    descriptor: request_descriptor.header().type_name()?.to_string(),
+                });
+            }
+
+            // TODO: the current schema models `RequestType` as a generic
+            // `HolonType`. A dedicated request-contract descriptor would allow
+            // richer validation than simple descriptor identity matching.
+            Ok(())
+        }
+        (None, None) => Ok(()),
     }
 }
 
-fn validate_target_affords_dance(
-    target: &crate::reference_layer::HolonReference,
-    dance_name: MapString,
+fn validate_affording_holon_contract(
+    bound_invocation: &crate::dances::BoundDanceInvocation,
 ) -> Result<(), HolonError> {
-    let target_descriptor = target.holon_descriptor()?;
-    target_descriptor.get_dance_by_name(dance_name)?;
+    if let Some(affording_descriptor) = bound_invocation.affording_holon_descriptor() {
+        affording_descriptor.get_dance_by_name(bound_invocation.dance_descriptor().dance_name()?)?;
+    }
+
+    // TODO: once the schema exposes an explicit affording-holon requirement,
+    // validate required/optional/forbidden subject presence here instead of
+    // treating affordance validation as purely opportunistic.
+    Ok(())
+}
+
+fn validate_invocation_source(
+    _bound_invocation: &crate::dances::BoundDanceInvocation,
+) -> Result<(), HolonError> {
+    // Binding parses the enum value eagerly. If binding succeeded, the source
+    // is structurally valid for this execution posture.
     Ok(())
 }
 
@@ -98,6 +142,9 @@ fn validate_response_descriptor(
     Ok(())
 }
 
+// TODO: move single-related cardinality helpers onto `ReadableHolon` (or an
+// adjacent shared reference-layer surface) instead of keeping them local here.
+#[allow(dead_code)]
 fn single_related(
     holon: &crate::reference_layer::HolonReference,
     relationship: CoreRelationshipTypeName,
@@ -124,6 +171,10 @@ fn single_related(
     }
 }
 
+// TODO: move optional single-related cardinality helpers onto `ReadableHolon`
+// (or an adjacent shared reference-layer surface) instead of keeping them
+// local here.
+#[allow(dead_code)]
 fn single_related_opt(
     holon: &crate::reference_layer::HolonReference,
     relationship: CoreRelationshipTypeName,

--- a/shared_crates/holons_core/src/dances/dance_v2_executor.rs
+++ b/shared_crates/holons_core/src/dances/dance_v2_executor.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use base_types::MapString;
+use core_types::HolonError;
+use type_names::CoreRelationshipTypeName;
+
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::descriptors::{DanceDescriptor, DanceResponseDescriptor, Descriptor, HolonDescriptor};
+use crate::dances::{DanceInvocationReference, DanceResponseReference};
+use crate::reference_layer::{ReadableHolon, WritableHolon};
+
+/// Shared execution seam for canonical `DanceV2` ingress.
+///
+/// PR4 keeps the implementation static and descriptor-backed. The executor
+/// validates the typed invocation boundary, request shape, target affordances,
+/// implementation cardinality, and response descriptor shape before minting a
+/// new typed response reference.
+pub async fn execute_dance_v2(
+    context: &Arc<TransactionContext>,
+    invocation: DanceInvocationReference,
+) -> Result<DanceResponseReference, HolonError> {
+    let invocation_holon = invocation.as_holon_reference();
+    let dance_descriptor_ref = single_related(invocation_holon, CoreRelationshipTypeName::InvokesDance)?;
+    let dance_descriptor = DanceDescriptor::from_holon(dance_descriptor_ref.clone());
+    let request_type = dance_descriptor.request_type()?;
+    let response_descriptor = dance_descriptor.response()?;
+
+    validate_request_shape(invocation_holon, request_type.as_ref())?;
+
+    if let Some(target) = single_related_opt(invocation_holon, CoreRelationshipTypeName::Target)? {
+        validate_target_affords_dance(&target, dance_descriptor.header().type_name()?)?;
+    }
+
+    let implementations = dance_descriptor_ref
+        .related_holons(&CoreRelationshipTypeName::ForDance)?
+        .read()
+        .map_err(|error| HolonError::FailedToAcquireLock(format!("{error}")))?
+        .get_members()
+        .len();
+
+    if implementations == 0 {
+        return Err(HolonError::DescriptorDeclarationNotFound {
+            kind: "dance implementation".to_string(),
+            name: dance_descriptor.header().type_name()?.to_string(),
+            descriptor: dance_descriptor_ref.summarize()?,
+        });
+    }
+
+    if implementations > 1 {
+        return Err(HolonError::DuplicateInheritedDeclaration {
+            kind: "dance implementation".to_string(),
+            name: dance_descriptor.header().type_name()?.to_string(),
+            descriptor: dance_descriptor_ref.summarize()?,
+        });
+    }
+
+    validate_response_descriptor(&response_descriptor)?;
+
+    let mut response = context
+        .mutation()
+        .new_holon(Some(MapString("dance-response".to_string())))?;
+    response.with_descriptor(response_descriptor.holon().clone())?;
+
+    DanceResponseReference::new(response.into())
+}
+
+fn validate_request_shape(
+    invocation_holon: &crate::reference_layer::HolonReference,
+    request_type: Option<&HolonDescriptor>,
+) -> Result<(), HolonError> {
+    let request = single_related_opt(invocation_holon, CoreRelationshipTypeName::Request)?;
+    match (request_type, request) {
+        (Some(_), None) => Err(HolonError::MissingRequiredRelationship {
+            relationship: "Request".to_string(),
+            descriptor: invocation_holon.summarize()?,
+        }),
+        (None, Some(_)) => Err(HolonError::InvalidRelationship(
+            "Request".to_string(),
+            invocation_holon.summarize()?,
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_target_affords_dance(
+    target: &crate::reference_layer::HolonReference,
+    dance_name: MapString,
+) -> Result<(), HolonError> {
+    let target_descriptor = target.holon_descriptor()?;
+    target_descriptor.get_dance_by_name(dance_name)?;
+    Ok(())
+}
+
+fn validate_response_descriptor(
+    response_descriptor: &DanceResponseDescriptor,
+) -> Result<(), HolonError> {
+    let _ = response_descriptor.response_body()?;
+    Ok(())
+}
+
+fn single_related(
+    holon: &crate::reference_layer::HolonReference,
+    relationship: CoreRelationshipTypeName,
+) -> Result<crate::reference_layer::HolonReference, HolonError> {
+    let relationship_name = relationship.as_relationship_name().to_string();
+    let collection = holon.related_holons(&relationship)?;
+    let members = collection
+        .read()
+        .map_err(|error| HolonError::FailedToAcquireLock(format!("{error}")))?
+        .get_members()
+        .clone();
+
+    match members.as_slice() {
+        [single] => Ok(single.clone()),
+        [] => Err(HolonError::MissingRequiredRelationship {
+            relationship: relationship_name,
+            descriptor: holon.summarize()?,
+        }),
+        many => Err(HolonError::MultipleRelatedHolons {
+            relationship: relationship_name,
+            descriptor: holon.summarize()?,
+            count: many.len(),
+        }),
+    }
+}
+
+fn single_related_opt(
+    holon: &crate::reference_layer::HolonReference,
+    relationship: CoreRelationshipTypeName,
+) -> Result<Option<crate::reference_layer::HolonReference>, HolonError> {
+    let relationship_name = relationship.as_relationship_name().to_string();
+    let collection = holon.related_holons(&relationship)?;
+    let members = collection
+        .read()
+        .map_err(|error| HolonError::FailedToAcquireLock(format!("{error}")))?
+        .get_members()
+        .clone();
+
+    match members.as_slice() {
+        [] => Ok(None),
+        [single] => Ok(Some(single.clone())),
+        many => Err(HolonError::MultipleRelatedHolons {
+            relationship: relationship_name,
+            descriptor: holon.summarize()?,
+            count: many.len(),
+        }),
+    }
+}

--- a/shared_crates/holons_core/src/dances/dance_v2_executor.rs
+++ b/shared_crates/holons_core/src/dances/dance_v2_executor.rs
@@ -5,10 +5,8 @@ use core_types::HolonError;
 use type_names::CoreRelationshipTypeName;
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::{
-    DanceDescriptor, DanceResponseDescriptor, Descriptor,
-};
 use crate::dances::{DanceImplementation, DanceInvocation, DanceResponseReference};
+use crate::descriptors::{DanceDescriptor, DanceResponseDescriptor, Descriptor};
 use crate::reference_layer::{ReadableHolon, WritableHolon};
 
 /// Executes a descriptor-driven dance invocation and returns a typed response
@@ -63,9 +61,8 @@ fn build_response_reference(
     response_descriptor: &DanceResponseDescriptor,
     body: Option<crate::reference_layer::HolonReference>,
 ) -> Result<DanceResponseReference, HolonError> {
-    let mut response = context
-        .mutation()
-        .new_holon(Some(MapString("dance-response".to_string())))?;
+    let mut response =
+        context.mutation().new_holon(Some(MapString("dance-response".to_string())))?;
     response.with_descriptor(response_descriptor.holon().clone())?;
     if let Some(body_ref) = body {
         response_descriptor.attach_response_body(&mut response, body_ref)?;
@@ -118,7 +115,8 @@ fn validate_affording_holon_contract(
     bound_invocation: &crate::dances::BoundDanceInvocation,
 ) -> Result<(), HolonError> {
     if let Some(affording_descriptor) = bound_invocation.affording_holon_descriptor() {
-        affording_descriptor.get_dance_by_name(bound_invocation.dance_descriptor().dance_name()?)?;
+        affording_descriptor
+            .get_dance_by_name(bound_invocation.dance_descriptor().dance_name()?)?;
     }
 
     // TODO: once the schema exposes an explicit affording-holon requirement,

--- a/shared_crates/holons_core/src/dances/implementation.rs
+++ b/shared_crates/holons_core/src/dances/implementation.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use core_types::HolonError;
+
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::descriptors::{accessor_helpers, DanceDescriptor, TypeHeader};
+use crate::dances::{implementations, BoundDanceInvocation};
+use crate::reference_layer::HolonReference;
+use type_names::{CoreDanceImplementationName, CoreRelationshipTypeName};
+
+/// Runtime wrapper for a dance implementation holon.
+#[derive(Debug, Clone)]
+pub struct DanceImplementation {
+    holon: HolonReference,
+}
+
+impl DanceImplementation {
+    pub fn from_holon(holon: HolonReference) -> Self {
+        Self { holon }
+    }
+
+    pub fn header(&self) -> TypeHeader<'_> {
+        TypeHeader::new(&self.holon)
+    }
+
+    pub fn for_dance(&self) -> Result<DanceDescriptor, HolonError> {
+        let descriptor =
+            accessor_helpers::require_single_related(&self.holon, CoreRelationshipTypeName::ForDance)?;
+        Ok(DanceDescriptor::from_holon(descriptor))
+    }
+
+    pub fn invoke(
+        &self,
+        context: &Arc<TransactionContext>,
+        bound_invocation: &BoundDanceInvocation,
+    ) -> Result<Option<HolonReference>, HolonError> {
+        let implementation_name = self.header().type_name()?;
+
+        if implementation_name == CoreDanceImplementationName::Commit.as_command_name().0 {
+            return implementations::commit::invoke(context, bound_invocation);
+        }
+
+        if implementation_name == CoreDanceImplementationName::DeleteHolon.as_command_name().0 {
+            return implementations::delete_holon::invoke(context, bound_invocation);
+        }
+
+        Err(HolonError::NotImplemented(format!(
+            "Descriptor-driven host invocation is not implemented for DanceImplementation `{}` yet. Guest-side persistence primitives should be wrapped explicitly rather than treated as canonical host dances.",
+            implementation_name
+        )))
+    }
+}
+
+impl From<HolonReference> for DanceImplementation {
+    fn from(holon: HolonReference) -> Self {
+        Self::from_holon(holon)
+    }
+}

--- a/shared_crates/holons_core/src/dances/implementation.rs
+++ b/shared_crates/holons_core/src/dances/implementation.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use core_types::HolonError;
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::{accessor_helpers, DanceDescriptor, TypeHeader};
 use crate::dances::{implementations, BoundDanceInvocation};
+use crate::descriptors::{accessor_helpers, DanceDescriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 use type_names::{CoreDanceImplementationName, CoreRelationshipTypeName};
 
@@ -24,8 +24,10 @@ impl DanceImplementation {
     }
 
     pub fn for_dance(&self) -> Result<DanceDescriptor, HolonError> {
-        let descriptor =
-            accessor_helpers::require_single_related(&self.holon, CoreRelationshipTypeName::ForDance)?;
+        let descriptor = accessor_helpers::require_single_related(
+            &self.holon,
+            CoreRelationshipTypeName::ForDance,
+        )?;
         Ok(DanceDescriptor::from_holon(descriptor))
     }
 

--- a/shared_crates/holons_core/src/dances/implementations/commit.rs
+++ b/shared_crates/holons_core/src/dances/implementations/commit.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use core_types::HolonError;
+
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::dances::BoundDanceInvocation;
+use crate::reference_layer::HolonReference;
+
+pub fn invoke(
+    context: &Arc<TransactionContext>,
+    _bound_invocation: &BoundDanceInvocation,
+) -> Result<Option<HolonReference>, HolonError> {
+    let commit_response = context.commit()?;
+    Ok(Some(HolonReference::Transient(commit_response)))
+}

--- a/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
+++ b/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
@@ -3,31 +3,36 @@ use std::sync::Arc;
 use core_types::{HolonError, HolonId};
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::dances::BoundDanceInvocation;
-use crate::descriptors::accessor_helpers;
+use crate::descriptors::Descriptor;
+use crate::dances::{BoundDanceInvocation, DeleteHolonParameters};
 use crate::reference_layer::ReadableHolon;
-use type_names::CoreRelationshipTypeName;
 
 pub fn invoke(
     context: &Arc<TransactionContext>,
     bound_invocation: &BoundDanceInvocation,
 ) -> Result<Option<crate::reference_layer::HolonReference>, HolonError> {
-    let request =
-        bound_invocation.request().ok_or_else(|| HolonError::MissingRequiredRelationship {
-            relationship: CoreRelationshipTypeName::Request.as_relationship_name().to_string(),
+    let request = bound_invocation
+        .request()
+        .cloned()
+        .ok_or_else(|| HolonError::MissingRequiredRelationship {
+            relationship: "Request".to_string(),
             descriptor: bound_invocation
                 .invocation()
                 .as_holon_reference()
                 .summarize()
                 .unwrap_or_else(|_| "DanceInvocation".to_string()),
         })?;
+    let request_type = bound_invocation.request_type().ok_or_else(|| {
+        HolonError::MissingRequiredRelationship {
+            relationship: "RequestType".to_string(),
+            descriptor: bound_invocation.dance_descriptor().holon().summarize().unwrap_or_else(
+                |_| "DeleteHolon".to_string(),
+            ),
+        }
+    })?;
+    let parameters = DeleteHolonParameters::new(request, request_type)?;
+    let holon_id = parameters.holon_id()?;
 
-    let target = accessor_helpers::require_single_related(
-        request,
-        CoreRelationshipTypeName::ReferenceTarget,
-    )?;
-
-    let holon_id = target.holon_id()?;
     let local_id = match holon_id {
         HolonId::Local(local_id) => local_id,
         HolonId::External(external_id) => external_id.local_id,

--- a/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
+++ b/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
@@ -3,33 +3,33 @@ use std::sync::Arc;
 use core_types::{HolonError, HolonId};
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::Descriptor;
 use crate::dances::{BoundDanceInvocation, DeleteHolonParameters};
+use crate::descriptors::Descriptor;
 use crate::reference_layer::ReadableHolon;
 
 pub fn invoke(
     context: &Arc<TransactionContext>,
     bound_invocation: &BoundDanceInvocation,
 ) -> Result<Option<crate::reference_layer::HolonReference>, HolonError> {
-    let request = bound_invocation
-        .request()
-        .cloned()
-        .ok_or_else(|| HolonError::MissingRequiredRelationship {
+    let request = bound_invocation.request().cloned().ok_or_else(|| {
+        HolonError::MissingRequiredRelationship {
             relationship: "Request".to_string(),
             descriptor: bound_invocation
                 .invocation()
                 .as_holon_reference()
                 .summarize()
                 .unwrap_or_else(|_| "DanceInvocation".to_string()),
-        })?;
-    let request_type = bound_invocation.request_type().ok_or_else(|| {
-        HolonError::MissingRequiredRelationship {
-            relationship: "RequestType".to_string(),
-            descriptor: bound_invocation.dance_descriptor().holon().summarize().unwrap_or_else(
-                |_| "DeleteHolon".to_string(),
-            ),
         }
     })?;
+    let request_type =
+        bound_invocation.request_type().ok_or_else(|| HolonError::MissingRequiredRelationship {
+            relationship: "RequestType".to_string(),
+            descriptor: bound_invocation
+                .dance_descriptor()
+                .holon()
+                .summarize()
+                .unwrap_or_else(|_| "DeleteHolon".to_string()),
+        })?;
     let parameters = DeleteHolonParameters::new(request, request_type)?;
     let holon_id = parameters.holon_id()?;
 

--- a/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
+++ b/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use core_types::{HolonError, HolonId};
+
+use crate::core_shared_objects::transactions::TransactionContext;
+use crate::descriptors::accessor_helpers;
+use crate::dances::BoundDanceInvocation;
+use crate::reference_layer::ReadableHolon;
+use type_names::CoreRelationshipTypeName;
+
+pub fn invoke(
+    context: &Arc<TransactionContext>,
+    bound_invocation: &BoundDanceInvocation,
+) -> Result<Option<crate::reference_layer::HolonReference>, HolonError> {
+    let request = bound_invocation.request().ok_or_else(|| HolonError::MissingRequiredRelationship {
+        relationship: CoreRelationshipTypeName::Request.as_relationship_name().to_string(),
+        descriptor: bound_invocation
+            .invocation()
+            .as_holon_reference()
+            .summarize()
+            .unwrap_or_else(|_| "DanceInvocation".to_string()),
+    })?;
+
+    let target = accessor_helpers::require_single_related(
+        request,
+        CoreRelationshipTypeName::ReferenceTarget,
+    )?;
+
+    let holon_id = target.holon_id()?;
+    let local_id = match holon_id {
+        HolonId::Local(local_id) => local_id,
+        HolonId::External(external_id) => external_id.local_id,
+    };
+
+    context.mutation().delete_holon(local_id)?;
+
+    Ok(None)
+}

--- a/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
+++ b/shared_crates/holons_core/src/dances/implementations/delete_holon.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use core_types::{HolonError, HolonId};
 
 use crate::core_shared_objects::transactions::TransactionContext;
-use crate::descriptors::accessor_helpers;
 use crate::dances::BoundDanceInvocation;
+use crate::descriptors::accessor_helpers;
 use crate::reference_layer::ReadableHolon;
 use type_names::CoreRelationshipTypeName;
 
@@ -12,14 +12,15 @@ pub fn invoke(
     context: &Arc<TransactionContext>,
     bound_invocation: &BoundDanceInvocation,
 ) -> Result<Option<crate::reference_layer::HolonReference>, HolonError> {
-    let request = bound_invocation.request().ok_or_else(|| HolonError::MissingRequiredRelationship {
-        relationship: CoreRelationshipTypeName::Request.as_relationship_name().to_string(),
-        descriptor: bound_invocation
-            .invocation()
-            .as_holon_reference()
-            .summarize()
-            .unwrap_or_else(|_| "DanceInvocation".to_string()),
-    })?;
+    let request =
+        bound_invocation.request().ok_or_else(|| HolonError::MissingRequiredRelationship {
+            relationship: CoreRelationshipTypeName::Request.as_relationship_name().to_string(),
+            descriptor: bound_invocation
+                .invocation()
+                .as_holon_reference()
+                .summarize()
+                .unwrap_or_else(|_| "DanceInvocation".to_string()),
+        })?;
 
     let target = accessor_helpers::require_single_related(
         request,

--- a/shared_crates/holons_core/src/dances/implementations/mod.rs
+++ b/shared_crates/holons_core/src/dances/implementations/mod.rs
@@ -1,0 +1,2 @@
+pub mod commit;
+pub mod delete_holon;

--- a/shared_crates/holons_core/src/dances/mod.rs
+++ b/shared_crates/holons_core/src/dances/mod.rs
@@ -11,7 +11,7 @@ pub use self::contract::{
     build_dance_v2_invocation, build_dance_v2_response, BoundDanceInvocation, DanceContext,
     DanceDiagnostic, DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult, DanceIdentity,
     DanceInvocation, DanceInvocationSource, DanceOutcome, DanceParameters, DanceRequestState,
-    DanceResponseReference, DanceResult, DanceTarget, InvocationSource,
+    DanceResponseReference, DanceResult, DanceTarget, DeleteHolonParameters, InvocationSource,
 };
 pub use self::dance_initiator::DanceInitiator;
 pub use self::dance_request::{DanceRequest, DanceType, RequestBody};

--- a/shared_crates/holons_core/src/dances/mod.rs
+++ b/shared_crates/holons_core/src/dances/mod.rs
@@ -1,17 +1,20 @@
 pub mod contract;
 pub mod dance_initiator;
+pub mod implementation;
+pub mod implementations;
 pub mod dance_request;
 pub mod dance_response;
 pub mod dance_v2_executor;
 pub mod holon_dance_adapter;
 
 pub use self::contract::{
-    build_dance_v2_invocation, build_dance_v2_response, DanceContext, DanceDiagnostic,
+    build_dance_v2_invocation, build_dance_v2_response, BoundDanceInvocation, DanceContext, DanceDiagnostic,
     DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult, DanceIdentity,
-    DanceInvocation, DanceInvocationReference, DanceInvocationSource, DanceOutcome,
+    DanceInvocation, DanceInvocationSource, DanceOutcome,
     DanceParameters, DanceRequestState, DanceResponseReference, DanceResult, DanceTarget,
     InvocationSource,
 };
+pub use self::implementation::DanceImplementation;
 pub use self::dance_initiator::DanceInitiator;
 pub use self::dance_request::{DanceRequest, DanceType, RequestBody};
 pub use self::dance_response::{DanceResponse, ResponseBody, ResponseStatusCode};

--- a/shared_crates/holons_core/src/dances/mod.rs
+++ b/shared_crates/holons_core/src/dances/mod.rs
@@ -1,21 +1,20 @@
 pub mod contract;
 pub mod dance_initiator;
-pub mod implementation;
-pub mod implementations;
 pub mod dance_request;
 pub mod dance_response;
 pub mod dance_v2_executor;
 pub mod holon_dance_adapter;
+pub mod implementation;
+pub mod implementations;
 
 pub use self::contract::{
-    build_dance_v2_invocation, build_dance_v2_response, BoundDanceInvocation, DanceContext, DanceDiagnostic,
-    DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult, DanceIdentity,
-    DanceInvocation, DanceInvocationSource, DanceOutcome,
-    DanceParameters, DanceRequestState, DanceResponseReference, DanceResult, DanceTarget,
-    InvocationSource,
+    build_dance_v2_invocation, build_dance_v2_response, BoundDanceInvocation, DanceContext,
+    DanceDiagnostic, DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult, DanceIdentity,
+    DanceInvocation, DanceInvocationSource, DanceOutcome, DanceParameters, DanceRequestState,
+    DanceResponseReference, DanceResult, DanceTarget, InvocationSource,
 };
-pub use self::implementation::DanceImplementation;
 pub use self::dance_initiator::DanceInitiator;
 pub use self::dance_request::{DanceRequest, DanceType, RequestBody};
 pub use self::dance_response::{DanceResponse, ResponseBody, ResponseStatusCode};
 pub use self::dance_v2_executor::execute_dance_v2;
+pub use self::implementation::DanceImplementation;

--- a/shared_crates/holons_core/src/dances/mod.rs
+++ b/shared_crates/holons_core/src/dances/mod.rs
@@ -2,13 +2,17 @@ pub mod contract;
 pub mod dance_initiator;
 pub mod dance_request;
 pub mod dance_response;
+pub mod dance_v2_executor;
 pub mod holon_dance_adapter;
 
 pub use self::contract::{
-    DanceContext, DanceDiagnostic, DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult,
-    DanceIdentity, DanceInvocation, DanceInvocationSource, DanceOutcome, DanceParameters,
-    DanceRequestState, DanceResult, DanceTarget, InvocationSource,
+    build_dance_v2_invocation, build_dance_v2_response, DanceContext, DanceDiagnostic,
+    DanceDiagnosticSeverity, DanceEvent, DanceExecutionResult, DanceIdentity,
+    DanceInvocation, DanceInvocationReference, DanceInvocationSource, DanceOutcome,
+    DanceParameters, DanceRequestState, DanceResponseReference, DanceResult, DanceTarget,
+    InvocationSource,
 };
 pub use self::dance_initiator::DanceInitiator;
 pub use self::dance_request::{DanceRequest, DanceType, RequestBody};
 pub use self::dance_response::{DanceResponse, ResponseBody, ResponseStatusCode};
+pub use self::dance_v2_executor::execute_dance_v2;

--- a/shared_crates/holons_core/src/descriptors/dance_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/dance_descriptor.rs
@@ -1,7 +1,8 @@
 use crate::descriptors::{
     accessor_helpers, DanceResponseDescriptor, Descriptor, HolonDescriptor, TypeHeader,
 };
-use crate::reference_layer::HolonReference;
+use crate::dances::DanceImplementation;
+use crate::reference_layer::{HolonReference, ReadableHolon};
 use core_types::HolonError;
 use type_names::CoreRelationshipTypeName;
 use type_names::{DanceName, ToDanceName};
@@ -32,12 +33,22 @@ impl DanceDescriptor {
         .map(HolonDescriptor::from_holon))
     }
 
-    pub fn response(&self) -> Result<DanceResponseDescriptor, HolonError> {
+    pub fn response_type(&self) -> Result<DanceResponseDescriptor, HolonError> {
         let response = accessor_helpers::require_single_related(
             &self.holon,
             CoreRelationshipTypeName::Response,
         )?;
         Ok(DanceResponseDescriptor::from_holon(response))
+    }
+
+    pub fn implementation_candidates(&self) -> Result<Vec<DanceImplementation>, HolonError> {
+        let implementations = self.holon.related_holons(CoreRelationshipTypeName::ForDance)?;
+        let members = implementations
+            .read()
+            .map_err(|error| HolonError::FailedToAcquireLock(format!("{error}")))?
+            .get_members()
+            .clone();
+        Ok(members.into_iter().map(DanceImplementation::from_holon).collect())
     }
 }
 
@@ -159,7 +170,7 @@ mod tests {
         let descriptor = DanceDescriptor::from_holon(holon.into());
 
         assert_eq!(
-            descriptor.response()?.header().type_name()?,
+            descriptor.response_type()?.header().type_name()?,
             MapString("DanceResponseType".to_string())
         );
 
@@ -173,7 +184,7 @@ mod tests {
         let descriptor = DanceDescriptor::from_holon(holon.into());
 
         assert!(matches!(
-            descriptor.response(),
+            descriptor.response_type(),
             Err(HolonError::MissingRequiredRelationship { relationship, .. })
                 if relationship == "Response"
         ));

--- a/shared_crates/holons_core/src/descriptors/dance_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/dance_descriptor.rs
@@ -1,7 +1,7 @@
+use crate::dances::DanceImplementation;
 use crate::descriptors::{
     accessor_helpers, DanceResponseDescriptor, Descriptor, HolonDescriptor, TypeHeader,
 };
-use crate::dances::DanceImplementation;
 use crate::reference_layer::{HolonReference, ReadableHolon};
 use core_types::HolonError;
 use type_names::CoreRelationshipTypeName;

--- a/shared_crates/holons_core/src/descriptors/dance_response_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/dance_response_descriptor.rs
@@ -1,5 +1,5 @@
 use crate::descriptors::{accessor_helpers, Descriptor, HolonDescriptor, TypeHeader};
-use crate::reference_layer::HolonReference;
+use crate::reference_layer::{HolonReference, WritableHolon};
 use core_types::HolonError;
 use type_names::CoreRelationshipTypeName;
 
@@ -23,6 +23,15 @@ impl DanceResponseDescriptor {
             CoreRelationshipTypeName::ResponseBody,
         )?
         .map(HolonDescriptor::from_holon))
+    }
+
+    pub fn attach_response_body<T: WritableHolon>(
+        &self,
+        response: &mut T,
+        body: HolonReference,
+    ) -> Result<(), HolonError> {
+        response.add_related_holons(CoreRelationshipTypeName::ResponseBody, vec![body])?;
+        Ok(())
     }
 }
 

--- a/shared_crates/type_system/type_names/src/command_names.rs
+++ b/shared_crates/type_system/type_names/src/command_names.rs
@@ -117,11 +117,27 @@ pub enum CoreCommandTypeName {
     DeleteHolon,
 }
 
+/// Canonical implementation names for core DanceV2 cutover dances.
+#[derive(Debug, Clone, PartialEq, Eq, VariantNames)]
+pub enum CoreDanceImplementationName {
+    GetHolonById,
+    DeleteHolon,
+    Commit,
+    LoadHolons,
+}
+
 impl CoreCommandTypeName {
     /// Canonical command type name in ClassCase (UpperCamel).
     pub fn as_command_name(&self) -> CommandName {
         // Use the Rust variant identifier as the core inventory source, then apply
         // the shared type-name case convention used by the neighboring modules.
+        let command_name = format!("{self:?}").to_case(Case::UpperCamel);
+        CommandName(MapString(command_name))
+    }
+}
+
+impl CoreDanceImplementationName {
+    pub fn as_command_name(&self) -> CommandName {
         let command_name = format!("{self:?}").to_case(Case::UpperCamel);
         CommandName(MapString(command_name))
     }

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -374,7 +374,7 @@ async fn assert_loaded_schema_backed_dance_discovery(
     );
     assert_eq!(
         inherited_query
-            .response()
+            .response_type()
             .expect("Query response")
             .response_body()
             .expect("Query response_body")


### PR DESCRIPTION
# Summary

Implements the PR4 client-ingress `DanceV2` refactor and lands the first host-local core dance cutovers.

This PR merges the work originally tracked across #545 and #548, but with one important implementation-grounded scope adjustment: only the host-local core cutovers that fit the current PR4 command-ingress and static execution model are included here. That means `delete_holon` and `commit` are now routed through canonical `DanceV2`, while `get_holon_by_id` and `load_holons` are deferred to a follow-up issue focused on guest-only and context-specific dance execution patterns.

## What changed

- Add canonical transaction-scoped `DanceV2` ingress using a typed `DanceInvocation` reference rather than legacy `DanceRequest`
- Add typed new-world execution-boundary wrappers in `holons_core`:
  - `DanceInvocation`
  - `DanceResponseReference`
- Add canonical host-local invocation builders in `holons_core`
- Add shared host-local `DanceV2` execution choreography in `holons_core`
- Keep implementation selection static and descriptor-driven through `ForDance`
- Add host-side `DanceImplementation` wrapper and per-dance implementation modules
- Route core `DeleteHolon` command through host-local canonical `DanceV2`
- Route core `Commit` command through host-local canonical `DanceV2`
- Preserve existing command result ergonomics:
  - `DeleteHolon` still returns `None`
  - `Commit` still returns the underlying transient commit-response reference
- Add first-class TS SDK `DanceV2` support and helper surfaces
- Keep legacy `TransactionAction::Dance(DanceRequest)` ingress active for deferred legacy/query paths

## Scope adjustment from the original issue text

Implementation work showed that the original #548 cutover list mixed together two different architectural categories:

- host-local core dances that can execute entirely inside host runtime once canonical `DanceV2` ingress exists
- guest-only or context-specific dances whose real execution boundary is host-to-guest or internal runtime-to-runtime

This PR only lands the first category.

### Included in this PR

- `delete_holon`
- `commit`

These now follow the core façade pattern:

- command remains the client-facing ingress
- host constructs canonical `DanceInvocation` in `holons_core`
- host executes through canonical `DanceV2`
- result is mapped back into the command result surface

### Explicitly deferred from this PR

- `get_holon_by_id`
- `load_holons`

These were intentionally not cut over here because they point at a separate design problem: guest-only and context-specific dances.

- `get_holon_by_id` is better understood as an internal runtime or cross-context lookup dance
- `load_holons` already has a meaningful host-preparation and guest-execution split, so its real dance boundary is host-to-guest rather than client-to-host

A follow-up issue should define that guest-only/context-specific pattern explicitly.

## Architectural outcomes

- `DanceV2` is now real at the command ingress boundary
- canonical invocation construction lives in `holons_core`
- core command façades can delegate internally to canonical dance execution without exposing dance choreography to client code
- typed response-holon handling is now in place for the new-world path
- legacy command ingress for old-world dance/query flows remains available where later issues still depend on it

## Testing

Verified in the landing branch:

- `npm run build:happ`
- `npm run build:host`
- `npm test`
- `npm start`

Additional coverage added/updated for:

- `DanceV2` command and wire shapes
- runtime execution of host-local `DanceV2`
- `DeleteHolon` cutover behavior
- `Commit` cutover behavior
- TS SDK command routing and helper behavior

## Notes for reviewers

- The remaining legacy host command dance ingress is the retained `TransactionAction::Dance(DanceRequest)` path used for deferred legacy/query/navigation flows
- Query and navigation dance migration remains scoped to PR5
- `LoadHolons` was intentionally kept out of this PR after implementation work clarified that it is a better first exemplar of a guest-only dance pattern rather than a host-local core cutover
- `get_holon_by_id` was also intentionally deferred for the same reason

## Issues

- Closes #545
- Partially addresses #548 with an implementation-grounded scope adjustment
- Follow-up work is still needed for guest-only and context-specific dance execution patterns