### PR TITLE
516 relationship persistence follow up 2 nursery level duplicate detection and idempotent smartlink persistence

### DIFF
--- a/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
@@ -172,6 +172,12 @@ fn get_smartlink_from_link(
     Ok(smartlink)
 }
 
+/// Persists a SmartLink, suppressing the write when an equivalent link already exists.
+///
+/// Equivalence is source `LocalId` + target action hash + byte-identical encoded tag,
+/// which covers relationship name, reference-type marker (including external space id),
+/// and smart property values. `PropertyMap` is a `BTreeMap`, so equivalent inputs encode
+/// to byte-identical tags, making repeated commit passes idempotent at this choke point.
 pub fn save_smartlink(input: SmartLink) -> Result<(), HolonError> {
     // TODO: populate from property_map Null-separated property values (serialized into a String) for each of the properties listed in the access path
 
@@ -180,15 +186,44 @@ pub fn save_smartlink(input: SmartLink) -> Result<(), HolonError> {
         input.to_address.clone(),
         input.smart_property_values,
     )?;
-    create_link(
-        try_action_hash_from_local_id(&input.from_address)?,
-        try_action_hash_from_local_id(&input.to_address.local_id())?,
-        LinkTypes::SmartLink,
-        link_tag,
-    )
-    .map_err(|e| holon_error_from_wasm_error(e))?;
+    let source_hash = try_action_hash_from_local_id(&input.from_address)?;
+    let target_hash = try_action_hash_from_local_id(&input.to_address.local_id())?;
+
+    if equivalent_smartlink_exists(&source_hash, &target_hash, &link_tag)? {
+        debug!(
+            "SmartLink already persisted for relationship {:?} from {:?}; skipping duplicate write",
+            input.relationship_name.0 .0, input.from_address
+        );
+        return Ok(());
+    }
+
+    create_link(source_hash, target_hash, LinkTypes::SmartLink, link_tag)
+        .map_err(|e| holon_error_from_wasm_error(e))?;
 
     Ok(())
+}
+
+/// Returns true when a live SmartLink from `source_hash` to `target_hash` carrying exactly
+/// `link_tag` already exists.
+///
+/// The full encoded tag serves as the narrowest possible `tag_prefix` filter; exact tag
+/// bytes are then compared because a different tag may extend this one as a prefix (for
+/// example, the same relationship and target with additional smart property values).
+fn equivalent_smartlink_exists(
+    source_hash: &ActionHash,
+    target_hash: &ActionHash,
+    link_tag: &LinkTag,
+) -> Result<bool, HolonError> {
+    let links_query = LinkQuery::try_new(source_hash.clone(), LinkTypes::SmartLink)
+        .map_err(|e| holon_error_from_wasm_error(e))?
+        .tag_prefix(link_tag.clone());
+
+    let links = get_links(links_query, GetStrategy::default())
+        .map_err(|e| holon_error_from_wasm_error(e))?;
+
+    Ok(links.into_iter().any(|link| {
+        link.tag == *link_tag && link.target.into_action_hash().as_ref() == Some(target_hash)
+    }))
 }
 
 // HELPER FUNCTIONS //
@@ -482,5 +517,73 @@ mod tests {
         assert_eq!(Some(space_id), decoded_link_tag_object.proxy_id);
         assert!(decoded_link_tag_object.smart_property_values.is_some());
         assert_eq!(Some(property_values), decoded_link_tag_object.smart_property_values);
+    }
+
+    /// Pins the equivalence-model assumption behind duplicate suppression in
+    /// `save_smartlink`: equivalent inputs must encode to byte-identical tags
+    /// regardless of property insertion order (`PropertyMap` is a `BTreeMap`).
+    #[test]
+    fn test_encode_link_tag_is_deterministic_for_equivalent_inputs() {
+        let local_id =
+            LocalId("uhCkkLQ8hxxrt27W8TtkpcX1XAqbUyfD5_Rv5Us0X_-YeCT6RtMxU".as_bytes().to_vec());
+        let holon_id = HolonId::Local(local_id);
+        let relationship_name = RelationshipName(MapString("ex_relationship_name".to_string()));
+
+        let mut property_values_ascending: PropertyMap = BTreeMap::new();
+        property_values_ascending.insert(
+            PropertyName(MapString("ex_name_1".to_string())),
+            BaseValue::StringValue(MapString("ex_value_1".to_string())),
+        );
+        property_values_ascending.insert(
+            PropertyName(MapString("ex_name_2".to_string())),
+            BaseValue::StringValue(MapString("ex_value_2".to_string())),
+        );
+
+        let mut property_values_descending: PropertyMap = BTreeMap::new();
+        property_values_descending.insert(
+            PropertyName(MapString("ex_name_2".to_string())),
+            BaseValue::StringValue(MapString("ex_value_2".to_string())),
+        );
+        property_values_descending.insert(
+            PropertyName(MapString("ex_name_1".to_string())),
+            BaseValue::StringValue(MapString("ex_value_1".to_string())),
+        );
+
+        let tag_from_ascending =
+            encode_link_tag(&relationship_name, holon_id.clone(), Some(property_values_ascending))
+                .unwrap();
+        let tag_from_descending =
+            encode_link_tag(&relationship_name, holon_id, Some(property_values_descending))
+                .unwrap();
+
+        assert_eq!(tag_from_ascending.into_inner(), tag_from_descending.into_inner());
+    }
+
+    /// Pins why `equivalent_smartlink_exists` compares exact tag bytes after the
+    /// full-tag `tag_prefix` query: a tag carrying additional smart property values
+    /// extends the property-free tag as a prefix, so it would be returned by the
+    /// prefix query but must not count as an equivalent link.
+    #[test]
+    fn test_extended_link_tag_matches_prefix_but_not_exact_bytes() {
+        let local_id =
+            LocalId("uhCkkLQ8hxxrt27W8TtkpcX1XAqbUyfD5_Rv5Us0X_-YeCT6RtMxU".as_bytes().to_vec());
+        let holon_id = HolonId::Local(local_id);
+        let relationship_name = RelationshipName(MapString("ex_relationship_name".to_string()));
+
+        let base_tag = encode_link_tag(&relationship_name, holon_id.clone(), None).unwrap();
+
+        let mut property_values: PropertyMap = BTreeMap::new();
+        property_values.insert(
+            PropertyName(MapString("Key".to_string())),
+            BaseValue::StringValue(MapString("ex_key".to_string())),
+        );
+        let extended_tag =
+            encode_link_tag(&relationship_name, holon_id, Some(property_values)).unwrap();
+
+        let base_bytes = base_tag.into_inner();
+        let extended_bytes = extended_tag.into_inner();
+
+        assert!(extended_bytes.starts_with(&base_bytes));
+        assert_ne!(extended_bytes, base_bytes);
     }
 }

--- a/happ/crates/holons_loader/src/loader_ref_resolver.rs
+++ b/happ/crates/holons_loader/src/loader_ref_resolver.rs
@@ -936,10 +936,8 @@ impl LoaderRefResolver {
         }
 
         let number_of_targets = write_targets.len() as i64;
-        staged_source.add_related_holons_ungoverned(
-            declared_relationship_name.clone(),
-            write_targets,
-        )?;
+        staged_source
+            .add_related_holons_ungoverned(declared_relationship_name.clone(), write_targets)?;
 
         Ok(number_of_targets)
     }

--- a/happ/crates/holons_loader/src/loader_ref_resolver.rs
+++ b/happ/crates/holons_loader/src/loader_ref_resolver.rs
@@ -108,7 +108,7 @@ impl LoaderRefResolver {
     ///
     /// Multi-pass orchestration (deterministic):
     ///   1) Pass-2a: DescribedBy -> with_descriptor()
-    ///   2) Pass-2b: Extends -> add_related_holons()
+    ///   2) Pass-2b: Extends -> add_related_holons_ungoverned()
     ///   3) Pass-2c: process remaining declared relationship references
     pub fn resolve_relationships(
         context: &Arc<TransactionContext>,
@@ -903,7 +903,7 @@ impl LoaderRefResolver {
 
     /// Performs the actual write:
     /// - DescribedBy: exactly one target → `with_descriptor`
-    /// - Others: batch → `add_related_holons`
+    /// - Others: batch → `add_related_holons_ungoverned`
     fn write_relationship(
         mut staged_source: StagedReference,
         declared_relationship_name: &RelationshipName,
@@ -936,7 +936,10 @@ impl LoaderRefResolver {
         }
 
         let number_of_targets = write_targets.len() as i64;
-        staged_source.add_related_holons(declared_relationship_name.clone(), write_targets)?;
+        staged_source.add_related_holons_ungoverned(
+            declared_relationship_name.clone(),
+            write_targets,
+        )?;
 
         Ok(number_of_targets)
     }

--- a/host/crates/holons_loader_client/src/parser.rs
+++ b/host/crates/holons_loader_client/src/parser.rs
@@ -128,13 +128,15 @@ pub fn parse_files_into_load_set(
     // We collect all per-file issues rather than failing fast so the caller
     // can report a comprehensive summary to the user.
     let mut issues: Vec<ImportFileParsingIssue> = Vec::new();
+    let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
 
     for import_file in &content_set.files_to_load {
-        if let Err(issue) = parse_single_import_file_into_bundle(
+        if let Err(issue) = parse_single_import_file_into_bundle_with_tracker(
             context,
             &load_set_ref,
             import_file,
             &content_set.schema.raw_contents,
+            &mut inverse_target_tracker,
         ) {
             issues.push(issue);
         }
@@ -181,19 +183,24 @@ pub fn create_holon_load_set(
 ///
 /// On success, the `HolonLoadSet` now contains a new bundle for this file.
 /// On failure, a single `ImportFileParsingIssue` is returned.
-pub fn parse_single_import_file_into_bundle(
+fn parse_single_import_file_into_bundle_with_tracker(
     context: &Arc<TransactionContext>,
     load_set_ref: &HolonReference,
     import_file: &FileData,
     schema_json: &str,
+    inverse_target_tracker: &mut HasInverseTargetUniquenessTracker,
 ) -> Result<(), ImportFileParsingIssue> {
     let raw_json = import_file.raw_contents.as_str();
     let file_path = PathBuf::from(import_file.filename.clone());
 
     // 2) Validate against the loader JSON Schema and deserialize into
     //    `RawLoaderFileWithSlices<'_>`.
-    let raw_file_with_slices =
-        match validate_and_deserialize_loader_file(raw_json, schema_json, &import_file.filename) {
+    let (raw_file_with_slices, has_inverse_pairs) =
+        match validate_and_deserialize_loader_file_with_pairs(
+            raw_json,
+            schema_json,
+            &import_file.filename,
+        ) {
             Ok(wrapper) => wrapper,
             Err(err) => {
                 return Err(ImportFileParsingIssue {
@@ -207,6 +214,24 @@ pub fn parse_single_import_file_into_bundle(
                 });
             }
         };
+
+    for pair in has_inverse_pairs {
+        if let Err(err) = inverse_target_tracker.record(
+            &import_file.filename,
+            &pair.declared_source_key,
+            &pair.inverse_target_key,
+        ) {
+            return Err(ImportFileParsingIssue {
+                file_path: file_path.clone(),
+                kind: ImportFileParsingIssueKind::SchemaValidationFailure,
+                message: format!(
+                    "Loader import file '{}' failed relationship-pair validation: {}",
+                    import_file.filename, err
+                ),
+                source_error: Some(err),
+            });
+        }
+    }
 
     // 3) Create the HolonLoaderBundle for this file and attach it to
     //    the HolonLoadSet.
@@ -343,11 +368,21 @@ pub fn parse_single_import_file_into_bundle(
 /// - Run schema validation using the `json_schema_validation` crate.
 /// - On success, deserialize into `RawLoaderFileWithSlices`.
 /// - On failure, return `HolonError::ValidationError`.
-pub fn validate_and_deserialize_loader_file<'a>(
+#[cfg(test)]
+fn validate_and_deserialize_loader_file<'a>(
     raw_json: &'a str,
     schema_json: &str,
     filename: &str,
 ) -> Result<RawLoaderFileWithSlices<'a>, HolonError> {
+    validate_and_deserialize_loader_file_with_pairs(raw_json, schema_json, filename)
+        .map(|(raw_file, _pairs)| raw_file)
+}
+
+fn validate_and_deserialize_loader_file_with_pairs<'a>(
+    raw_json: &'a str,
+    schema_json: &str,
+    filename: &str,
+) -> Result<(RawLoaderFileWithSlices<'a>, Vec<HasInversePair>), HolonError> {
     // 1. First run schema validation using in-memory schema + instance JSON.
     match validate_json_str_against_schema_str(schema_json, raw_json) {
         Ok(()) => { /* schema validation succeeded */ }
@@ -366,9 +401,9 @@ pub fn validate_and_deserialize_loader_file<'a>(
             ))
         })?;
 
-    validate_relationship_pair_metadata_authoring(&raw_file, filename)?;
+    let has_inverse_pairs = validate_relationship_pair_metadata_authoring(&raw_file, filename)?;
 
-    Ok(raw_file)
+    Ok((raw_file, has_inverse_pairs))
 }
 
 #[derive(Debug)]
@@ -377,12 +412,60 @@ struct RelationshipDescriptorImportMetadata {
     extends_inverse_relationship_type: bool,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct HasInversePair {
+    declared_source_key: String,
+    inverse_target_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct HasInverseTargetClaim {
+    filename: String,
+    declared_source_key: String,
+}
+
+#[derive(Debug, Default)]
+struct HasInverseTargetUniquenessTracker {
+    targets: HashMap<String, HasInverseTargetClaim>,
+}
+
+impl HasInverseTargetUniquenessTracker {
+    fn record(
+        &mut self,
+        filename: &str,
+        declared_source_key: &str,
+        inverse_target_key: &str,
+    ) -> Result<(), HolonError> {
+        if let Some(previous) = self.targets.get(inverse_target_key) {
+            return Err(import_relationship_validation_error(format!(
+                "Inverse relationship descriptor '{}' is targeted by more than one declared relationship descriptor via HasInverse: '{}' in '{}' and '{}' in '{}'",
+                inverse_target_key,
+                previous.declared_source_key,
+                previous.filename,
+                declared_source_key,
+                filename
+            )));
+        }
+
+        self.targets.insert(
+            inverse_target_key.to_string(),
+            HasInverseTargetClaim {
+                filename: filename.to_string(),
+                declared_source_key: declared_source_key.to_string(),
+            },
+        );
+        Ok(())
+    }
+}
+
 fn validate_relationship_pair_metadata_authoring(
     raw_file: &RawLoaderFileWithSlices<'_>,
     filename: &str,
-) -> Result<(), HolonError> {
+) -> Result<Vec<HasInversePair>, HolonError> {
     let mut decoded_holons = Vec::with_capacity(raw_file.holons.len());
     let mut relationship_descriptors = HashMap::new();
+    let mut has_inverse_pairs = Vec::new();
+    let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
 
     for raw_value in &raw_file.holons {
         let raw_holon = serde_json::from_str::<RawLoaderHolon>(raw_value.get()).map_err(|err| {
@@ -447,9 +530,15 @@ fn validate_relationship_pair_metadata_authoring(
                 )));
             }
         }
+
+        inverse_target_tracker.record(filename, &raw_holon.key, &target_key)?;
+        has_inverse_pairs.push(HasInversePair {
+            declared_source_key: raw_holon.key.clone(),
+            inverse_target_key: target_key.clone(),
+        });
     }
 
-    Ok(())
+    Ok(has_inverse_pairs)
 }
 
 fn relationship_targets<'a>(
@@ -529,8 +618,58 @@ mod tests {
         )
     }
 
-    fn assert_relationship_validation_error(
-        result: Result<RawLoaderFileWithSlices<'_>, HolonError>,
+    fn shared_inverse_target_import() -> String {
+        r#"{
+          "holons": [
+            {
+              "key": "(BookType)-[Authors]->(PersonType)",
+              "type": "TypeDescriptor.HolonType",
+              "properties": {
+                "instance_type_kind": "TypeKind.Relationship"
+              },
+              "relationships": [
+                { "name": "Extends", "target": { "$ref": "DeclaredRelationshipType" } },
+                {
+                  "name": "HasInverse",
+                  "target": {
+                    "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
+                  }
+                }
+              ]
+            },
+            {
+              "key": "(BookType)-[Editors]->(PersonType)",
+              "type": "TypeDescriptor.HolonType",
+              "properties": {
+                "instance_type_kind": "TypeKind.Relationship"
+              },
+              "relationships": [
+                { "name": "Extends", "target": { "$ref": "DeclaredRelationshipType" } },
+                {
+                  "name": "HasInverse",
+                  "target": {
+                    "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
+                  }
+                }
+              ]
+            },
+            {
+              "key": "(PersonType)-[AuthoredBy]->(BookType)",
+              "type": "TypeDescriptor.HolonType",
+              "properties": {
+                "instance_type_kind": "TypeKind.Relationship"
+              },
+              "relationships": [
+                { "name": "Extends", "target": { "$ref": "InverseRelationshipType" } }
+              ]
+            }
+          ]
+        }"#
+        .to_string()
+    }
+
+    fn assert_relationship_validation_error<T: std::fmt::Debug>(
+        result: Result<T, HolonError>,
     ) -> String {
         match result {
             Err(HolonError::ValidationError(ValidationError::RelationshipError(message))) => {
@@ -583,11 +722,12 @@ mod tests {
             .collect::<Vec<_>>();
         schema_paths.sort();
 
+        let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
         for schema_path in schema_paths {
             let raw_json = fs::read_to_string(&schema_path).unwrap_or_else(|error| {
                 panic!("failed to read core schema export {}: {error}", schema_path.display())
             });
-            validate_and_deserialize_loader_file(
+            let (_raw_file, has_inverse_pairs) = validate_and_deserialize_loader_file_with_pairs(
                 &raw_json,
                 BOOTSTRAP_SCHEMA,
                 &schema_path.display().to_string(),
@@ -598,7 +738,61 @@ mod tests {
                     schema_path.display()
                 )
             });
+            for pair in has_inverse_pairs {
+                inverse_target_tracker
+                    .record(
+                        &schema_path.display().to_string(),
+                        &pair.declared_source_key,
+                        &pair.inverse_target_key,
+                    )
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "core schema export {} failed cross-file inverse uniqueness validation: {error}",
+                            schema_path.display()
+                        )
+                    });
+            }
         }
+    }
+
+    #[test]
+    fn loader_import_validation_rejects_shared_inverse_target() {
+        let raw_json = shared_inverse_target_import();
+
+        let message = assert_relationship_validation_error(validate_and_deserialize_loader_file(
+            &raw_json,
+            BOOTSTRAP_SCHEMA,
+            "shared-inverse-target.json",
+        ));
+
+        assert!(message.contains("targeted by more than one declared relationship descriptor"));
+        assert!(message.contains("(BookType)-[Authors]->(PersonType)"));
+        assert!(message.contains("(BookType)-[Editors]->(PersonType)"));
+        assert!(message.contains("(PersonType)-[AuthoredBy]->(BookType)"));
+    }
+
+    #[test]
+    fn inverse_target_uniqueness_tracker_rejects_cross_file_duplicate() {
+        let mut tracker = HasInverseTargetUniquenessTracker::default();
+        tracker
+            .record(
+                "authors.json",
+                "(BookType)-[Authors]->(PersonType)",
+                "(PersonType)-[AuthoredBy]->(BookType)",
+            )
+            .expect("first declared relationship should claim inverse target");
+
+        let message = assert_relationship_validation_error(tracker.record(
+            "editors.json",
+            "(BookType)-[Editors]->(PersonType)",
+            "(PersonType)-[AuthoredBy]->(BookType)",
+        ));
+
+        assert!(message.contains("authors.json"));
+        assert!(message.contains("editors.json"));
+        assert!(message.contains("(BookType)-[Authors]->(PersonType)"));
+        assert!(message.contains("(BookType)-[Editors]->(PersonType)"));
+        assert!(message.contains("(PersonType)-[AuthoredBy]->(BookType)"));
     }
 
     #[test]

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -90,7 +90,9 @@ pub fn effective_descriptor_lineage(
     ancestors(&described_by_descriptor)
 }
 
-fn described_by_descriptor(holon: &HolonReference) -> Result<Option<HolonReference>, HolonError> {
+pub(crate) fn described_by_descriptor(
+    holon: &HolonReference,
+) -> Result<Option<HolonReference>, HolonError> {
     let collection_arc = holon.related_holons(CoreRelationshipTypeName::DescribedBy)?;
     let collection = collection_arc.read().map_err(lock_error)?;
     let members = collection.get_members();

--- a/shared_crates/holons_core/src/reference_layer/staged_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/staged_reference.rs
@@ -1,12 +1,16 @@
 use derive_new::new;
+use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 use std::{fmt, sync::Arc};
 use tracing::info;
-use type_names::relationship_names::CoreRelationshipTypeName;
+use type_names::relationship_names::{CoreRelationshipTypeName, ToRelationshipName};
 
 use crate::core_shared_objects::holon::StagedState;
 use crate::core_shared_objects::transactions::{
     TransactionContext, TransactionContextHandle, TxId,
+};
+use crate::descriptors::{
+    effective_relationship_declaration, inheritance::described_by_descriptor, RelationshipDirection,
 };
 use crate::reference_layer::readable_impl::ReadableHolonImpl;
 use crate::reference_layer::writable_impl::WritableHolonImpl;
@@ -25,8 +29,21 @@ use crate::{
 };
 use base_types::{BaseValue, MapString};
 use core_types::{
-    HolonError, HolonId, HolonNodeModel, PropertyName, PropertyValue, RelationshipName, TemporaryId,
+    HolonError, HolonId, HolonNodeModel, PropertyName, PropertyValue, RelationshipName,
+    TemporaryId, ValidationError,
 };
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum DuplicatePolicy {
+    Enforced { allows_duplicates: bool },
+    Ungoverned,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct RelationshipMutationPolicy {
+    note_definitional: Option<bool>,
+    duplicate_policy: DuplicatePolicy,
+}
 
 #[derive(new, Debug, Clone)]
 pub struct StagedReference {
@@ -192,10 +209,10 @@ impl StagedReference {
         format!("TemporaryId={}", self.id)
     }
 
-    fn classify_relationship_mutation(
+    fn relationship_mutation_policy(
         &self,
         relationship_name: &RelationshipName,
-    ) -> Result<Option<bool>, HolonError> {
+    ) -> Result<RelationshipMutationPolicy, HolonError> {
         let rc_holon = self.get_rc_holon()?;
         let staged_state = {
             let holon = rc_holon.read().map_err(|e| {
@@ -215,15 +232,115 @@ impl StagedReference {
             }
         };
 
-        if staged_state == StagedState::ForCreate {
-            return Ok(None);
+        let source_ref = HolonReference::Staged(self.clone());
+        let relationship_descriptor = match effective_relationship_declaration(
+            &source_ref,
+            relationship_name.clone(),
+        ) {
+            Ok(descriptor) => descriptor,
+            Err(
+                original_error @ HolonError::DescriptorDeclarationNotFound {
+                    kind: _,
+                    name: _,
+                    descriptor: _,
+                },
+            ) => {
+                let source_descriptor = described_by_descriptor(&source_ref)?;
+                if staged_state == StagedState::ForCreate && source_descriptor.is_none() {
+                    return Ok(RelationshipMutationPolicy {
+                        note_definitional: None,
+                        duplicate_policy: DuplicatePolicy::Ungoverned,
+                    });
+                }
+
+                if source_descriptor.is_some() {
+                    match source_ref
+                        .holon_descriptor()?
+                        .allows_relationship(relationship_name.clone())
+                    {
+                        Ok(qualified)
+                            if qualified.descriptor_direction == RelationshipDirection::Inverse =>
+                        {
+                            return Err(HolonError::ValidationError(
+                                    ValidationError::RelationshipError(format!(
+                                        "Relationship '{}' is an inverse relationship and cannot be staged as ordinary mutation input. Stage the declared relationship from the declared source endpoint instead.",
+                                        relationship_name
+                                    )),
+                                ));
+                        }
+                        Ok(_) => return Err(original_error),
+                        Err(_) => return Err(original_error),
+                    }
+                }
+
+                return Err(original_error);
+            }
+            Err(err) => return Err(err),
+        };
+
+        let duplicate_policy = DuplicatePolicy::Enforced {
+            allows_duplicates: relationship_descriptor.allows_duplicates()?,
+        };
+        let note_definitional = if staged_state == StagedState::ForCreate {
+            None
+        } else {
+            Some(relationship_descriptor.is_definitional()?)
+        };
+
+        Ok(RelationshipMutationPolicy { note_definitional, duplicate_policy })
+    }
+
+    fn filter_duplicate_disallowed_entries(
+        &self,
+        relationship_name: &RelationshipName,
+        entries: Vec<(HolonReference, Option<MapString>)>,
+    ) -> Result<Vec<(HolonReference, Option<MapString>)>, HolonError> {
+        let collection_arc = self.related_holons(relationship_name)?;
+        let collection = collection_arc.read().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire read lock on holon collection: {}",
+                e
+            ))
+        })?;
+
+        let mut seen_reference_ids = HashSet::new();
+        let mut key_to_reference_id = HashMap::new();
+        for member in collection.get_members() {
+            let reference_id = member.reference_id_string();
+            seen_reference_ids.insert(reference_id.clone());
+            if let Some(key) = member.key()? {
+                key_to_reference_id.entry(key).or_insert(reference_id);
+            }
+        }
+        drop(collection);
+
+        let mut filtered = Vec::new();
+        for (reference, key) in entries {
+            let reference_id = reference.reference_id_string();
+            if seen_reference_ids.contains(&reference_id) {
+                continue;
+            }
+
+            if let Some(key) = &key {
+                if let Some(existing_id) = key_to_reference_id.get(key) {
+                    if existing_id != &reference_id {
+                        return Err(HolonError::DuplicateError(
+                            relationship_name.to_string(),
+                            format!(
+                                "Duplicate target key '{}' resolves to non-identical references: existing {}, requested {}",
+                                key.0, existing_id, reference_id
+                            ),
+                        ));
+                    }
+                }
+                key_to_reference_id.insert(key.clone(), reference_id.clone());
+            }
+
+            seen_reference_ids.insert(reference_id);
+            filtered.push((reference, key));
         }
 
-        let source_ref = HolonReference::Staged(self.clone());
-        let relationship_descriptor =
-            source_ref.holon_descriptor()?.get_relationship_by_name(relationship_name.clone())?;
-
-        Ok(Some(relationship_descriptor.is_definitional()?))
+        Ok(filtered)
     }
 
     fn related_holons_with_keys(
@@ -242,8 +359,21 @@ impl StagedReference {
         &self,
         relationship_name: RelationshipName,
         entries: Vec<(HolonReference, Option<MapString>)>,
-        is_definitional: Option<bool>,
+        policy: RelationshipMutationPolicy,
     ) -> Result<(), HolonError> {
+        let entries = match policy.duplicate_policy {
+            DuplicatePolicy::Enforced { allows_duplicates: false } => {
+                self.filter_duplicate_disallowed_entries(&relationship_name, entries)?
+            }
+            DuplicatePolicy::Enforced { allows_duplicates: true } | DuplicatePolicy::Ungoverned => {
+                entries
+            }
+        };
+
+        if entries.is_empty() {
+            return Ok(());
+        }
+
         let rc_holon = self.get_rc_holon()?;
         let mut holon_mut = rc_holon.write().map_err(|e| {
             HolonError::FailedToAcquireLock(format!(
@@ -255,7 +385,7 @@ impl StagedReference {
         match &mut *holon_mut {
             Holon::Staged(staged_holon) => {
                 staged_holon.add_related_holons_with_keys(relationship_name, entries)?;
-                if let Some(is_definitional) = is_definitional {
+                if let Some(is_definitional) = policy.note_definitional {
                     staged_holon.note_relationship_mutation(is_definitional)?;
                 }
             }
@@ -306,7 +436,35 @@ impl StagedReference {
         holons: Vec<HolonReference>,
     ) -> Result<(), HolonError> {
         let holons_with_keys = Self::related_holons_with_keys(holons)?;
-        self.add_related_holons_with_classification(relationship_name, holons_with_keys, None)
+        self.add_related_holons_with_classification(
+            relationship_name,
+            holons_with_keys,
+            RelationshipMutationPolicy {
+                note_definitional: None,
+                duplicate_policy: DuplicatePolicy::Ungoverned,
+            },
+        )
+    }
+
+    /// Adds relationship targets without descriptor-policy classification.
+    ///
+    /// This is a narrowly scoped escape hatch for descriptor-graph construction
+    /// paths, such as loader Pass-2 bootstrap writes, where the caller already
+    /// owns relationship validation and deduplication but the self-describing
+    /// relationship declarations may not exist yet. Ordinary runtime mutation
+    /// must use [`crate::reference_layer::WritableHolon::add_related_holons`]
+    /// so #516 duplicate policy, metadata failures, and inverse-name rejection
+    /// are enforced.
+    pub fn add_related_holons_ungoverned<T: ToRelationshipName>(
+        &mut self,
+        relationship_name: T,
+        holons: Vec<HolonReference>,
+    ) -> Result<&mut Self, HolonError> {
+        self.add_related_holons_without_classification(
+            relationship_name.to_relationship_name(),
+            holons,
+        )?;
+        Ok(self)
     }
 
     fn remove_related_holons_without_classification(
@@ -523,15 +681,11 @@ impl WritableHolonImpl for StagedReference {
         holons: Vec<HolonReference>,
     ) -> Result<&mut Self, HolonError> {
         self.is_accessible(AccessType::Write)?;
-        let is_definitional = self.classify_relationship_mutation(&relationship_name)?;
+        let policy = self.relationship_mutation_policy(&relationship_name)?;
         // Precompute keys before taking the holon write lock to avoid re-entrant locking on self-edges.
         let holons_with_keys = Self::related_holons_with_keys(holons)?;
 
-        self.add_related_holons_with_classification(
-            relationship_name,
-            holons_with_keys,
-            is_definitional,
-        )?;
+        self.add_related_holons_with_classification(relationship_name, holons_with_keys, policy)?;
 
         Ok(self)
     }
@@ -542,7 +696,7 @@ impl WritableHolonImpl for StagedReference {
         holons: Vec<HolonReference>,
     ) -> Result<&mut Self, HolonError> {
         self.is_accessible(AccessType::Write)?;
-        let is_definitional = self.classify_relationship_mutation(&relationship_name)?;
+        let policy = self.relationship_mutation_policy(&relationship_name)?;
         let holons_with_keys = Self::related_holons_with_keys(holons)?;
         info!(
             "Removing {:?} related holons from relationship: {:?}",
@@ -552,7 +706,7 @@ impl WritableHolonImpl for StagedReference {
         self.remove_related_holons_with_classification(
             &relationship_name,
             holons_with_keys,
-            is_definitional,
+            policy.note_definitional,
         )?;
 
         Ok(self)
@@ -677,13 +831,13 @@ mod tests {
     use crate::{
         core_shared_objects::StagedHolon,
         descriptors::test_support::{
-            build_context, new_descriptor_holon, new_holon_type_descriptor,
+            build_context, core_holon_type_name, new_descriptor_holon, new_holon_type_descriptor,
             new_relationship_descriptor_holon, new_test_holon,
         },
         reference_layer::WritableHolon,
     };
     use core_types::LocalId;
-    use type_names::CorePropertyTypeName;
+    use type_names::{CoreHolonTypeName, CorePropertyTypeName};
 
     fn force_staged_reference_for_update(
         context: &Arc<TransactionContext>,
@@ -784,6 +938,109 @@ mod tests {
         Ok((staged_source_type, staged_target_type))
     }
 
+    fn staged_relationship_descriptor_with_metadata(
+        context: &Arc<TransactionContext>,
+        relationship_name: &str,
+        is_definitional: Option<BaseValue>,
+        allows_duplicates: Option<BaseValue>,
+    ) -> Result<(StagedReference, StagedReference), HolonError> {
+        let source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        let target_type = new_holon_type_descriptor(context, "target-type", "TargetType")?;
+        let staged_source_type = context.mutation().stage_new_holon(source_type)?;
+        let staged_target_type = context.mutation().stage_new_holon(target_type)?;
+
+        let mut relationship_descriptor = new_descriptor_holon(
+            context,
+            "relationship-descriptor",
+            relationship_name,
+            "Relationship",
+        )?;
+        if let Some(is_definitional) = is_definitional {
+            relationship_descriptor.with_property_value_impl(
+                CorePropertyTypeName::IsDefinitional.as_property_name(),
+                is_definitional,
+            )?;
+        }
+        if let Some(allows_duplicates) = allows_duplicates {
+            relationship_descriptor.with_property_value_impl(
+                CorePropertyTypeName::AllowsDuplicates.as_property_name(),
+                allows_duplicates,
+            )?;
+        }
+        let staged_relationship_descriptor =
+            context.mutation().stage_new_holon(relationship_descriptor)?;
+
+        let mut staged_source_type = staged_source_type;
+        staged_source_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceRelationships,
+            vec![staged_relationship_descriptor.into()],
+        )?;
+
+        Ok((staged_source_type, staged_target_type))
+    }
+
+    struct RelationshipPairFixture {
+        target_type: StagedReference,
+    }
+
+    fn relationship_pair_fixture(
+        context: &Arc<TransactionContext>,
+    ) -> Result<RelationshipPairFixture, HolonError> {
+        let declared_type = context.mutation().stage_new_holon(new_descriptor_holon(
+            context,
+            "declared-relationship-type",
+            &core_holon_type_name(CoreHolonTypeName::DeclaredRelationshipType),
+            "Relationship",
+        )?)?;
+        let inverse_type = context.mutation().stage_new_holon(new_descriptor_holon(
+            context,
+            "inverse-relationship-type",
+            &core_holon_type_name(CoreHolonTypeName::InverseRelationshipType),
+            "Relationship",
+        )?)?;
+        let mut source_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
+            context,
+            "book-type",
+            "BookType",
+        )?)?;
+        let mut target_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
+            context,
+            "person-type",
+            "PersonType",
+        )?)?;
+        let mut declared =
+            context.mutation().stage_new_holon(new_relationship_descriptor_holon(
+                context,
+                "authored-by",
+                "AuthoredBy",
+                HolonReference::from(&source_type),
+                HolonReference::from(&target_type),
+            )?)?;
+        let mut inverse = context.mutation().stage_new_holon(new_relationship_descriptor_holon(
+            context,
+            "authors",
+            "Authors",
+            HolonReference::from(&target_type),
+            HolonReference::from(&source_type),
+        )?)?;
+
+        declared
+            .add_related_holons(CoreRelationshipTypeName::Extends, vec![declared_type.into()])?;
+        inverse.add_related_holons(CoreRelationshipTypeName::Extends, vec![inverse_type.into()])?;
+        declared
+            .add_related_holons(CoreRelationshipTypeName::HasInverse, vec![(&inverse).into()])?;
+        inverse
+            .add_related_holons(CoreRelationshipTypeName::InverseOf, vec![(&declared).into()])?;
+        source_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceRelationships,
+            vec![(&declared).into()],
+        )?;
+        target_type
+            .add_related_holons(CoreRelationshipTypeName::TargetOf, vec![(&declared).into()])?;
+
+        Ok(RelationshipPairFixture { target_type })
+    }
+
     fn staged_update_source(
         context: &Arc<TransactionContext>,
         source_descriptor: StagedReference,
@@ -803,6 +1060,15 @@ mod tests {
         key: &str,
     ) -> Result<StagedReference, HolonError> {
         context.mutation().stage_new_holon(new_test_holon(context, key)?)
+    }
+
+    fn relationship_member_count(
+        source: &StagedReference,
+        relationship_name: &str,
+    ) -> Result<usize, HolonError> {
+        let collection = source.related_holons(relationship_name)?;
+        let count = collection.read().unwrap().get_members().len();
+        Ok(count)
     }
 
     #[test]
@@ -833,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn for_create_relationship_mutation_skips_descriptor_classification() -> Result<(), HolonError>
+    fn undescribed_for_create_relationship_mutation_keeps_legacy_append() -> Result<(), HolonError>
     {
         let context = build_context();
         let source = new_test_holon(&context, "new-source")?;
@@ -843,6 +1109,148 @@ mod tests {
         staged_source.add_related_holons("UndeclaredRelationship", vec![target.into()])?;
 
         assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
+        Ok(())
+    }
+
+    #[test]
+    fn described_for_create_unknown_relationship_errors_before_mutation() -> Result<(), HolonError>
+    {
+        let context = build_context();
+        let source_descriptor = context.mutation().stage_new_holon(new_holon_type_descriptor(
+            &context,
+            "source-type",
+            "SourceType",
+        )?)?;
+        let source = new_test_holon(&context, "new-source")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        staged_source.with_descriptor(source_descriptor.into())?;
+        let target = staged_target(&context, "new-target")?;
+
+        let result =
+            staged_source.add_related_holons("UndeclaredRelationship", vec![target.into()]);
+
+        assert!(matches!(
+            result,
+            Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
+                if kind == "relationship" && name == "UndeclaredRelationship"
+        ));
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn ungoverned_add_appends_described_for_create_unresolved_relationship(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let source_descriptor = context.mutation().stage_new_holon(new_holon_type_descriptor(
+            &context,
+            "source-type",
+            "SourceType",
+        )?)?;
+        let source = new_test_holon(&context, "new-source")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        staged_source.with_descriptor(source_descriptor.into())?;
+        let target = staged_target(&context, "new-target")?;
+
+        let ordinary_result =
+            staged_source.add_related_holons("UndeclaredRelationship", vec![target.clone().into()]);
+        assert!(matches!(
+            ordinary_result,
+            Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
+                if kind == "relationship" && name == "UndeclaredRelationship"
+        ));
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 0);
+
+        staged_source
+            .add_related_holons_ungoverned("UndeclaredRelationship", vec![target.into()])?;
+
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 1);
+        assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_disallowed_repeated_add_is_idempotent_no_op() -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_descriptor, _) =
+            staged_relationship_descriptor(&context, "AuthoredBy", Some(false))?;
+        let mut staged_source = staged_update_source(&context, source_descriptor)?;
+        let target = staged_target(&context, "author")?;
+
+        staged_source.add_related_holons("AuthoredBy", vec![target.clone().into()])?;
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 1);
+        force_staged_reference_for_update(&context, &staged_source)?;
+
+        staged_source.add_related_holons("AuthoredBy", vec![target.into()])?;
+
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 1);
+        assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_disallowed_same_key_different_reference_errors() -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_descriptor, _) =
+            staged_relationship_descriptor(&context, "AuthoredBy", Some(false))?;
+        let mut staged_source = staged_update_source(&context, source_descriptor)?;
+        let first_target = staged_target(&context, "author")?;
+        let second_target = staged_target(&context, "author")?;
+
+        staged_source.add_related_holons("AuthoredBy", vec![first_target.into()])?;
+        force_staged_reference_for_update(&context, &staged_source)?;
+        let result = staged_source.add_related_holons("AuthoredBy", vec![second_target.into()]);
+
+        assert!(matches!(
+            result,
+            Err(HolonError::DuplicateError(relationship, detail))
+                if relationship == "AuthoredBy"
+                    && detail.contains("Duplicate target key 'author'")
+                    && detail.contains("non-identical references")
+        ));
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 1);
+        assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_allowed_relationship_preserves_repeated_targets() -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_descriptor, _) = staged_relationship_descriptor_with_metadata(
+            &context,
+            "AuthoredBy",
+            Some(BaseValue::BooleanValue(true.into())),
+            Some(BaseValue::BooleanValue(true.into())),
+        )?;
+        let mut staged_source = staged_update_source(&context, source_descriptor)?;
+        let target = staged_target(&context, "author")?;
+
+        staged_source.add_related_holons("AuthoredBy", vec![target.clone().into()])?;
+        staged_source.add_related_holons("AuthoredBy", vec![target.into()])?;
+
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 2);
+        assert!(staged_source.is_in_state(&context, StagedState::ForUpdateNewVersion)?);
+        Ok(())
+    }
+
+    #[test]
+    fn inverse_relationship_name_is_rejected_as_mutation_input() -> Result<(), HolonError> {
+        let context = build_context();
+        let fixture = relationship_pair_fixture(&context)?;
+        let source = new_test_holon(&context, "person-instance")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        staged_source.with_descriptor((&fixture.target_type).into())?;
+        let target = staged_target(&context, "book-instance")?;
+
+        let result = staged_source.add_related_holons("Authors", vec![target.into()]);
+
+        assert!(matches!(
+            result,
+            Err(HolonError::ValidationError(ValidationError::RelationshipError(message)))
+                if message.contains("inverse relationship")
+                    && message.contains("declared source endpoint")
+        ));
+        assert_eq!(relationship_member_count(&staged_source, "Authors")?, 0);
         Ok(())
     }
 
@@ -914,7 +1322,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_is_definitional_errors_before_mutation() -> Result<(), HolonError> {
+    fn missing_allows_duplicates_errors_before_mutation() -> Result<(), HolonError> {
         let context = build_context();
         let (source_descriptor, _) = staged_relationship_descriptor(&context, "AuthoredBy", None)?;
         let mut staged_source = staged_update_source(&context, source_descriptor)?;
@@ -922,10 +1330,55 @@ mod tests {
 
         let result = staged_source.add_related_holons("AuthoredBy", vec![target.into()]);
 
-        assert!(matches!(result, Err(HolonError::EmptyField(field)) if field == "IsDefinitional"));
+        assert!(
+            matches!(result, Err(HolonError::EmptyField(field)) if field == "AllowsDuplicates")
+        );
         assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
         let collection = staged_source.related_holons("AuthoredBy")?;
         assert!(collection.read().unwrap().get_members().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_is_definitional_errors_after_duplicate_policy_resolution() -> Result<(), HolonError>
+    {
+        let context = build_context();
+        let (source_descriptor, _) = staged_relationship_descriptor_with_metadata(
+            &context,
+            "AuthoredBy",
+            None,
+            Some(BaseValue::BooleanValue(false.into())),
+        )?;
+        let mut staged_source = staged_update_source(&context, source_descriptor)?;
+        let target = staged_target(&context, "author")?;
+
+        let result = staged_source.add_related_holons("AuthoredBy", vec![target.into()]);
+
+        assert!(matches!(result, Err(HolonError::EmptyField(field)) if field == "IsDefinitional"));
+        assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_allows_duplicates_errors_before_mutation() -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_descriptor, _) = staged_relationship_descriptor_with_metadata(
+            &context,
+            "AuthoredBy",
+            Some(BaseValue::BooleanValue(false.into())),
+            Some(BaseValue::StringValue(MapString("not-a-boolean".into()))),
+        )?;
+        let mut staged_source = staged_update_source(&context, source_descriptor)?;
+        let target = staged_target(&context, "author")?;
+
+        let result = staged_source.add_related_holons("AuthoredBy", vec![target.into()]);
+
+        assert!(
+            matches!(result, Err(HolonError::UnexpectedValueType(_, expected)) if expected == "Boolean")
+        );
+        assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 0);
         Ok(())
     }
 

--- a/shared_crates/holons_core/src/reference_layer/staged_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/staged_reference.rs
@@ -209,28 +209,28 @@ impl StagedReference {
         format!("TemporaryId={}", self.id)
     }
 
+    fn staged_state(&self) -> Result<StagedState, HolonError> {
+        let rc_holon = self.get_rc_holon()?;
+        let holon = rc_holon.read().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire read lock on staged holon: {}",
+                e
+            ))
+        })?;
+
+        match &*holon {
+            Holon::Staged(staged_holon) => Ok(staged_holon.get_staged_state()),
+            _ => Err(HolonError::InvalidType(
+                "StagedReference should point to a StagedHolon".to_string(),
+            )),
+        }
+    }
+
     fn relationship_mutation_policy(
         &self,
         relationship_name: &RelationshipName,
     ) -> Result<RelationshipMutationPolicy, HolonError> {
-        let rc_holon = self.get_rc_holon()?;
-        let staged_state = {
-            let holon = rc_holon.read().map_err(|e| {
-                HolonError::FailedToAcquireLock(format!(
-                    "Failed to acquire read lock on staged holon: {}",
-                    e
-                ))
-            })?;
-
-            match &*holon {
-                Holon::Staged(staged_holon) => staged_holon.get_staged_state(),
-                _ => {
-                    return Err(HolonError::InvalidType(
-                        "StagedReference should point to a StagedHolon".to_string(),
-                    ))
-                }
-            }
-        };
+        let staged_state = self.staged_state()?;
 
         let source_ref = HolonReference::Staged(self.clone());
         let relationship_descriptor = match effective_relationship_declaration(
@@ -288,6 +288,21 @@ impl StagedReference {
         };
 
         Ok(RelationshipMutationPolicy { note_definitional, duplicate_policy })
+    }
+
+    fn classify_relationship_removal(
+        &self,
+        relationship_name: &RelationshipName,
+    ) -> Result<Option<bool>, HolonError> {
+        if self.staged_state()? == StagedState::ForCreate {
+            return Ok(None);
+        }
+
+        let source_ref = HolonReference::Staged(self.clone());
+        let relationship_descriptor =
+            effective_relationship_declaration(&source_ref, relationship_name.clone())?;
+
+        Ok(Some(relationship_descriptor.is_definitional()?))
     }
 
     fn filter_duplicate_disallowed_entries(
@@ -696,7 +711,7 @@ impl WritableHolonImpl for StagedReference {
         holons: Vec<HolonReference>,
     ) -> Result<&mut Self, HolonError> {
         self.is_accessible(AccessType::Write)?;
-        let policy = self.relationship_mutation_policy(&relationship_name)?;
+        let is_definitional = self.classify_relationship_removal(&relationship_name)?;
         let holons_with_keys = Self::related_holons_with_keys(holons)?;
         info!(
             "Removing {:?} related holons from relationship: {:?}",
@@ -706,7 +721,7 @@ impl WritableHolonImpl for StagedReference {
         self.remove_related_holons_with_classification(
             &relationship_name,
             holons_with_keys,
-            policy.note_definitional,
+            is_definitional,
         )?;
 
         Ok(self)
@@ -1165,6 +1180,30 @@ mod tests {
             .add_related_holons_ungoverned("UndeclaredRelationship", vec![target.into()])?;
 
         assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 1);
+        assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
+        Ok(())
+    }
+
+    #[test]
+    fn for_create_remove_skips_descriptor_classification_after_descriptor_added(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let source_descriptor = context.mutation().stage_new_holon(new_holon_type_descriptor(
+            &context,
+            "source-type",
+            "SourceType",
+        )?)?;
+        let source = new_test_holon(&context, "new-source")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        let target = staged_target(&context, "new-target")?;
+
+        staged_source.add_related_holons("UndeclaredRelationship", vec![target.clone().into()])?;
+        staged_source.with_descriptor(source_descriptor.into())?;
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 1);
+
+        staged_source.remove_related_holons("UndeclaredRelationship", vec![target.into()])?;
+
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 0);
         assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
         Ok(())
     }

--- a/shared_crates/holons_core/src/reference_layer/staged_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/staged_reference.rs
@@ -305,6 +305,15 @@ impl StagedReference {
         Ok(Some(relationship_descriptor.is_definitional()?))
     }
 
+    /// Filters add entries for a duplicate-disallowed relationship against the staged
+    /// collection: exact repeats (same reference identity) are dropped as idempotent
+    /// no-ops, while a same-key entry with a different identity fails with
+    /// `DuplicateError`.
+    ///
+    /// This check sees only the staged collection, so it is authoritative for
+    /// `ForCreate` sources but best-effort for `ForUpdate*` sources, whose prior
+    /// relationships live in the persisted graph. Commit-time SmartLink suppression
+    /// is the authoritative duplicate guard against persisted links (issue #516).
     fn filter_duplicate_disallowed_entries(
         &self,
         relationship_name: &RelationshipName,
@@ -1224,6 +1233,80 @@ mod tests {
 
         assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 1);
         assert!(staged_source.is_in_state(&context, StagedState::ForUpdate)?);
+        Ok(())
+    }
+
+    /// Pins the issue #516 §4.6 authority matrix for `ForCreate`: all of a new
+    /// holon's relationships are staged, so the mutation-time duplicate check is
+    /// authoritative there — the exact repeat is dropped without descriptor
+    /// escalation and the source stays `ForCreate`.
+    #[test]
+    fn duplicate_disallowed_repeated_add_is_idempotent_for_described_for_create_source(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_descriptor, _) =
+            staged_relationship_descriptor(&context, "AuthoredBy", Some(false))?;
+        let source = new_test_holon(&context, "source-instance")?;
+        let mut staged_source = context.mutation().stage_new_holon(source)?;
+        staged_source.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![source_descriptor.into()],
+        )?;
+        let target = staged_target(&context, "author")?;
+
+        staged_source.add_related_holons("AuthoredBy", vec![target.clone().into()])?;
+        staged_source.add_related_holons("AuthoredBy", vec![target.into()])?;
+
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 1);
+        assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
+        Ok(())
+    }
+
+    /// A duplicate declared base name anywhere in the source's effective lineage is
+    /// an eager local schema defect; it must surface through ordinary mutation
+    /// validation rather than being swallowed or treated as a permissive fallback.
+    #[test]
+    fn duplicate_inherited_declaration_surfaces_through_mutation() -> Result<(), HolonError> {
+        let context = build_context();
+        let source_type = new_holon_type_descriptor(&context, "source-type", "SourceType")?;
+        let target_type = new_holon_type_descriptor(&context, "target-type", "TargetType")?;
+        let staged_source_type = context.mutation().stage_new_holon(source_type)?;
+        let staged_target_type = context.mutation().stage_new_holon(target_type)?;
+
+        let first_declaration = new_relationship_descriptor_holon(
+            &context,
+            "relationship-descriptor-a",
+            "AuthoredBy",
+            staged_source_type.clone().into(),
+            staged_target_type.clone().into(),
+        )?;
+        let second_declaration = new_relationship_descriptor_holon(
+            &context,
+            "relationship-descriptor-b",
+            "AuthoredBy",
+            staged_source_type.clone().into(),
+            staged_target_type.into(),
+        )?;
+        let staged_first = context.mutation().stage_new_holon(first_declaration)?;
+        let staged_second = context.mutation().stage_new_holon(second_declaration)?;
+
+        let mut staged_source_type = staged_source_type;
+        staged_source_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceRelationships,
+            vec![staged_first.into(), staged_second.into()],
+        )?;
+
+        let mut staged_source = staged_update_source(&context, staged_source_type)?;
+        let target = staged_target(&context, "author")?;
+
+        let result = staged_source.add_related_holons("AuthoredBy", vec![target.into()]);
+
+        assert!(matches!(
+            result,
+            Err(HolonError::DuplicateInheritedDeclaration { kind, name, .. })
+                if kind == "relationship" && name == "AuthoredBy"
+        ));
+        assert_eq!(relationship_member_count(&staged_source, "AuthoredBy")?, 0);
         Ok(())
     }
 

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -725,12 +725,20 @@ pub async fn execute_verify_relationship_anchoring(state: &mut TestExecutionStat
 
     // Non-definitional graph-only mutation: no new node was created for this
     // commit, so the Properties edge and its inverse must be anchored to the
-    // existing Book id. The fixture also replayed this edge in a second
-    // graph-only commit (issue #516), so exactly one link must exist in each
-    // direction: commit-time duplicate suppression absorbed the equivalent
-    // re-write.
+    // existing Book id. The fixture's second graph-only commit re-persisted the
+    // full cloned Properties collection (issue #516), so exactly one link must
+    // exist in each direction: commit-time duplicate suppression absorbed the
+    // equivalent re-write.
     assert_related_ids_contain_exactly_once(&original_book, "Properties", &title_property_id);
     assert_related_ids_contain_exactly_once(&title_property, "PropertyOf", &original_book_id);
+
+    // The replay commit also appended Name.PropertyType; its links prove that
+    // commit persisted the touched collection, so the single Title link above
+    // reflects duplicate suppression rather than a skipped write.
+    let name_property = find_holon_by_key(&holons, "Name.PropertyType");
+    let name_property_id = local_id(&name_property);
+    assert_related_ids_contain_exactly_once(&original_book, "Properties", &name_property_id);
+    assert_related_ids_contain_exactly_once(&name_property, "PropertyOf", &original_book_id);
 
     // Definitional mutation: the AuthoredBy edge and its Authors inverse must
     // be anchored to the new Book version, not the prior persisted source.

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -688,6 +688,8 @@ pub async fn execute_verify_book_person_instance_links(state: &mut TestExecution
 /// fixture has exercised both update modes:
 /// - graph-only mutation: Book --Properties--> Title.PropertyType is anchored to
 ///   the existing Book node, with no new Book node created for that commit.
+///   The fixture replays this edge in a second graph-only commit, so exactly one
+///   forward and one inverse link must remain (issue #516 duplicate suppression).
 /// - version-producing mutation: Book --AuthoredBy--> Person is anchored to the
 ///   new Book version, and lineage is persisted bidirectionally through
 ///   Predecessor/Successor.
@@ -723,9 +725,12 @@ pub async fn execute_verify_relationship_anchoring(state: &mut TestExecutionStat
 
     // Non-definitional graph-only mutation: no new node was created for this
     // commit, so the Properties edge and its inverse must be anchored to the
-    // existing Book id.
-    assert_related_ids_contain(&original_book, "Properties", &title_property_id);
-    assert_related_ids_contain(&title_property, "PropertyOf", &original_book_id);
+    // existing Book id. The fixture also replayed this edge in a second
+    // graph-only commit (issue #516), so exactly one link must exist in each
+    // direction: commit-time duplicate suppression absorbed the equivalent
+    // re-write.
+    assert_related_ids_contain_exactly_once(&original_book, "Properties", &title_property_id);
+    assert_related_ids_contain_exactly_once(&title_property, "PropertyOf", &original_book_id);
 
     // Definitional mutation: the AuthoredBy edge and its Authors inverse must
     // be anchored to the new Book version, not the prior persisted source.
@@ -910,6 +915,22 @@ fn assert_related_ids_do_not_contain(
     assert!(
         ids.iter().all(|actual| actual != unexpected),
         "expected relationship {relationship_name} ids {ids:?} not to contain {unexpected:?}"
+    );
+}
+
+/// Asserts the target id appears exactly once in the persisted relationship —
+/// duplicate SmartLinks would surface here as repeated members, because the
+/// guest fetch path adds one collection member per persisted link.
+fn assert_related_ids_contain_exactly_once(
+    holon: &HolonReference,
+    relationship_name: &str,
+    expected: &LocalId,
+) {
+    let ids = related_holon_ids(holon, relationship_name);
+    let occurrences = ids.iter().filter(|actual| *actual == expected).count();
+    assert_eq!(
+        occurrences, 1,
+        "expected relationship {relationship_name} ids {ids:?} to contain {expected:?} exactly once"
     );
 }
 

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -148,11 +148,13 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // Replay the already-persisted graph-only edge to prove commit-time SmartLink
-    // idempotency (issue #516). Removing then re-adding the target leaves the staged
-    // collection unchanged but marks `Properties` as touched, so commit re-attempts a
-    // SmartLink write equivalent to the one persisted by the previous commit.
-    // Duplicate suppression must leave exactly one forward/inverse link pair,
-    // asserted by the relationship-anchoring verification step below.
+    // idempotency (issue #516). `stage_new_version` clones all persisted
+    // relationships into the staged map, so appending a second Properties target
+    // marks the relationship touched; the graph-only commit then re-persists the
+    // whole collection, including a SmartLink equivalent to the already-persisted
+    // Book --Properties--> Title.PropertyType edge. Duplicate suppression must
+    // leave exactly one link per direction for that edge, asserted by the
+    // relationship-anchoring verification step below.
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before replaying the persisted Properties edge".to_string()),
@@ -168,31 +170,26 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // Fresh saved-key lookup so the target binds to this transaction (issue #515).
-    let replay_title_stub =
-        fixture_context.mutation().new_holon(Some(MapString("Title.PropertyType".to_string())))?;
-    let replay_title_token = test_case.add_lookup_saved_holon_by_key_step(
+    let name_property_stub =
+        fixture_context.mutation().new_holon(Some(MapString("Name.PropertyType".to_string())))?;
+    let name_property_token = test_case.add_lookup_saved_holon_by_key_step(
         &mut fixture_holons,
-        replay_title_stub,
-        MapString("Title.PropertyType".to_string()),
+        name_property_stub,
+        MapString("Name.PropertyType".to_string()),
         None,
         None,
     )?;
 
-    let replay_update = test_case.add_remove_related_holons_step(
-        &mut fixture_holons,
-        replay_update,
-        RelationshipName(MapString("Properties".to_string())),
-        vec![replay_title_token.clone()],
-        None,
-        Some("Remove cloned Book --Properties--> Title.PropertyType member".to_string()),
-    )?;
     test_case.add_add_related_holons_step(
         &mut fixture_holons,
         replay_update,
         RelationshipName(MapString("Properties".to_string())),
-        vec![replay_title_token],
+        vec![name_property_token],
         None,
-        Some("Re-add already-persisted Book --Properties--> Title.PropertyType".to_string()),
+        Some(
+            "Append Book --Properties--> Name.PropertyType beside the cloned Title member"
+                .to_string(),
+        ),
     )?;
 
     test_case.add_commit_step(

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -31,6 +31,10 @@ fn schema_backed_db_count(fixture_holons: &FixtureHolons) -> MapInteger {
 /// assertions. Commit-time relationship persistence must anchor graph-only
 /// changes to the existing Book node and version-producing changes to the new
 /// Book version.
+///
+/// A second graph-only cycle replays the already-persisted `Properties` edge
+/// (issue #516): commit-time SmartLink duplicate suppression must absorb the
+/// equivalent re-write, leaving exactly one forward and one inverse link.
 #[fixture]
 pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
     let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, mut fixture_bindings } =
@@ -141,6 +145,69 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_ensure_database_count_step(
         post_setup_db_count.clone(),
         Some("Graph-only update must not create a new Book node".to_string()),
+    )?;
+
+    // Replay the already-persisted graph-only edge to prove commit-time SmartLink
+    // idempotency (issue #516). Removing then re-adding the target leaves the staged
+    // collection unchanged but marks `Properties` as touched, so commit re-attempts a
+    // SmartLink write equivalent to the one persisted by the previous commit.
+    // Duplicate suppression must leave exactly one forward/inverse link pair,
+    // asserted by the relationship-anchoring verification step below.
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin new transaction before replaying the persisted Properties edge".to_string()),
+    )?;
+
+    let replay_update = test_case.add_stage_new_version_step(
+        &mut fixture_holons,
+        graph_only_update.clone(),
+        None,
+        staged_versions_with_same_base_key.clone(),
+        None,
+        Some("Stage Book as replay graph-only update context".to_string()),
+    )?;
+
+    // Fresh saved-key lookup so the target binds to this transaction (issue #515).
+    let replay_title_stub =
+        fixture_context.mutation().new_holon(Some(MapString("Title.PropertyType".to_string())))?;
+    let replay_title_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        replay_title_stub,
+        MapString("Title.PropertyType".to_string()),
+        None,
+        None,
+    )?;
+
+    let replay_update = test_case.add_remove_related_holons_step(
+        &mut fixture_holons,
+        replay_update,
+        RelationshipName(MapString("Properties".to_string())),
+        vec![replay_title_token.clone()],
+        None,
+        Some("Remove cloned Book --Properties--> Title.PropertyType member".to_string()),
+    )?;
+    test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        replay_update,
+        RelationshipName(MapString("Properties".to_string())),
+        vec![replay_title_token],
+        None,
+        Some("Re-add already-persisted Book --Properties--> Title.PropertyType".to_string()),
+    )?;
+
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some(
+            "Commit replayed graph-only edge --- expecting SmartLink duplicate suppression"
+                .to_string(),
+        ),
+    )?;
+
+    test_case.add_ensure_database_count_step(
+        post_setup_db_count.clone(),
+        Some("Replayed graph-only update must not create a new Book node".to_string()),
     )?;
 
     // Begin a fresh transaction before the definitional relationship mutation.


### PR DESCRIPTION
Closes #516 (and #444).

Hardens relationship semantics at three enforcement points: import validation, ordinary
staged mutation, and commit-time SmartLink persistence. Follows the landed #442/#536/#562
model: mutation stays declared-side-only, inverse links are derived at commit, and
`effective_relationship_declaration` remains the single declared-resolution contract.

## 1. Loader: inverse-side `HasInverse` uniqueness

`host/crates/holons_loader_client/src/parser.rs`

- Each inverse relationship descriptor may be targeted by **at most one** declared
  descriptor via `HasInverse`, enforced both within a file and **across the whole load
  set** (a `HasInverseTargetUniquenessTracker` held across the per-file loop).
- A violation surfaces as a `SchemaValidationFailure` import issue attributed to the file
  containing the second reference, naming both declared descriptors and the shared target.
- The existing checks (exactly one `HasInverse` per declared descriptor, target must extend
  `InverseRelationshipType`, authored `InverseOf` rejected) are unchanged.

## 2. Ordinary mutation: descriptor-aware duplicate policy (staged references)

`shared_crates/holons_core/src/reference_layer/staged_reference.rs`

- `classify_relationship_mutation` is replaced by a consolidated
  `relationship_mutation_policy` resolver anchored on the **instance** via
  `effective_relationship_declaration` (the commit Pass 2 contract), eliminating the
  parallel `DescribedBy`-anchored `get_relationship_by_name` lookup.
- On successful resolution the policy is **Enforced**: `AllowsDuplicates` is read
  (missing/non-bool metadata fails loudly — `EmptyField` / `UnexpectedValueType`), and
  update states additionally read `IsDefinitional` for state escalation.
- **Duplicate handling** when duplicates are disallowed: exact repeats (same reference
  identity) are dropped as idempotent no-ops — a pure no-op add does not escalate staged
  state; a same-key entry with a different identity fails with a clear `DuplicateError`;
  `allows_duplicates == true` preserves repeated targets exactly as before.
- **Inverse-name rejection**: resolution is declared-first; only on a miss is the name
  classified via `allows_relationship`, and an inverse name gets a clear error directing
  the caller to the declared source endpoint. Refinement errors (notably
  `UnsupportedStagedTraversal` from the `TargetOf` index guard on staged-uncommitted
  endpoints) never leak — the original miss is returned instead.
- `DuplicateInheritedDeclaration` propagates through mutation validation (eager local
  schema-defect surfacing, per the issue).
- **Removal** uses its own classifier: `ForCreate` sources skip descriptor classification
  entirely; update states resolve the declaration for `IsDefinitional` only (see decision
  notes below).

## 3. Commit-time SmartLink duplicate suppression

`happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs`

- `save_smartlink` is now idempotent: it queries existing links with the **full encoded tag
  as `tag_prefix`** (narrowest possible filter), then compares **exact tag bytes** (guarding
  against a longer tag extending ours as a prefix) **and** target action hash. An equivalent
  link → idempotent success with a debug log; otherwise `create_link` as before.
- Equivalence = source `LocalId` + target hash + byte-identical tag, which covers
  relationship name, reference-type marker (incl. external space id), and smart property
  values. Tags are deterministic because `PropertyMap` is a `BTreeMap` (pinned by test).
- Both commit call sites flow through this single choke point, so forward links, generated
  inverse links, and `HasInverse`/`InverseOf` metadata links share one equivalence model.
- `commit_functions.rs` is unchanged; DHT link validation remains a no-op by design
  (sibling links are not cheaply visible to validation).

## Decisions and scope notes

- **Staged-only enforcement.** Duplicate policy and inverse-name rejection apply to
  `StagedReference` mutation only. `TransientReference` mutation is deliberately unchanged
  (transients never commit, so there is no SmartLink risk). This deviates from the issue's
  scope table, which also listed `transient_reference.rs` / `holon_reference.rs`.
- **Schema-gated enforcement.** An undescribed `ForCreate` source keeps legacy append
  behavior (this is what keeps undescribed fixtures and bootstrap staging working); a
  *described* source gets full validation with no permissive fallback.
- **Loader bootstrap exception.** Guest loader Pass 2 uses a documented
  `add_related_holons_ungoverned` escape hatch on `StagedReference`. Core-schema self-load
  is inherently circular: Pass 2a describes every holon before any `InstanceRelationships`
  edges exist, so ordinary policy resolution would fail on every described `ForCreate`
  source mid-load (the seed edge `(MetaHolonType)-[InstanceRelationships]->` is
  self-licensing). Write-access checks still apply on this path; ordinary callers do not
  use it.
- **`ForCreate` removal policy.** Removal on a `ForCreate` source does no descriptor work.
  Routing removal through full policy resolution created an un-removable staged member
  (add while undescribed → describe → remove failed with `DescriptorDeclarationNotFound`).
  Duplicate policy protects additions; removing an existing staged member needs no
  descriptor license. Update-state removal still resolves the declaration and errors on
  unknown names, preserving pre-#516 behavior.
- **Authority matrix (§4.6).** Mutation-time detection is authoritative for `ForCreate`
  (all relationships are staged) and best-effort for `ForUpdate*`; commit-time suppression
  is the authoritative guard against the persisted graph. Documented on
  `filter_duplicate_disallowed_entries` and pinned by tests on both sides.
- **Out of scope, per issue:** no cleanup of already-duplicated persisted links, no
  cardinality enforcement, no cross-space inverse propagation, no strong concurrency
  guarantees beyond best-effort suppression in an eventually consistent DHT.

## Testing

- **Unit — `holons_core` (19 staged_reference tests):** idempotent repeat (update-state and
  described-`ForCreate` variants), same-key/different-identity rejection, duplicates-allowed
  preservation, missing/invalid `AllowsDuplicates`/`IsDefinitional`, described-`ForCreate`
  unknown-name error, undescribed-`ForCreate` legacy append (schema gate pinned), inverse-name
  rejection on staged-uncommitted endpoints (pins no `UnsupportedStagedTraversal` leak),
  `DuplicateInheritedDeclaration` through mutation, `ForCreate` remove after describing,
  graph-only/new-version escalation, ungoverned loader path.
- **Unit — loader client (7 parser tests):** shared-inverse-target rejection (same file and
  cross-file), canonical core-schema imports validated jointly across all files.
- **Unit — smartlink adapter:** tag encode/decode round-trip, byte-determinism across
  insertion order, prefix-extension non-match (why exact-byte comparison is required).
- **Sweettest:** `stage_new_version_fixture` gains a replay leg — a second graph-only commit
  re-persists the cloned `Properties` collection against the same source, and the anchoring
  verifier now asserts **exactly one** forward and one inverse link for the replayed edge
  (plus the newly appended member's links, proving the commit wrote the touched collection
  rather than skipping it). Existing regression gates pass, including the core-schema load
  metrics (380 holons / 1778 links) and Book/Person forward+inverse materialization.
- **Commands:** `npm run check`, `npm run test:unit`, `npm run fmt:check`, and
  `npm run sweetest` (Nix) all green; `npm run check -w map-happ` proves WASM safety of the
  shared-crate changes.
