### PR TITLE
560 - recovery dev mode gating

### DIFF
--- a/host/conductora/plugins/tauri-plugin-holochain/DEV_MODE.md
+++ b/host/conductora/plugins/tauri-plugin-holochain/DEV_MODE.md
@@ -17,16 +17,14 @@ Core goals:
 Dev mode is controlled by one launch-time environment variable:
 
 ```sh
-HC_DEV_MODE=1
+MAP_START_MODE=dev
 ```
 
-Truthy values are: `1`, `true`, `yes`, `on` (case-insensitive).
-
-When `HC_DEV_MODE` is unset (or falsey), runtime uses normal mode.
+When `MAP_START_MODE` is unset or set to `prod`, runtime uses normal mode.
 
 ## Runtime Behavior
 
-| Area | Normal Mode | Dev Mode (`HC_DEV_MODE=1`) |
+| Area | Normal Mode | Dev Mode (`MAP_START_MODE=dev`) |
 |---|---|---|
 | Keystore | `LairServerInProc` (in-process lair) | `DangerTestKeystore` (in-memory, ephemeral) |
 | Device seed | Created in lair under tag `"DEVICE_SEED"` | Not used; setup generates an explicit agent key via `generate_agent_pub_key()` |

--- a/host/conductora/src/env.rs
+++ b/host/conductora/src/env.rs
@@ -1,0 +1,6 @@
+pub fn hc_dev_mode_enabled() -> bool {
+    match std::env::var("HC_DEV_MODE") {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
+}

--- a/host/conductora/src/env.rs
+++ b/host/conductora/src/env.rs
@@ -1,6 +1,6 @@
-pub fn hc_dev_mode_enabled() -> bool {
-    match std::env::var("HC_DEV_MODE") {
-        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+pub fn dev_mode_enabled() -> bool {
+    match std::env::var("MAP_START_MODE") {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "dev"),
         Err(_) => false,
     }
 }

--- a/host/conductora/src/lib.rs
+++ b/host/conductora/src/lib.rs
@@ -1,5 +1,6 @@
 // Module declarations
 mod config;
+pub mod env;
 mod map_commands;
 mod runtime;
 mod setup;

--- a/host/conductora/src/main.rs
+++ b/host/conductora/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 pub mod config;
+pub mod env;
 mod logging;
 mod map_commands;
 mod runtime;

--- a/host/conductora/src/runtime/init_runtime.rs
+++ b/host/conductora/src/runtime/init_runtime.rs
@@ -46,19 +46,25 @@ pub fn init_from_state(handle: &AppHandle) -> bool {
         Arc::new(RuntimeSession::new(Arc::clone(&space_manager), recovery_receptor.clone()));
 
     if recovery_receptor.is_some() {
-        match session.restore_open_sessions() {
-            Ok(restored) => {
-                tracing::info!(
-                    "[RUNTIME] Runtime session initialized. Restored {} recovery session(s).",
-                    restored
-                );
-            }
-            Err(err) => {
-                tracing::error!(
-                    "[RUNTIME] Failed to restore recovery sessions during startup: {}",
-                    err
-                );
-                return false;
+        if crate::env::hc_dev_mode_enabled() {
+            tracing::info!(
+                "[RUNTIME] Startup session recovery suppressed: HC_DEV_MODE is enabled."
+            );
+        } else {
+            match session.restore_open_sessions() {
+                Ok(restored) => {
+                    tracing::info!(
+                        "[RUNTIME] Runtime session initialized. Restored {} recovery session(s).",
+                        restored
+                    );
+                }
+                Err(err) => {
+                    tracing::error!(
+                        "[RUNTIME] Failed to restore recovery sessions during startup: {}",
+                        err
+                    );
+                    return false;
+                }
             }
         }
     }

--- a/host/conductora/src/runtime/init_runtime.rs
+++ b/host/conductora/src/runtime/init_runtime.rs
@@ -47,9 +47,7 @@ pub fn init_from_state(handle: &AppHandle) -> bool {
 
     if recovery_receptor.is_some() {
         if crate::env::dev_mode_enabled() {
-            tracing::info!(
-                "[RUNTIME] Startup session recovery suppressed: MAP_START_MODE=dev."
-            );
+            tracing::info!("[RUNTIME] Startup session recovery suppressed: MAP_START_MODE=dev.");
         } else {
             match session.restore_open_sessions() {
                 Ok(restored) => {

--- a/host/conductora/src/runtime/init_runtime.rs
+++ b/host/conductora/src/runtime/init_runtime.rs
@@ -46,9 +46,9 @@ pub fn init_from_state(handle: &AppHandle) -> bool {
         Arc::new(RuntimeSession::new(Arc::clone(&space_manager), recovery_receptor.clone()));
 
     if recovery_receptor.is_some() {
-        if crate::env::hc_dev_mode_enabled() {
+        if crate::env::dev_mode_enabled() {
             tracing::info!(
-                "[RUNTIME] Startup session recovery suppressed: HC_DEV_MODE is enabled."
+                "[RUNTIME] Startup session recovery suppressed: MAP_START_MODE=dev."
             );
         } else {
             match session.restore_open_sessions() {

--- a/host/conductora/src/setup/providers/holochain/plugins.rs
+++ b/host/conductora/src/setup/providers/holochain/plugins.rs
@@ -12,7 +12,7 @@ pub fn holochain_plugin(
         network_config_from_storage_config(hc_cfg),
     );
     //.signal_url_configured(hc_cfg.signal_url.is_some());
-    if crate::env::hc_dev_mode_enabled() {
+    if crate::env::dev_mode_enabled() {
         let dir = dev_conductor_dir(provider_key, &hc_cfg.app_id)?;
         plugin_config = plugin_config.dev_mode(true).dev_data_root(dir);
     }

--- a/host/conductora/src/setup/providers/holochain/plugins.rs
+++ b/host/conductora/src/setup/providers/holochain/plugins.rs
@@ -12,7 +12,7 @@ pub fn holochain_plugin(
         network_config_from_storage_config(hc_cfg),
     );
     //.signal_url_configured(hc_cfg.signal_url.is_some());
-    if hc_dev_mode_enabled() {
+    if crate::env::hc_dev_mode_enabled() {
         let dir = dev_conductor_dir(provider_key, &hc_cfg.app_id)?;
         plugin_config = plugin_config.dev_mode(true).dev_data_root(dir);
     }
@@ -96,11 +96,4 @@ pub fn dev_conductor_dir(
         .map_err(|e| anyhow::anyhow!("Failed to create dev conductor root {:?}: {}", root, e))?;
 
     Ok(root.join(key))
-}
-
-pub fn hc_dev_mode_enabled() -> bool {
-    match std::env::var("HC_DEV_MODE") {
-        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
-        Err(_) => false,
-    }
 }

--- a/host/conductora/src/setup/providers/holochain/setup.rs
+++ b/host/conductora/src/setup/providers/holochain/setup.rs
@@ -2,7 +2,6 @@ use crate::config::providers::holochain::{CellDetail, HolochainConfig};
 use crate::config::StorageProvider;
 use crate::runtime::RuntimeInitiatorState;
 use crate::setup::common_setup::{register_receptor, serialize_props};
-use crate::setup::providers::holochain::plugins::hc_dev_mode_enabled;
 use crate::setup::window_setup::ProviderWindowSetup;
 use async_trait::async_trait;
 use client_shared_types::base_receptor::ReceptorType;
@@ -30,7 +29,7 @@ impl HolochainSetup {
             return Err(anyhow::anyhow!("Invalid storage provider config for Holochain"));
         };
         let app_id = &hc_cfg.app_id;
-        let dev_mode = hc_dev_mode_enabled();
+        let dev_mode = crate::env::hc_dev_mode_enabled();
 
         let happ = load_happ_bundle(hc_cfg).map_err(|e| {
             tracing::error!("[HOLOCHAIN SETUP] Failed to load happ bundle: {}", e);

--- a/host/conductora/src/setup/providers/holochain/setup.rs
+++ b/host/conductora/src/setup/providers/holochain/setup.rs
@@ -29,7 +29,7 @@ impl HolochainSetup {
             return Err(anyhow::anyhow!("Invalid storage provider config for Holochain"));
         };
         let app_id = &hc_cfg.app_id;
-        let dev_mode = crate::env::hc_dev_mode_enabled();
+        let dev_mode = crate::env::dev_mode_enabled();
 
         let happ = load_happ_bundle(hc_cfg).map_err(|e| {
             tracing::error!("[HOLOCHAIN SETUP] Failed to load happ bundle: {}", e);

--- a/host/conductora/src/setup/providers/local/setup.rs
+++ b/host/conductora/src/setup/providers/local/setup.rs
@@ -24,9 +24,7 @@ impl LocalSetup {
         //let t_setup = std::time::Instant::now();
         let is_recovery = local_cfg.features.iter().any(|f| f == "recovery");
         if is_recovery {
-            //let receptor_cfg: BaseReceptor =
             Self::build_recovery_receptor(&handle, name, local_cfg).await?;
-            // register_receptor(&handle, receptor_cfg).await?;
         } else {
             return Err(anyhow::anyhow!(
                 "Local storage '{}' enabled without 'recovery' feature: Registering a non-recovery receptor is currently not allowed as we have not defined other local receptors.",name));
@@ -75,7 +73,12 @@ impl LocalSetup {
 /// - Returns `Ok(Some(store))` if a snapshot store was successfully created.
 /// - Returns `Err` if the app data directory cannot be resolved or the store cannot be created.
 ///
-/// The database is placed at: `{app_data_dir}/storage/{name}/snapshots.db`
+/// The database is placed at:
+/// - production: `{app_data_dir}/storage/{name}/snapshots.db`
+/// - HC dev mode: `/tmp/conductora_dev/local_recovery/{name}/snapshots.db`
+///
+/// The dev path mirrors the Holochain conductor dev-data convention, so `clean:hc:deep`
+/// wipes both automatically.
 ///
 /// Blocking I/O (dir creation + SQLite open) is offloaded via `spawn_blocking`.
 pub async fn create_snapshot_store<C: ProviderConfig>(
@@ -84,12 +87,15 @@ pub async fn create_snapshot_store<C: ProviderConfig>(
     name: &str,
 ) -> Result<Arc<TransactionRecoveryStore>, anyhow::Error> {
     // Path resolution is non-blocking — do it on the async thread
-    let app_data_dir = handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| anyhow::anyhow!("Failed to resolve app data dir: {}", e))?;
-
-    let snapshot_dir = app_data_dir.join("storage").join(name);
+    let snapshot_dir = if crate::env::hc_dev_mode_enabled() {
+        std::path::PathBuf::from("/tmp/conductora_dev/local_recovery").join(name)
+    } else {
+        let app_data_dir = handle
+            .path()
+            .app_data_dir()
+            .map_err(|e| anyhow::anyhow!("Failed to resolve app data dir: {}", e))?;
+        app_data_dir.join("storage").join(name)
+    };
     let db_path = snapshot_dir.join("snapshots.db");
     tracing::info!("[SNAPSHOT] Creating snapshot store at: {:?}", db_path);
 

--- a/host/conductora/src/setup/providers/local/setup.rs
+++ b/host/conductora/src/setup/providers/local/setup.rs
@@ -87,7 +87,7 @@ pub async fn create_snapshot_store<C: ProviderConfig>(
     name: &str,
 ) -> Result<Arc<TransactionRecoveryStore>, anyhow::Error> {
     // Path resolution is non-blocking — do it on the async thread
-    let snapshot_dir = if crate::env::hc_dev_mode_enabled() {
+    let snapshot_dir = if crate::env::dev_mode_enabled() {
         std::path::PathBuf::from("/tmp/conductora_dev").join(name)
     } else {
         let app_data_dir = handle

--- a/host/conductora/src/setup/providers/local/setup.rs
+++ b/host/conductora/src/setup/providers/local/setup.rs
@@ -21,7 +21,7 @@ impl LocalSetup {
         let StorageProvider::Local(local_cfg) = provider else {
             return Err(anyhow::anyhow!("Invalid storage provider config for Local"));
         };
-        //let t_setup = std::time::Instant::now();
+        //let t_setup = std::time::Instant::now(); //remove feature in 570
         let is_recovery = local_cfg.features.iter().any(|f| f == "recovery");
         if is_recovery {
             Self::build_recovery_receptor(&handle, name, local_cfg).await?;

--- a/host/conductora/src/setup/providers/local/setup.rs
+++ b/host/conductora/src/setup/providers/local/setup.rs
@@ -38,7 +38,7 @@ impl LocalSetup {
         name: &str,
         local_config: &LocalConfig,
     ) -> anyhow::Result<()> {
-        tracing::info!("[LOCAL SETUP] Recovery feature enabled for Local storage.");
+        tracing::info!("[LOCAL SETUP] Session feature enabled for Local storage.");
         let snapshot_store = create_snapshot_store(handle, local_config, name).await?;
         // continue with receptor config creation as normal
         let props = serialize_props(local_config);
@@ -88,7 +88,7 @@ pub async fn create_snapshot_store<C: ProviderConfig>(
 ) -> Result<Arc<TransactionRecoveryStore>, anyhow::Error> {
     // Path resolution is non-blocking — do it on the async thread
     let snapshot_dir = if crate::env::hc_dev_mode_enabled() {
-        std::path::PathBuf::from("/tmp/conductora_dev/local_recovery").join(name)
+        std::path::PathBuf::from("/tmp/conductora_dev").join(name)
     } else {
         let app_data_dir = handle
             .path()

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "host/map-sdk"
   ],
   "scripts": {
-    "start": "npm run build:happ && RUST_LOG=${RUST_LOG:-host:warn} WASM_LOG=${WASM_LOG:-warn} HC_DEV_MODE=${HC_DEV_MODE:-1} npm run start -w map-host",
-    "start:info": "npm run build:happ && RUST_LOG=host=info npm run start:host",
-    "start:debug": "npm run build:happ && RUST_LOG=host=debug npm run start:host",
-    "start:host": "npm run start -w map-host",
-    "start:nobuild": "RUST_LOG=host:debug WASM_LOG=info HC_DEV_MODE=1 npm run start -w map-host",
+    "start": "npm run build:happ && RUST_LOG=host:warn WASM_LOG=warn npm run start:host",
+    "start:info": "npm run build:happ && RUST_LOG=host:info WASM_LOG=info npm run start:host",
+    "start:debug": "npm run build:happ && RUST_LOG=host:debug WASM_LOG=info npm run start:host",
+    "start:host": "HC_DEV_MODE=1 npm run start -w map-host",
+    "start:production": "npm run build:happ && RUST_LOG=host:info WASM_LOG=warn npm run start -w map-host",
 
     "build": "npm run build:happ && npm run build:host",
     "build:host": "npm run build -w map-host",
@@ -42,7 +42,8 @@
     "clean": "npm run clean:rust:deep && npm run clean:hc:deep -w map-host && npm run clean:ui",
     "clean:rust": "npm run clean:rust -w map-host && npm run clean:rust -w map-happ",
     "clean:rust:deep": "npm run clean:rust:deep -w map-host && npm run clean:rust:deep -w map-happ",
-    "clean:ui": "npm run clean:ui -w map-host"
+    "clean:ui": "npm run clean:ui -w map-host",
+    "clean:recovery": "bash scripts/clean-recovery.sh"
   },
   "devDependencies": {
     "autoprefixer": "^10.4",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start": "npm run build:happ && RUST_LOG=host:warn WASM_LOG=warn npm run start:host",
     "start:info": "npm run build:happ && RUST_LOG=host:info WASM_LOG=info npm run start:host",
     "start:debug": "npm run build:happ && RUST_LOG=host:debug WASM_LOG=info npm run start:host",
-    "start:host": "HC_DEV_MODE=1 npm run start -w map-host",
-    "start:production": "npm run build:happ && RUST_LOG=host:info WASM_LOG=warn npm run start -w map-host",
+    "start:host": "MAP_START_MODE=dev npm run start -w map-host",
+    "start:production": "npm run build:happ && RUST_LOG=host:info WASM_LOG=warn MAP_START_MODE=prod npm run start -w map-host",
 
     "build": "npm run build:happ && npm run build:host",
     "build:host": "npm run build -w map-host",
@@ -39,7 +39,7 @@
     "regen:sdk-fixtures": "npm run regen:sdk-fixtures -w map-host",
     "hooks:install": "bash ./scripts/install-git-hooks.sh",
 
-    "clean": "npm run clean:rust:deep && npm run clean:hc:deep -w map-host && npm run clean:ui",
+    "clean": "npm run clean:rust:deep && npm run clean:hc:deep -w map-host && npm run clean:ui && npm run clean:recovery",
     "clean:rust": "npm run clean:rust -w map-host && npm run clean:rust -w map-happ",
     "clean:rust:deep": "npm run clean:rust:deep -w map-host && npm run clean:rust:deep -w map-happ",
     "clean:ui": "npm run clean:ui -w map-host",

--- a/scripts/clean-recovery.sh
+++ b/scripts/clean-recovery.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+case "$(uname -s)" in
+  Darwin)
+    DATA_DIR="$HOME/Library/Application Support/com.map-holons.tauri.dev"
+    ;;
+  Linux)
+    DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/com.map-holons.tauri.dev"
+    ;;
+  *)
+    echo "clean:recovery: unsupported platform $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+TARGET="$DATA_DIR/storage/local_recovery"
+rm -rf "$TARGET"
+echo "Recovery session data cleared: $TARGET"


### PR DESCRIPTION
## Work done

- `src/env.rs` — shared `hc_dev_mode_enabled()` replacing per-file copies
- `init_runtime.rs` — startup `restore_open_sessions()` skipped when HC_DEV_MODE on
- `local/setup.rs` — `create_snapshot_store` uses `/tmp/conductora_dev/session/` in dev mode, `app_data_dir/storage/session/` in production
- `package.json` — scripts clarified; `start:host` explicitly sets HC_DEV_MODE=1; `start:production` added; `clean:recovery` added
- `scripts/clean-recovery.sh` — cross-platform wipe of production snapshot data
- existing script `clean:hc:deep` removes all of `/tmp/conductora_dev` snapshot data

## notes

- Session recovery is a production resilience feature. Its value is entirely about surviving unexpected shutdowns — the user closes the app mid-transaction, crashes, loses power, and expects to resume on the next start. In dev mode:

  - You're restarting constantly and deliberately
  - You want a clean, predictable start every time — stale sessions from the last dev run are noise, not signal
  - The feature itself doesn't need to be exercised on every dev start
  - The only time you'd want to test it is explicitly — start in start:production, create an open session, kill the app,  restart in start:production, verify it restores. clean:recovery resets state between test attempts. That's it.
