### PR TITLE
555 add reference layer definitional equivalence for holonreference

### DIFF
--- a/host/crates/map_commands_runtime/src/holon_handler.rs
+++ b/host/crates/map_commands_runtime/src/holon_handler.rs
@@ -24,6 +24,8 @@ fn handle_read(
             Ok(MapResult::Reference(HolonReference::Transient(transient)))
         }
         ReadableHolonAction::GetEssentialContent => {
+            // Legacy wire-contract path retained until raw essential-content APIs are retired.
+            #[allow(deprecated)]
             let content = target.essential_content()?;
             Ok(MapResult::EssentialContent(content))
         }

--- a/shared_crates/holons_core/src/core_shared_objects/holon/holon_utils.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/holon/holon_utils.rs
@@ -18,7 +18,11 @@ use super::state::{HolonState, ValidationState};
 //   HELPER OBJECTS
 //  ================
 
-/// Used for testing in order to match the EssentialContent of a Holon.
+/// Snapshot of raw holon content used by legacy comparison and wire-contract paths.
+///
+/// This type remains supported while callers migrate to reference-layer
+/// definitional equivalence for comparison. Planned retirement is tied to the
+/// future wire and SDK cleanup that removes raw essential-content extraction.
 #[derive(new, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct EssentialHolonContent {
     pub property_map: PropertyMap,

--- a/shared_crates/holons_core/src/lib.rs
+++ b/shared_crates/holons_core/src/lib.rs
@@ -28,7 +28,8 @@ pub use descriptors::{
     RelationshipDirection, TransactionDescriptor, TypeHeader, ValueDescriptor,
 };
 pub use reference_layer::{
-    HolonCollectionApi, HolonReference, HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior,
+    Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi, HolonReference,
+    HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver, NodeResolution,
     ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior, TransientReference,
     WritableHolon,
 };

--- a/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
+++ b/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
@@ -503,3 +503,581 @@ impl VisitedPairKey {
         })
     }
 }
+
+#[cfg(test)]
+// These tests run against the in-memory `build_context()` over `TestHolonService`,
+// which cannot perform real commits (host/guest crossings return `NotImplemented`).
+// Consequences for coverage:
+// - Genuine saved holons carrying content don't exist here, so saved-vs-unsaved
+//   *structural* recursion (reading a saved side's property map and members while the
+//   other side is transient/staged) is intentionally NOT exercised in this module; it
+//   is covered by the Phase 5 sweettest regression.
+// - Saved-identity tests use synthetic `SmartReference` ids, which is valid precisely
+//   because the saved short-circuit never reads content.
+// - All descriptors here are transient; no staged-phase holon is exercised.
+mod tests {
+    use super::*;
+    use crate::descriptors::test_support::{
+        build_context, new_holon_type_descriptor, new_relationship_descriptor_holon, new_test_holon,
+    };
+    use crate::reference_layer::{SmartReference, TransientReference, WritableHolon};
+    use base_types::{BaseValue, MapBoolean, MapString};
+    use core_types::{LocalId, PropertyName};
+    use std::sync::Arc;
+    use type_names::{CorePropertyTypeName, CoreRelationshipTypeName, ToPropertyName};
+
+    type TestContext = Arc<crate::core_shared_objects::transactions::TransactionContext>;
+
+    fn relationship_name(name: &str) -> RelationshipName {
+        RelationshipName(MapString(name.to_string()))
+    }
+
+    fn property_name(name: &str) -> PropertyName {
+        MapString(name.to_string()).to_property_name()
+    }
+
+    fn holon_id(byte: u8) -> HolonId {
+        HolonId::Local(LocalId(vec![byte; 39]))
+    }
+
+    fn saved_reference(context: &TestContext, byte: u8) -> HolonReference {
+        HolonReference::Smart(SmartReference::new_from_id(context.context_handle(), holon_id(byte)))
+    }
+
+    fn saved_reference_with_key(context: &TestContext, byte: u8, key: &str) -> HolonReference {
+        HolonReference::smart_with_key(
+            context.context_handle(),
+            holon_id(byte),
+            MapString(key.to_string()),
+        )
+    }
+
+    fn described_holon(
+        context: &TestContext,
+        key: &str,
+        descriptor: &TransientReference,
+    ) -> Result<TransientReference, HolonError> {
+        let mut holon = new_test_holon(context, key)?;
+        holon.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(descriptor)],
+        )?;
+        Ok(holon)
+    }
+
+    fn add_relationship_descriptor(
+        context: &TestContext,
+        source_type: &mut TransientReference,
+        target_type: &TransientReference,
+        name: &str,
+        is_definitional: bool,
+        is_ordered: bool,
+    ) -> Result<TransientReference, HolonError> {
+        let mut relationship = new_relationship_descriptor_holon(
+            context,
+            &format!("{}-{}-relationship", name.to_lowercase(), source_type.temporary_id()),
+            name,
+            HolonReference::from(&*source_type),
+            HolonReference::from(target_type),
+        )?;
+        relationship
+            .with_property_value(CorePropertyTypeName::IsDefinitional, is_definitional)?
+            .with_property_value(CorePropertyTypeName::IsOrdered, is_ordered)?;
+        source_type.add_related_holons(
+            CoreRelationshipTypeName::InstanceRelationships,
+            vec![HolonReference::from(&relationship)],
+        )?;
+        Ok(relationship)
+    }
+
+    fn simple_types(
+        context: &TestContext,
+        prefix: &str,
+    ) -> Result<(TransientReference, TransientReference), HolonError> {
+        Ok((
+            new_holon_type_descriptor(context, &format!("{prefix}-source-type"), "SourceType")?,
+            new_holon_type_descriptor(context, &format!("{prefix}-target-type"), "TargetType")?,
+        ))
+    }
+
+    fn outcome(
+        left: &TransientReference,
+        right: &TransientReference,
+    ) -> Result<EquivalenceOutcome, HolonError> {
+        left.definitional_equivalence(&HolonReference::from(right))
+    }
+
+    fn assert_equivalent(
+        left: &TransientReference,
+        right: &TransientReference,
+    ) -> Result<(), HolonError> {
+        assert_eq!(outcome(left, right)?, EquivalenceOutcome::Equivalent);
+        Ok(())
+    }
+
+    fn assert_divergent(
+        left: &TransientReference,
+        right: &TransientReference,
+    ) -> Result<Divergence, HolonError> {
+        match outcome(left, right)? {
+            EquivalenceOutcome::Equivalent => {
+                panic!("expected divergent definitional-equivalence outcome")
+            }
+            EquivalenceOutcome::Divergent(divergence) => Ok(divergence),
+        }
+    }
+
+    #[test]
+    fn identical_property_maps_without_definitional_relationships_are_equivalent(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_type, _) = simple_types(&context, "same-properties")?;
+        let mut left = described_holon(&context, "same-key", &source_type)?;
+        let mut right = described_holon(&context, "same-key", &source_type)?;
+        left.with_property_value(CorePropertyTypeName::Description, "same")?;
+        right.with_property_value(CorePropertyTypeName::Description, "same")?;
+
+        assert_equivalent(&left, &right)
+    }
+
+    #[test]
+    fn property_map_mismatch_is_divergent_at_root() -> Result<(), HolonError> {
+        let context = build_context();
+        let (source_type, _) = simple_types(&context, "property-mismatch")?;
+        let mut left = described_holon(&context, "same-key", &source_type)?;
+        let mut right = described_holon(&context, "same-key", &source_type)?;
+        left.with_property_value(CorePropertyTypeName::Description, "left")?;
+        right.with_property_value(CorePropertyTypeName::Description, "right")?;
+
+        let divergence = assert_divergent(&left, &right)?;
+
+        assert!(divergence.path.is_empty());
+        assert!(divergence.reason.contains("Description"));
+        Ok(())
+    }
+
+    #[test]
+    fn saved_pairs_short_circuit_on_identity() -> Result<(), HolonError> {
+        let context = build_context();
+        let left = saved_reference(&context, 7);
+        let same = saved_reference(&context, 7);
+        let different = saved_reference(&context, 8);
+
+        assert_eq!(left.definitional_equivalence(&same)?, EquivalenceOutcome::Equivalent);
+        assert!(matches!(
+            left.definitional_equivalence(&different)?,
+            EquivalenceOutcome::Divergent(_)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_extra_definitional_relationship_members_diverge_both_directions(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "missing-member")?;
+        let relation = relationship_name("RelatedTo");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "RelatedTo",
+            true,
+            false,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let right = described_holon(&context, "root", &source_type)?;
+        let member = described_holon(&context, "member", &target_type)?;
+        left.add_related_holons(relation.clone(), vec![HolonReference::from(member)])?;
+
+        assert!(matches!(outcome(&left, &right)?, EquivalenceOutcome::Divergent(_)));
+        assert!(matches!(outcome(&right, &left)?, EquivalenceOutcome::Divergent(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn wrong_definitional_target_diverges_with_relationship_path() -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "wrong-target")?;
+        let relation = relationship_name("RelatedTo");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "RelatedTo",
+            true,
+            false,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let mut right = described_holon(&context, "root", &source_type)?;
+        let left_member = described_holon(&context, "left-member", &target_type)?;
+        let right_member = described_holon(&context, "right-member", &target_type)?;
+        left.add_related_holons(relation.clone(), vec![HolonReference::from(left_member)])?;
+        right.add_related_holons(relation.clone(), vec![HolonReference::from(right_member)])?;
+
+        let divergence = assert_divergent(&left, &right)?;
+
+        assert_eq!(divergence.path, vec![relation]);
+        Ok(())
+    }
+
+    #[test]
+    fn definitional_relationship_name_sets_must_match() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut left_type = new_holon_type_descriptor(&context, "left-name-set-type", "RootType")?;
+        let right_type = new_holon_type_descriptor(&context, "right-name-set-type", "RootType")?;
+        let target_type =
+            new_holon_type_descriptor(&context, "name-set-target-type", "TargetType")?;
+        add_relationship_descriptor(
+            &context,
+            &mut left_type,
+            &target_type,
+            "OnlyOnLeft",
+            true,
+            false,
+        )?;
+        let left = described_holon(&context, "root", &left_type)?;
+        let right = described_holon(&context, "root", &right_type)?;
+
+        let divergence = assert_divergent(&left, &right)?;
+
+        assert!(divergence.reason.contains("OnlyOnLeft"));
+        Ok(())
+    }
+
+    #[test]
+    fn different_described_by_targets_diverge_through_relationship_rule() -> Result<(), HolonError>
+    {
+        let context = build_context();
+        let meta_type = new_holon_type_descriptor(&context, "descriptor-meta-type", "MetaType")?;
+        let mut left_type =
+            new_holon_type_descriptor(&context, "left-described-by-type", "LeftType")?;
+        let mut right_type =
+            new_holon_type_descriptor(&context, "right-described-by-type", "RightType")?;
+        let described_by = CoreRelationshipTypeName::DescribedBy.as_relationship_name();
+        add_relationship_descriptor(
+            &context,
+            &mut left_type,
+            &meta_type,
+            "DescribedBy",
+            true,
+            false,
+        )?;
+        add_relationship_descriptor(
+            &context,
+            &mut right_type,
+            &meta_type,
+            "DescribedBy",
+            true,
+            false,
+        )?;
+        left_type.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&meta_type)],
+        )?;
+        right_type.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&meta_type)],
+        )?;
+        let left = described_holon(&context, "root", &left_type)?;
+        let right = described_holon(&context, "root", &right_type)?;
+
+        let divergence = assert_divergent(&left, &right)?;
+
+        assert_eq!(divergence.path, vec![described_by]);
+        Ok(())
+    }
+
+    #[test]
+    fn same_key_different_saved_targets_are_divergent() -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "saved-target")?;
+        let relation = relationship_name("SavedTarget");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "SavedTarget",
+            true,
+            true,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let mut right = described_holon(&context, "root", &source_type)?;
+        left.add_related_holons(
+            relation.clone(),
+            vec![saved_reference_with_key(&context, 1, "same-saved-key")],
+        )?;
+        right.add_related_holons(
+            relation.clone(),
+            vec![saved_reference_with_key(&context, 2, "same-saved-key")],
+        )?;
+
+        let divergence = assert_divergent(&left, &right)?;
+
+        assert_eq!(divergence.path, vec![relation]);
+        assert!(divergence.reason.contains("Saved holon ids differ"));
+        Ok(())
+    }
+
+    #[test]
+    fn ordered_relationship_members_are_compared_positionally() -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "ordered")?;
+        let relation = relationship_name("OrderedMembers");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "OrderedMembers",
+            true,
+            true,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let mut right = described_holon(&context, "root", &source_type)?;
+        let left_a = described_holon(&context, "a", &target_type)?;
+        let left_b = described_holon(&context, "b", &target_type)?;
+        let right_a = described_holon(&context, "a", &target_type)?;
+        let right_b = described_holon(&context, "b", &target_type)?;
+
+        left.add_related_holons(
+            relation.clone(),
+            vec![HolonReference::from(left_a), HolonReference::from(left_b)],
+        )?;
+        right.add_related_holons(
+            relation,
+            vec![HolonReference::from(right_b), HolonReference::from(right_a)],
+        )?;
+
+        assert!(matches!(outcome(&left, &right)?, EquivalenceOutcome::Divergent(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn unordered_relationship_members_are_matched_as_multisets() -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "unordered")?;
+        let relation = relationship_name("UnorderedMembers");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "UnorderedMembers",
+            true,
+            false,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let mut right = described_holon(&context, "root", &source_type)?;
+        let left_a = described_holon(&context, "a", &target_type)?;
+        let left_b = described_holon(&context, "b", &target_type)?;
+        let right_a = described_holon(&context, "a", &target_type)?;
+        let right_b = described_holon(&context, "b", &target_type)?;
+
+        left.add_related_holons(
+            relation.clone(),
+            vec![HolonReference::from(left_a), HolonReference::from(left_b)],
+        )?;
+        right.add_related_holons(
+            relation,
+            vec![HolonReference::from(right_b), HolonReference::from(right_a)],
+        )?;
+
+        assert_equivalent(&left, &right)
+    }
+
+    #[test]
+    fn undescribed_holons_compare_by_properties_only_when_relationless() -> Result<(), HolonError> {
+        let context = build_context();
+        let left = new_test_holon(&context, "same-key")?;
+        let right = new_test_holon(&context, "same-key")?;
+
+        assert_equivalent(&left, &right)
+    }
+
+    #[test]
+    fn undescribed_holons_with_relationship_members_error() -> Result<(), HolonError> {
+        let context = build_context();
+        let relation = relationship_name("Unlicensed");
+        let mut left = new_test_holon(&context, "same-key")?;
+        let right = new_test_holon(&context, "same-key")?;
+        let member = new_test_holon(&context, "member")?;
+        left.add_related_holons(relation, vec![HolonReference::from(member)])?;
+
+        assert!(matches!(outcome(&left, &right), Err(HolonError::MissingDescribedBy { .. })));
+        Ok(())
+    }
+
+    #[test]
+    fn non_definitional_relationships_are_ignored() -> Result<(), HolonError> {
+        let context = build_context();
+        let (mut source_type, target_type) = simple_types(&context, "non-def")?;
+        let relation = relationship_name("NavigatesTo");
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "NavigatesTo",
+            false,
+            false,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let right = described_holon(&context, "root", &source_type)?;
+        let member = described_holon(&context, "member", &target_type)?;
+        left.add_related_holons(relation, vec![HolonReference::from(member)])?;
+
+        assert_equivalent(&left, &right)
+    }
+
+    #[test]
+    fn self_referencing_definitional_cycles_terminate() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut source_type = new_holon_type_descriptor(&context, "self-cycle-type", "CycleType")?;
+        let relation = relationship_name("LinksTo");
+        let target_type = source_type.clone();
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "LinksTo",
+            true,
+            false,
+        )?;
+        let mut left = described_holon(&context, "root", &source_type)?;
+        let mut right = described_holon(&context, "root", &source_type)?;
+        left.add_related_holons(relation.clone(), vec![HolonReference::from(&left)])?;
+        right.add_related_holons(relation, vec![HolonReference::from(&right)])?;
+
+        assert_equivalent(&left, &right)
+    }
+
+    #[test]
+    fn mutually_referencing_definitional_cycles_terminate() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut source_type =
+            new_holon_type_descriptor(&context, "mutual-cycle-type", "CycleType")?;
+        let relation = relationship_name("LinksTo");
+        let target_type = source_type.clone();
+        add_relationship_descriptor(
+            &context,
+            &mut source_type,
+            &target_type,
+            "LinksTo",
+            true,
+            false,
+        )?;
+        let mut left_a = described_holon(&context, "a", &source_type)?;
+        let mut left_b = described_holon(&context, "b", &source_type)?;
+        let mut right_a = described_holon(&context, "a", &source_type)?;
+        let mut right_b = described_holon(&context, "b", &source_type)?;
+        left_a.add_related_holons(relation.clone(), vec![HolonReference::from(&left_b)])?;
+        left_b.add_related_holons(relation.clone(), vec![HolonReference::from(&left_a)])?;
+        right_a.add_related_holons(relation.clone(), vec![HolonReference::from(&right_b)])?;
+        right_b.add_related_holons(relation, vec![HolonReference::from(&right_a)])?;
+
+        assert_equivalent(&left_a, &right_a)
+    }
+
+    struct TestResolver {
+        canonical_key: MapString,
+        canonical_reference: HolonReference,
+        match_by_key_property: PropertyName,
+    }
+
+    impl EquivalenceResolver for TestResolver {
+        fn resolve(&self, reference: &HolonReference) -> Result<NodeResolution, HolonError> {
+            match reference {
+                HolonReference::Smart(smart_reference) => {
+                    if smart_reference
+                        .smart_property_values()
+                        .and_then(|properties| properties.get(&self.match_by_key_property))
+                        .is_some()
+                    {
+                        return Ok(NodeResolution::MatchByKey);
+                    }
+                }
+                _ if reference.property_value(self.match_by_key_property.clone())?.is_some() => {
+                    return Ok(NodeResolution::MatchByKey);
+                }
+                _ => {}
+            }
+            if !reference.is_saved() && reference.key()? == Some(self.canonical_key.clone()) {
+                return Ok(NodeResolution::Canonical(self.canonical_reference.clone()));
+            }
+            Ok(NodeResolution::AsIs)
+        }
+    }
+
+    #[test]
+    fn resolver_canonical_substitution_feeds_saved_identity_rule() -> Result<(), HolonError> {
+        let context = build_context();
+        let alias = new_test_holon(&context, "alias")?;
+        let canonical = saved_reference(&context, 9);
+        let resolver = TestResolver {
+            canonical_key: MapString("alias".to_string()),
+            canonical_reference: canonical.clone(),
+            match_by_key_property: property_name("MatchByKey"),
+        };
+
+        assert_eq!(
+            alias.definitional_equivalence_with_resolver(&canonical, &resolver)?,
+            EquivalenceOutcome::Equivalent
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolver_match_by_key_compares_keys_without_recursing() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut marker_properties = PropertyMap::new();
+        marker_properties
+            .insert(property_name("MatchByKey"), BaseValue::BooleanValue(MapBoolean(true)));
+        let left = HolonReference::smart_with_properties(context.context_handle(), holon_id(1), {
+            let mut properties = marker_properties.clone();
+            properties.insert(
+                CorePropertyTypeName::Key.to_property_name(),
+                BaseValue::StringValue(MapString("shared-key".to_string())),
+            );
+            properties
+        });
+        let right = saved_reference_with_key(&context, 2, "shared-key");
+        let resolver = TestResolver {
+            canonical_key: MapString("unused".to_string()),
+            canonical_reference: saved_reference(&context, 3),
+            match_by_key_property: property_name("MatchByKey"),
+        };
+
+        assert_eq!(
+            left.definitional_equivalence_with_resolver(&right, &resolver)?,
+            EquivalenceOutcome::Equivalent
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn divergence_path_is_assembled_outermost_first() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut root_type = new_holon_type_descriptor(&context, "path-root-type", "RootType")?;
+        let mut child_type = new_holon_type_descriptor(&context, "path-child-type", "ChildType")?;
+        let grand_type = new_holon_type_descriptor(&context, "path-grand-type", "GrandType")?;
+        let outer = relationship_name("Outer");
+        let inner = relationship_name("Inner");
+        add_relationship_descriptor(&context, &mut root_type, &child_type, "Outer", true, true)?;
+        add_relationship_descriptor(&context, &mut child_type, &grand_type, "Inner", true, true)?;
+        let mut left_root = described_holon(&context, "root", &root_type)?;
+        let mut right_root = described_holon(&context, "root", &root_type)?;
+        let mut left_child = described_holon(&context, "child", &child_type)?;
+        let mut right_child = described_holon(&context, "child", &child_type)?;
+        let mut left_grand = described_holon(&context, "grand", &grand_type)?;
+        let mut right_grand = described_holon(&context, "grand", &grand_type)?;
+        left_grand.with_property_value(CorePropertyTypeName::Description, "left")?;
+        right_grand.with_property_value(CorePropertyTypeName::Description, "right")?;
+        left_child.add_related_holons(inner.clone(), vec![HolonReference::from(left_grand)])?;
+        right_child.add_related_holons(inner.clone(), vec![HolonReference::from(right_grand)])?;
+        left_root.add_related_holons(outer.clone(), vec![HolonReference::from(left_child)])?;
+        right_root.add_related_holons(outer.clone(), vec![HolonReference::from(right_child)])?;
+
+        let divergence = assert_divergent(&left_root, &right_root)?;
+
+        assert_eq!(divergence.path, vec![outer, inner]);
+        Ok(())
+    }
+}

--- a/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
+++ b/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
@@ -308,7 +308,7 @@ fn definitional_relationships(
         }
         Err(HolonError::MissingDescribedBy { .. }) => {
             let all_related = reference.all_related_holons()?;
-            if relationship_map_is_empty(&all_related) {
+            if relationship_map_is_empty(&all_related)? {
                 Ok(BTreeMap::new())
             } else {
                 Err(HolonError::MissingDescribedBy { holon: reference.summarize()? })
@@ -318,8 +318,30 @@ fn definitional_relationships(
     }
 }
 
-fn relationship_map_is_empty(relationship_map: &RelationshipMap) -> bool {
-    relationship_map.count() == 0
+/// Returns `true` only when no relationship in the map holds any members.
+///
+/// A relationship name can linger in the map with an empty collection after all
+/// of its members are removed, so map size alone does not indicate emptiness;
+/// each collection's membership must be inspected. This keeps a relationless
+/// undescribed holon's definitional surface empty (per the equivalence rule)
+/// instead of forcing a spurious `MissingDescribedBy`.
+fn relationship_map_is_empty(relationship_map: &RelationshipMap) -> Result<bool, HolonError> {
+    for (_relationship_name, collection) in relationship_map.iter() {
+        let has_members = !collection
+            .read()
+            .map_err(|e| {
+                HolonError::FailedToAcquireLock(format!(
+                    "Failed to acquire read lock on holon collection: {}",
+                    e
+                ))
+            })?
+            .get_members()
+            .is_empty();
+        if has_members {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 fn compare_relationship_name_sets(
@@ -904,6 +926,21 @@ mod tests {
 
         assert!(matches!(outcome(&left, &right), Err(HolonError::MissingDescribedBy { .. })));
         Ok(())
+    }
+
+    #[test]
+    fn undescribed_holons_with_emptied_relationship_are_relationless() -> Result<(), HolonError> {
+        // Removing the only member leaves the relationship name in the map with an
+        // empty collection. An undescribed holon in that state must still present an
+        // empty definitional surface rather than erroring with MissingDescribedBy.
+        let context = build_context();
+        let mut left = new_test_holon(&context, "same-key")?;
+        let right = new_test_holon(&context, "same-key")?;
+        let member = HolonReference::from(new_test_holon(&context, "member")?);
+        left.add_related_holons(relationship_name("Unlicensed"), vec![member.clone()])?;
+        left.remove_related_holons(relationship_name("Unlicensed"), vec![member])?;
+
+        assert_equivalent(&left, &right)
     }
 
     #[test]

--- a/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
+++ b/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
@@ -1,0 +1,507 @@
+//! Definitional-equivalence comparison for [`HolonReference`].
+//!
+//! This module implements the definitional-equivalence relation inside the reference layer so
+//! callers can ask whether two holons are definitionally equivalent without
+//! extracting raw property maps or reimplementing graph-walk policy outside
+//! `holons_core`.
+//!
+//! The recursive algorithm is:
+//!
+//! 1. Resolve each node through the caller-supplied [`EquivalenceResolver`].
+//!    `Canonical` substitutes a reference for the rest of the comparison at that
+//!    node. `MatchByKey` is an opaque placeholder path used by the test harness:
+//!    it compares only keys and does not recurse.
+//! 2. If both resolved references are saved, compare only their
+//!    [`core_types::HolonId`] values. Saved identity is a conclusive anchor, so
+//!    no structural fallback is attempted and no content is read.
+//! 3. Apply coinductive cycle termination via a visited-pair set keyed by typed
+//!    reference identity.
+//! 4. Compare raw `property_map` values internally via
+//!    `essential_content_impl()?.property_map`. This intentionally excludes
+//!    `EssentialHolonContent.key` and `.errors`; key semantics are already part
+//!    of the property surface, and `errors` are lifecycle-dependent rather than
+//!    definition-level content.
+//! 5. Derive each side's definitional relationship-name set from that side's
+//!    own descriptor. Undescribed holons with no relationship content are
+//!    treated as having an empty definitional surface; undescribed holons with
+//!    relationship content are schema-integrity errors.
+//! 6. For each shared definitional relationship, compare members recursively.
+//!    Ordered relationships are matched positionally. Unordered relationships
+//!    use a greedy shrinking-multiset strategy with a per-candidate visited-set
+//!    snapshot. This is intentionally incomplete for ambiguous unsaved
+//!    duplicates, but keeps the implementation WASM-safe and bounded.
+//! 7. Return [`EquivalenceOutcome::Equivalent`] on success, or
+//!    [`EquivalenceOutcome::Divergent`] with a breadcrumb path and human-readable
+//!    reason at the first comparison failure.
+//!
+//! Breadcrumb segments are prepended while the recursion unwinds, so successful
+//! comparisons allocate no path segments.
+//!
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::{Arc, RwLock};
+
+use crate::core_shared_objects::{transactions::TxId, HolonCollection, RelationshipMap};
+use crate::reference_layer::{readable_impl::ReadableHolonImpl, HolonReference, ReadableHolon};
+use core_types::{HolonError, HolonId, PropertyMap, RelationshipName, TemporaryId};
+
+/// Outcome of definitional-equivalence comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EquivalenceOutcome {
+    Equivalent,
+    Divergent(Divergence),
+}
+
+/// Breadcrumb from the comparison root to the divergence site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Divergence {
+    pub path: Vec<RelationshipName>,
+    pub reason: String,
+}
+
+/// Resolver-directed substitution policy for a comparison node.
+#[derive(Debug, Clone)]
+pub enum NodeResolution {
+    /// Substitute this reference, then continue normal comparison.
+    Canonical(HolonReference),
+    /// Compare keys only and do not recurse into this node.
+    MatchByKey,
+    /// Compare the original reference as-is.
+    AsIs,
+}
+
+/// Reference translation seam for callers that need fixture or runtime rebinding.
+pub trait EquivalenceResolver {
+    fn resolve(&self, reference: &HolonReference) -> Result<NodeResolution, HolonError>;
+}
+
+/// Default resolver: every reference compares as itself.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoOpResolver;
+
+impl EquivalenceResolver for NoOpResolver {
+    fn resolve(&self, _reference: &HolonReference) -> Result<NodeResolution, HolonError> {
+        Ok(NodeResolution::AsIs)
+    }
+}
+
+pub(crate) fn definitional_equivalence<T>(
+    source: &T,
+    other: &HolonReference,
+    resolver: &dyn EquivalenceResolver,
+) -> Result<EquivalenceOutcome, HolonError>
+where
+    T: ReadableHolonImpl + ?Sized,
+{
+    let source_reference = source.holon_reference_impl();
+    compare_references(&source_reference, other, resolver, &mut HashSet::new())
+}
+
+/// Compares two references under the definitional-equivalence rule.
+///
+/// The function is structured cheapest-first: resolver rewrite, saved identity,
+/// cycle check, property surface, then descriptor-derived definitional
+/// relationships. Divergence paths are assembled on unwind by the caller frame
+/// that knows which relationship edge was being traversed.
+fn compare_references(
+    left: &HolonReference,
+    right: &HolonReference,
+    resolver: &dyn EquivalenceResolver,
+    visited: &mut HashSet<VisitedPairKey>,
+) -> Result<EquivalenceOutcome, HolonError> {
+    // Step 1: Canonicalize each node through the resolver. This is a single
+    // substitution step per side; the comparator does not loop until fixed
+    // point.
+    let left_resolution = resolver.resolve(left)?;
+    let right_resolution = resolver.resolve(right)?;
+
+    let left_reference = resolved_reference(left, &left_resolution);
+    let right_reference = resolved_reference(right, &right_resolution);
+
+    // Resolver placeholders compare only keys and intentionally do not recurse
+    // into structure.
+    if matches!(left_resolution, NodeResolution::MatchByKey)
+        || matches!(right_resolution, NodeResolution::MatchByKey)
+    {
+        return compare_by_key_only(left_reference, right_reference);
+    }
+
+    // Step 2: Saved-vs-saved identity is conclusive. If both sides are saved,
+    // the algorithm stops here and never reads content.
+    if left_reference.is_saved() && right_reference.is_saved() {
+        return compare_saved_identity(left_reference, right_reference);
+    }
+
+    // Step 3: Coinductive cycle handling. A pair already under comparison is
+    // presumed equivalent so recursion can terminate on cyclic graphs.
+    let pair_key = VisitedPairKey::new(left_reference, right_reference)?;
+    if visited.contains(&pair_key) {
+        return Ok(EquivalenceOutcome::Equivalent);
+    }
+    visited.insert(pair_key);
+
+    // Step 4: Compare the raw property surface internally. This is the only
+    // raw-map touch in the algorithm, and it excludes key/errors from
+    // EssentialHolonContent for the reasons described in the module header.
+    let left_content = left_reference.essential_content_impl()?;
+    let right_content = right_reference.essential_content_impl()?;
+    if let Some(divergence) =
+        compare_property_maps(&left_content.property_map, &right_content.property_map)
+    {
+        return Ok(EquivalenceOutcome::Divergent(divergence));
+    }
+
+    // Steps 5-6: Derive each side's definitional relationship surface from its
+    // own descriptor, then require the two name sets to match exactly before
+    // descending into members.
+    let left_relationships = definitional_relationships(left_reference)?;
+    let right_relationships = definitional_relationships(right_reference)?;
+    if let Some(divergence) =
+        compare_relationship_name_sets(&left_relationships, &right_relationships)
+    {
+        return Ok(EquivalenceOutcome::Divergent(divergence));
+    }
+
+    for relationship_name in left_relationships.keys() {
+        let left_descriptor = left_relationships
+            .get(relationship_name)
+            .expect("left relationship name should exist in left relationship map");
+        let right_descriptor = right_relationships
+            .get(relationship_name)
+            .expect("shared relationship name should exist in right relationship map");
+
+        let left_members =
+            collection_members(left_reference.related_holons(relationship_name.clone())?)?;
+        let right_members =
+            collection_members(right_reference.related_holons(relationship_name.clone())?)?;
+
+        // Step 7: Recurse through relationship members. Ordered relationships
+        // compare positionally; unordered relationships use greedy multiset
+        // matching. If a child divergence is found, prepend the current
+        // relationship segment while unwinding.
+        let ordered = left_descriptor.is_ordered || right_descriptor.is_ordered;
+        let outcome = if ordered {
+            compare_ordered_members(
+                relationship_name,
+                &left_members,
+                &right_members,
+                resolver,
+                visited,
+            )?
+        } else {
+            compare_unordered_members(
+                relationship_name,
+                &left_members,
+                &right_members,
+                resolver,
+                visited,
+            )?
+        };
+
+        if let EquivalenceOutcome::Divergent(divergence) = outcome {
+            return Ok(EquivalenceOutcome::Divergent(prepend_relationship_segment(
+                relationship_name,
+                divergence,
+            )));
+        }
+    }
+
+    Ok(EquivalenceOutcome::Equivalent)
+}
+
+fn resolved_reference<'a>(
+    original: &'a HolonReference,
+    resolution: &'a NodeResolution,
+) -> &'a HolonReference {
+    match resolution {
+        NodeResolution::Canonical(reference) => reference,
+        NodeResolution::MatchByKey | NodeResolution::AsIs => original,
+    }
+}
+
+fn compare_by_key_only(
+    left: &HolonReference,
+    right: &HolonReference,
+) -> Result<EquivalenceOutcome, HolonError> {
+    let left_key = left.key()?;
+    let right_key = right.key()?;
+
+    if left_key == right_key {
+        Ok(EquivalenceOutcome::Equivalent)
+    } else {
+        Ok(EquivalenceOutcome::Divergent(Divergence {
+            path: Vec::new(),
+            reason: format!(
+                "Keys differ under MatchByKey resolution: left={:?}, right={:?}",
+                left_key, right_key
+            ),
+        }))
+    }
+}
+
+fn compare_saved_identity(
+    left: &HolonReference,
+    right: &HolonReference,
+) -> Result<EquivalenceOutcome, HolonError> {
+    let left_id = left.holon_id()?;
+    let right_id = right.holon_id()?;
+
+    if left_id == right_id {
+        Ok(EquivalenceOutcome::Equivalent)
+    } else {
+        Ok(EquivalenceOutcome::Divergent(Divergence {
+            path: Vec::new(),
+            reason: format!("Saved holon ids differ: left={}, right={}", left_id, right_id),
+        }))
+    }
+}
+
+fn compare_property_maps(left: &PropertyMap, right: &PropertyMap) -> Option<Divergence> {
+    for (property_name, left_value) in left {
+        match right.get(property_name) {
+            Some(right_value) if right_value == left_value => {}
+            Some(right_value) => {
+                return Some(Divergence {
+                    path: Vec::new(),
+                    reason: format!(
+                        "Property {} differs: left={:?}, right={:?}",
+                        property_name, left_value, right_value
+                    ),
+                })
+            }
+            None => {
+                return Some(Divergence {
+                    path: Vec::new(),
+                    reason: format!("Property {} is missing on the right side", property_name),
+                })
+            }
+        }
+    }
+
+    for property_name in right.keys() {
+        if !left.contains_key(property_name) {
+            return Some(Divergence {
+                path: Vec::new(),
+                reason: format!("Property {} is missing on the left side", property_name),
+            });
+        }
+    }
+
+    None
+}
+
+fn definitional_relationships(
+    reference: &HolonReference,
+) -> Result<BTreeMap<RelationshipName, RelationshipComparisonDescriptor>, HolonError> {
+    match reference.holon_descriptor() {
+        Ok(descriptor) => {
+            let mut relationships = BTreeMap::new();
+            for descriptor in descriptor.instance_relationships()? {
+                if descriptor.is_definitional()? {
+                    let name = descriptor.base_relationship_name()?;
+                    relationships.insert(
+                        name,
+                        RelationshipComparisonDescriptor { is_ordered: descriptor.is_ordered()? },
+                    );
+                }
+            }
+            Ok(relationships)
+        }
+        Err(HolonError::MissingDescribedBy { .. }) => {
+            let all_related = reference.all_related_holons()?;
+            if relationship_map_is_empty(&all_related) {
+                Ok(BTreeMap::new())
+            } else {
+                Err(HolonError::MissingDescribedBy { holon: reference.summarize()? })
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn relationship_map_is_empty(relationship_map: &RelationshipMap) -> bool {
+    relationship_map.count() == 0
+}
+
+fn compare_relationship_name_sets(
+    left: &BTreeMap<RelationshipName, RelationshipComparisonDescriptor>,
+    right: &BTreeMap<RelationshipName, RelationshipComparisonDescriptor>,
+) -> Option<Divergence> {
+    let left_names = left.keys().cloned().collect::<BTreeSet<_>>();
+    let right_names = right.keys().cloned().collect::<BTreeSet<_>>();
+
+    if left_names == right_names {
+        return None;
+    }
+
+    let left_only =
+        left_names.difference(&right_names).map(ToString::to_string).collect::<Vec<_>>();
+    let right_only =
+        right_names.difference(&left_names).map(ToString::to_string).collect::<Vec<_>>();
+
+    Some(Divergence {
+        path: Vec::new(),
+        reason: format!(
+            "Definitional relationships differ: left-only=[{}], right-only=[{}]",
+            left_only.join(", "),
+            right_only.join(", ")
+        ),
+    })
+}
+
+fn compare_ordered_members(
+    relationship_name: &RelationshipName,
+    left_members: &[HolonReference],
+    right_members: &[HolonReference],
+    resolver: &dyn EquivalenceResolver,
+    visited: &mut HashSet<VisitedPairKey>,
+) -> Result<EquivalenceOutcome, HolonError> {
+    if left_members.len() != right_members.len() {
+        return Ok(diverge_here(format!(
+            "Ordered relationship {} has different lengths: left={}, right={}",
+            relationship_name,
+            left_members.len(),
+            right_members.len()
+        )));
+    }
+
+    for (left_member, right_member) in left_members.iter().zip(right_members.iter()) {
+        let outcome = compare_references(left_member, right_member, resolver, visited)?;
+        if !matches!(outcome, EquivalenceOutcome::Equivalent) {
+            return Ok(outcome);
+        }
+    }
+
+    Ok(EquivalenceOutcome::Equivalent)
+}
+
+/// Greedy unordered matching may return false negatives for ambiguous duplicate unsaved members.
+fn compare_unordered_members(
+    relationship_name: &RelationshipName,
+    left_members: &[HolonReference],
+    right_members: &[HolonReference],
+    resolver: &dyn EquivalenceResolver,
+    visited: &mut HashSet<VisitedPairKey>,
+) -> Result<EquivalenceOutcome, HolonError> {
+    if left_members.len() != right_members.len() {
+        return Ok(diverge_here(format!(
+            "Unordered relationship {} has different lengths: left={}, right={}",
+            relationship_name,
+            left_members.len(),
+            right_members.len()
+        )));
+    }
+
+    let mut remaining_right = right_members.to_vec();
+
+    for left_member in left_members {
+        let mut matched_index = None;
+        let mut matched_visited = None;
+
+        for (candidate_index, right_member) in remaining_right.iter().enumerate() {
+            let mut trial_visited = visited.clone();
+            match compare_references(left_member, right_member, resolver, &mut trial_visited)? {
+                EquivalenceOutcome::Equivalent => {
+                    matched_index = Some(candidate_index);
+                    matched_visited = Some(trial_visited);
+                    break;
+                }
+                EquivalenceOutcome::Divergent(_) => {}
+            }
+        }
+
+        match (matched_index, matched_visited) {
+            (Some(index), Some(trial_visited)) => {
+                *visited = trial_visited;
+                remaining_right.remove(index);
+            }
+            _ => {
+                return Ok(diverge_here(format!(
+                    "Unordered relationship {} has no matching member for {}",
+                    relationship_name,
+                    left_member.summarize()?
+                )))
+            }
+        }
+    }
+
+    if !remaining_right.is_empty() {
+        return Ok(diverge_here(format!(
+            "Unordered relationship {} has unmatched right-side members",
+            relationship_name
+        )));
+    }
+
+    Ok(EquivalenceOutcome::Equivalent)
+}
+
+fn collection_members(
+    collection: Arc<RwLock<HolonCollection>>,
+) -> Result<Vec<HolonReference>, HolonError> {
+    let collection = collection.read().map_err(|e| {
+        HolonError::FailedToAcquireLock(format!(
+            "Failed to acquire read lock on holon collection: {}",
+            e
+        ))
+    })?;
+    Ok(collection.get_members().clone())
+}
+
+fn prepend_relationship_segment(
+    relationship_name: &RelationshipName,
+    mut divergence: Divergence,
+) -> Divergence {
+    let mut path = Vec::with_capacity(divergence.path.len() + 1);
+    path.push(relationship_name.clone());
+    path.append(&mut divergence.path);
+    Divergence { path, reason: divergence.reason }
+}
+
+fn diverge_here(reason: String) -> EquivalenceOutcome {
+    EquivalenceOutcome::Divergent(Divergence { path: Vec::new(), reason })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ReferenceIdentity {
+    Saved { tx_id: TxId, holon_id: HolonId },
+    Staged { tx_id: TxId, temporary_id: TemporaryId },
+    Transient { tx_id: TxId, temporary_id: TemporaryId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct VisitedPairKey {
+    left: ReferenceIdentity,
+    right: ReferenceIdentity,
+}
+
+#[derive(Debug, Clone)]
+struct RelationshipComparisonDescriptor {
+    is_ordered: bool,
+}
+
+impl ReferenceIdentity {
+    fn from_reference(reference: &HolonReference) -> Result<Self, HolonError> {
+        match reference {
+            HolonReference::Smart(_) => {
+                Ok(Self::Saved { tx_id: reference.tx_id(), holon_id: reference.holon_id()? })
+            }
+            HolonReference::Staged(staged) => {
+                Ok(Self::Staged { tx_id: staged.tx_id(), temporary_id: staged.temporary_id() })
+            }
+            HolonReference::Transient(transient) => Ok(Self::Transient {
+                tx_id: transient.tx_id(),
+                temporary_id: transient.temporary_id(),
+            }),
+        }
+    }
+}
+
+impl VisitedPairKey {
+    fn new(left: &HolonReference, right: &HolonReference) -> Result<Self, HolonError> {
+        Ok(Self {
+            left: ReferenceIdentity::from_reference(left)?,
+            right: ReferenceIdentity::from_reference(right)?,
+        })
+    }
+}

--- a/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
+++ b/shared_crates/holons_core/src/reference_layer/definitional_equivalence.rs
@@ -37,8 +37,6 @@
 //! Breadcrumb segments are prepended while the recursion unwinds, so successful
 //! comparisons allocate no path segments.
 //!
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::{Arc, RwLock};
 

--- a/shared_crates/holons_core/src/reference_layer/mod.rs
+++ b/shared_crates/holons_core/src/reference_layer/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod available_relationships;
+pub(crate) mod definitional_equivalence;
 pub mod holon_collection_api;
 pub mod holon_reference;
 pub mod holon_service_api;
@@ -13,6 +14,9 @@ pub mod transient_reference;
 pub mod writable_holon;
 pub(crate) mod writable_impl;
 
+pub use definitional_equivalence::{
+    Divergence, EquivalenceOutcome, EquivalenceResolver, NoOpResolver, NodeResolution,
+};
 pub use holon_collection_api::HolonCollectionApi;
 pub use holon_reference::HolonReference;
 pub use holon_service_api::HolonServiceApi;

--- a/shared_crates/holons_core/src/reference_layer/readable_holon.rs
+++ b/shared_crates/holons_core/src/reference_layer/readable_holon.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, RwLock};
 use super::{HolonReference, TransientReference};
 use crate::descriptors::{HolonDescriptor, QualifiedRelationship};
 use crate::reference_layer::available_relationships;
+use crate::reference_layer::definitional_equivalence::{
+    self, EquivalenceOutcome, EquivalenceResolver, NoOpResolver,
+};
 use crate::reference_layer::readable_impl::ReadableHolonImpl;
 use crate::{
     core_shared_objects::{
@@ -23,6 +26,35 @@ pub trait ReadableHolon: ReadableHolonImpl {
     fn clone_holon(&self) -> Result<TransientReference, HolonError> {
         ReadableHolonImpl::clone_holon_impl(self)
     }
+
+    /// Returns true when this holon and `other` have the same definition-level content.
+    #[inline]
+    fn is_definitionally_equivalent(&self, other: &HolonReference) -> Result<bool, HolonError> {
+        Ok(matches!(self.definitional_equivalence(other)?, EquivalenceOutcome::Equivalent))
+    }
+
+    /// Compares this holon with `other`, returning diagnostic detail on divergence.
+    #[inline]
+    fn definitional_equivalence(
+        &self,
+        other: &HolonReference,
+    ) -> Result<EquivalenceOutcome, HolonError> {
+        self.definitional_equivalence_with_resolver(other, &NoOpResolver)
+    }
+
+    /// Compares this holon with `other` using caller-supplied reference resolution.
+    #[inline]
+    fn definitional_equivalence_with_resolver(
+        &self,
+        other: &HolonReference,
+        resolver: &dyn EquivalenceResolver,
+    ) -> Result<EquivalenceOutcome, HolonError> {
+        definitional_equivalence::definitional_equivalence(self, other, resolver)
+    }
+
+    #[deprecated(
+        note = "raw-content extraction is being retired; use is_definitionally_equivalent()/definitional_equivalence() for comparison"
+    )]
     #[inline]
     fn essential_content(&self) -> Result<EssentialHolonContent, HolonError> {
         ReadableHolonImpl::essential_content_impl(self)

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -51,7 +51,8 @@ pub use holons_core::dances::{
 };
 pub use holons_core::query_layer::{Node, NodeCollection, QueryExpression, QueryPathMap};
 pub use holons_core::reference_layer::{
-    HolonCollectionApi, HolonReference, HolonSpaceBehavior, HolonStagingBehavior, ReadableHolon,
+    Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi, HolonReference,
+    HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver, NodeResolution, ReadableHolon,
     SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
 };
 pub use holons_core::{

--- a/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
+++ b/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
@@ -1,0 +1,75 @@
+//! Sweettest reference translation for definitional-equivalence assertions.
+//!
+//! Fixture snapshots can refer to holons that have since been committed, and
+//! saved-lookup stubs intentionally stand in for pre-existing saved content.
+//! This resolver adapts those harness concepts to the phase-generic resolver
+//! port exposed by `holons_core`.
+
+use crate::{ExecutionHolons, SAVED_LOOKUP_STUB_MARKER};
+use holons_prelude::prelude::*;
+use type_names::property_names::ToPropertyName;
+
+/// Resolver used by saved-content assertions.
+pub struct ExecutionEquivalenceResolver<'a> {
+    execution_holons: &'a ExecutionHolons,
+}
+
+impl<'a> ExecutionEquivalenceResolver<'a> {
+    /// Creates a resolver over the execution registry for the current test run.
+    pub fn new(execution_holons: &'a ExecutionHolons) -> Self {
+        Self { execution_holons }
+    }
+}
+
+impl EquivalenceResolver for ExecutionEquivalenceResolver<'_> {
+    fn resolve(&self, reference: &HolonReference) -> Result<NodeResolution, HolonError> {
+        if is_saved_lookup_stub(reference)? {
+            return Ok(NodeResolution::MatchByKey);
+        }
+
+        if let Some(resolved_reference) =
+            canonical_saved_reference(reference, self.execution_holons)?
+        {
+            return Ok(NodeResolution::Canonical(resolved_reference));
+        }
+
+        Ok(NodeResolution::AsIs)
+    }
+}
+
+/// Detects fixture saved-lookup stubs without forcing a saved-reference fetch.
+fn is_saved_lookup_stub(reference: &HolonReference) -> Result<bool, HolonError> {
+    match reference {
+        HolonReference::Smart(smart) => {
+            Ok(smart.smart_property_values().is_some_and(|properties| {
+                properties.contains_key(&SAVED_LOOKUP_STUB_MARKER.to_property_name())
+            }))
+        }
+        HolonReference::Transient(_) | HolonReference::Staged(_) => {
+            Ok(reference.property_value(SAVED_LOOKUP_STUB_MARKER)?.is_some())
+        }
+    }
+}
+
+/// Maps fixture transient/staged snapshots to the saved reference recorded after commit.
+fn canonical_saved_reference(
+    reference: &HolonReference,
+    execution_holons: &ExecutionHolons,
+) -> Result<Option<HolonReference>, HolonError> {
+    let snapshot_id = match reference {
+        HolonReference::Transient(transient) => transient.temporary_id(),
+        HolonReference::Staged(staged) => staged.temporary_id(),
+        HolonReference::Smart(_) => return Ok(None),
+    };
+
+    let Some(resolved) = execution_holons.by_snapshot_id.get(&snapshot_id) else {
+        return Ok(None);
+    };
+
+    let resolved_reference = resolved.execution_handle.get_holon_reference()?;
+    if resolved_reference.is_saved() {
+        Ok(Some(resolved_reference))
+    } else {
+        Ok(None)
+    }
+}

--- a/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
+++ b/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
@@ -5,19 +5,23 @@
 //! This resolver adapts those harness concepts to the phase-generic resolver
 //! port exposed by `holons_core`.
 
-use crate::{ExecutionHolons, SAVED_LOOKUP_STUB_MARKER};
+use crate::{ExecutionHolons, FixtureHeadIndex, SAVED_LOOKUP_STUB_MARKER};
 use holons_prelude::prelude::*;
 use type_names::property_names::ToPropertyName;
 
 /// Resolver used by saved-content assertions.
 pub struct ExecutionEquivalenceResolver<'a> {
     execution_holons: &'a ExecutionHolons,
+    fixture_head_index: &'a FixtureHeadIndex,
 }
 
 impl<'a> ExecutionEquivalenceResolver<'a> {
     /// Creates a resolver over the execution registry for the current test run.
-    pub fn new(execution_holons: &'a ExecutionHolons) -> Self {
-        Self { execution_holons }
+    pub fn new(
+        execution_holons: &'a ExecutionHolons,
+        fixture_head_index: &'a FixtureHeadIndex,
+    ) -> Self {
+        Self { execution_holons, fixture_head_index }
     }
 }
 
@@ -28,7 +32,7 @@ impl EquivalenceResolver for ExecutionEquivalenceResolver<'_> {
         }
 
         if let Some(resolved_reference) =
-            canonical_saved_reference(reference, self.execution_holons)?
+            canonical_saved_reference(reference, self.execution_holons, self.fixture_head_index)?
         {
             return Ok(NodeResolution::Canonical(resolved_reference));
         }
@@ -58,6 +62,7 @@ fn is_saved_lookup_stub(reference: &HolonReference) -> Result<bool, HolonError> 
 fn canonical_saved_reference(
     reference: &HolonReference,
     execution_holons: &ExecutionHolons,
+    fixture_head_index: &FixtureHeadIndex,
 ) -> Result<Option<HolonReference>, HolonError> {
     let snapshot_id = match reference {
         HolonReference::Transient(transient) => transient.temporary_id(),
@@ -65,7 +70,9 @@ fn canonical_saved_reference(
         HolonReference::Smart(_) => return Ok(None),
     };
 
-    let Some(resolved) = execution_holons.by_snapshot_id.get(&snapshot_id) else {
+    let head_id = fixture_head_index.get(&snapshot_id).unwrap_or(&snapshot_id);
+
+    let Some(resolved) = execution_holons.by_snapshot_id.get(head_id) else {
         return Ok(None);
     };
 

--- a/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
+++ b/tests/sweetests/src/harness/execution_support/equivalence_resolver.rs
@@ -41,6 +41,9 @@ impl EquivalenceResolver for ExecutionEquivalenceResolver<'_> {
 fn is_saved_lookup_stub(reference: &HolonReference) -> Result<bool, HolonError> {
     match reference {
         HolonReference::Smart(smart) => {
+            // A saved-lookup stub may be a SmartReference with only cached
+            // marker/key properties. Calling `property_value()` would try to
+            // fetch backing saved content, which stubs intentionally lack.
             Ok(smart.smart_property_values().is_some_and(|properties| {
                 properties.contains_key(&SAVED_LOOKUP_STUB_MARKER.to_property_name())
             }))

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -14,8 +14,8 @@
 //! The expected snapshot that comes from the executor input token is intent; the resulting reference is 'DHT' reality.
 
 use crate::{
-    ExecutionEquivalenceResolver, ExecutionHolons, ExpectedSnapshot, TestReference,
-    SAVED_LOOKUP_STUB_MARKER,
+    ExecutionEquivalenceResolver, ExecutionHolons, ExpectedSnapshot, FixtureHeadIndex,
+    TestReference, SAVED_LOOKUP_STUB_MARKER,
 };
 use holons_core::core_shared_objects::holon::EssentialHolonContent;
 use holons_prelude::prelude::*;
@@ -121,13 +121,17 @@ impl ExecutionReference {
     /// derive definitional relationship policy from the actual saved root, and
     /// delegate relationship member comparison to the shared reference-layer
     /// comparator through `ExecutionEquivalenceResolver`.
-    pub fn assert_saved_content_eq(&self, execution_holons: &ExecutionHolons) {
+    pub fn assert_saved_content_eq(
+        &self,
+        execution_holons: &ExecutionHolons,
+        fixture_head_index: &FixtureHeadIndex,
+    ) {
         let expected_root = HolonReference::from(self.expected_snapshot.snapshot());
         let actual_root = self
             .execution_handle
             .get_holon_reference()
             .expect("Failed to get HolonReference for execution_handle");
-        let resolver = ExecutionEquivalenceResolver::new(execution_holons);
+        let resolver = ExecutionEquivalenceResolver::new(execution_holons, fixture_head_index);
 
         Self::compare_saved_content_root(&expected_root, &actual_root, &resolver).unwrap_or_else(
             |message| {

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -46,6 +46,7 @@ pub enum ExecutionHandle {
 }
 
 impl ExecutionHandle {
+    #[allow(deprecated)]
     pub fn essential_content(&self) -> Result<EssentialHolonContent, HolonError> {
         match self {
             Self::LiveReference(holon_reference) => holon_reference.essential_content(),
@@ -145,6 +146,9 @@ impl ExecutionReference {
         .unwrap_or_else(|message| panic!("{}", message));
     }
 
+    // Legacy subset assertion still compares raw essential content until the
+    // harness-local subset policy is separated from definitional equivalence.
+    #[allow(deprecated)]
     fn compare_holon_graph_eq(
         expected: &HolonReference,
         actual: &HolonReference,

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -19,8 +19,14 @@ use crate::{
 };
 use holons_core::core_shared_objects::holon::EssentialHolonContent;
 use holons_prelude::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+
+#[derive(Clone, Debug)]
+struct DefinitionalRelationshipPolicy {
+    name: RelationshipName,
+    is_ordered: bool,
+}
 
 #[derive(Clone, Debug)]
 pub struct ExecutionReference {
@@ -105,12 +111,16 @@ impl ExecutionReference {
             .unwrap_or_else(|message| panic!("{}", message));
     }
 
-    /// Assert saved DB content using reference-layer definitional equivalence.
+    /// Assert saved DB content using harness-root policy plus shared member equivalence.
     ///
     /// Commit may persist non-definitional navigational edges, such as inverse
-    /// SmartLinks, that were never present in fixture snapshots. The shared
-    /// comparator derives each side's definitional relationship surface from
-    /// its descriptor and ignores non-definitional edges.
+    /// SmartLinks, that were never present in fixture snapshots. Loader-owned
+    /// schema descriptors may also appear in fixtures only as key-only
+    /// `SavedLookup` stubs. The harness therefore keeps the root comparison
+    /// aligned with fixture reality: compare root properties structurally,
+    /// derive definitional relationship policy from the actual saved root, and
+    /// delegate relationship member comparison to the shared reference-layer
+    /// comparator through `ExecutionEquivalenceResolver`.
     pub fn assert_saved_content_eq(&self, execution_holons: &ExecutionHolons) {
         let expected_root = HolonReference::from(self.expected_snapshot.snapshot());
         let actual_root = self
@@ -119,30 +129,76 @@ impl ExecutionReference {
             .expect("Failed to get HolonReference for execution_handle");
         let resolver = ExecutionEquivalenceResolver::new(execution_holons);
 
-        match expected_root.definitional_equivalence_with_resolver(&actual_root, &resolver) {
-            Ok(EquivalenceOutcome::Equivalent) => {}
-            Ok(EquivalenceOutcome::Divergent(divergence)) => {
+        Self::compare_saved_content_root(&expected_root, &actual_root, &resolver).unwrap_or_else(
+            |message| {
                 panic!(
-                    "saved content mismatch for expected {}:{} vs actual {}:{}\npath: {}\nreason: {}",
+                    "saved content mismatch for expected {}:{} vs actual {}:{}\n{}",
                     expected_root.reference_kind_string(),
                     expected_root.reference_id_string(),
                     actual_root.reference_kind_string(),
                     actual_root.reference_id_string(),
-                    Self::format_divergence_path(&divergence.path),
-                    divergence.reason
-                );
-            }
-            Err(e) => {
-                panic!(
-                    "failed to compare saved content for expected {}:{} vs actual {}:{}: {:?}",
-                    expected_root.reference_kind_string(),
-                    expected_root.reference_id_string(),
-                    actual_root.reference_kind_string(),
-                    actual_root.reference_id_string(),
-                    e
-                );
-            }
+                    message
+                )
+            },
+        );
+    }
+
+    /// Saved-content root policy for fixture-authored expectations.
+    ///
+    /// This is intentionally not the full shared definitional-equivalence
+    /// relation at the root. Fixture snapshots own authored root properties and
+    /// declared root edges, but loader-saved schema/type descriptors are modeled
+    /// as opaque key-only stubs. The actual saved descriptor is therefore the
+    /// source of truth for which root relationships are definitional; member
+    /// subtrees use the shared comparator.
+    #[allow(deprecated)]
+    fn compare_saved_content_root(
+        expected: &HolonReference,
+        actual: &HolonReference,
+        resolver: &ExecutionEquivalenceResolver<'_>,
+    ) -> Result<(), String> {
+        let expected_content = expected.essential_content().map_err(|e| {
+            format!(
+                "failed to read expected root content {}:{}: {:?}",
+                expected.reference_kind_string(),
+                expected.reference_id_string(),
+                e
+            )
+        })?;
+        let actual_content = actual.essential_content().map_err(|e| {
+            format!(
+                "failed to read actual root content {}:{}: {:?}",
+                actual.reference_kind_string(),
+                actual.reference_id_string(),
+                e
+            )
+        })?;
+
+        if expected_content.property_map != actual_content.property_map {
+            return Err(format!(
+                "path: <root>\nreason: property map mismatch\nexpected: {:#?}\nactual: {:#?}",
+                expected_content.property_map, actual_content.property_map
+            ));
         }
+
+        let relationship_policies = Self::actual_definitional_relationship_policies(actual)?;
+        let expected_relationship_map = expected
+            .all_related_holons()
+            .map_err(|e| format!("failed to get expected root all_related_holons: {:?}", e))?;
+        let actual_relationship_map = actual
+            .all_related_holons()
+            .map_err(|e| format!("failed to get actual root all_related_holons: {:?}", e))?;
+
+        for relationship_policy in relationship_policies {
+            Self::compare_saved_root_relationship(
+                &expected_relationship_map,
+                &actual_relationship_map,
+                &relationship_policy,
+                resolver,
+            )?;
+        }
+
+        Ok(())
     }
 
     /// Harness-local subset assertion for per-step expected-content checks.
@@ -280,6 +336,227 @@ impl ExecutionReference {
         }
 
         Ok(())
+    }
+
+    fn actual_definitional_relationship_policies(
+        actual: &HolonReference,
+    ) -> Result<Vec<DefinitionalRelationshipPolicy>, String> {
+        let descriptor = match actual.holon_descriptor() {
+            Ok(descriptor) => descriptor,
+            Err(HolonError::MissingDescribedBy { .. }) => {
+                let relationship_map = actual.all_related_holons().map_err(|e| {
+                    format!(
+                        "failed to get actual root relationships for undescribed holon check: {:?}",
+                        e
+                    )
+                })?;
+                if Self::relationship_entries_with_members(&relationship_map)?.is_empty() {
+                    return Ok(Vec::new());
+                }
+                return Err(format!(
+                    "path: <root>\nreason: cannot derive definitional relationships for undescribed actual holon {}:{} with relationship content",
+                    actual.reference_kind_string(),
+                    actual.reference_id_string()
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "path: <root>\nreason: failed to resolve actual root descriptor: {:?}",
+                    e
+                ));
+            }
+        };
+
+        let mut policies = HashMap::new();
+        for relationship_descriptor in descriptor.instance_relationships().map_err(|e| {
+            format!(
+                "path: <root>\nreason: failed to resolve actual root instance relationships: {:?}",
+                e
+            )
+        })? {
+            if relationship_descriptor.is_definitional().map_err(|e| {
+                format!("path: <root>\nreason: failed to read IsDefinitional: {:?}", e)
+            })? {
+                let name = relationship_descriptor.base_relationship_name().map_err(|e| {
+                    format!(
+                        "path: <root>\nreason: failed to read definitional relationship name: {:?}",
+                        e
+                    )
+                })?;
+                let is_ordered = relationship_descriptor.is_ordered().map_err(|e| {
+                    format!(
+                        "path: <root>\nreason: failed to read IsOrdered for {:?}: {:?}",
+                        name, e
+                    )
+                })?;
+                policies.entry(name).or_insert(is_ordered);
+            }
+        }
+
+        let mut policies: Vec<_> = policies
+            .into_iter()
+            .map(|(name, is_ordered)| DefinitionalRelationshipPolicy { name, is_ordered })
+            .collect();
+        policies.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(policies)
+    }
+
+    fn compare_saved_root_relationship(
+        expected_relationship_map: &RelationshipMap,
+        actual_relationship_map: &RelationshipMap,
+        relationship_policy: &DefinitionalRelationshipPolicy,
+        resolver: &dyn EquivalenceResolver,
+    ) -> Result<(), String> {
+        let expected_members =
+            Self::relationship_members(expected_relationship_map, &relationship_policy.name)?;
+        let actual_members =
+            Self::relationship_members(actual_relationship_map, &relationship_policy.name)?;
+
+        if expected_members.is_empty() && actual_members.is_empty() {
+            return Ok(());
+        }
+
+        if relationship_policy.is_ordered {
+            return Self::compare_ordered_saved_root_members(
+                &relationship_policy.name,
+                &expected_members,
+                &actual_members,
+                resolver,
+            );
+        }
+
+        Self::compare_unordered_saved_root_members(
+            &relationship_policy.name,
+            &expected_members,
+            &actual_members,
+            resolver,
+        )
+    }
+
+    fn compare_ordered_saved_root_members(
+        relationship_name: &RelationshipName,
+        expected_members: &[HolonReference],
+        actual_members: &[HolonReference],
+        resolver: &dyn EquivalenceResolver,
+    ) -> Result<(), String> {
+        if expected_members.len() != actual_members.len() {
+            return Err(format!(
+                "path: {:?}\nreason: ordered member count mismatch: expected {}, actual {}",
+                relationship_name,
+                expected_members.len(),
+                actual_members.len()
+            ));
+        }
+
+        for (index, (expected_member, actual_member)) in
+            expected_members.iter().zip(actual_members.iter()).enumerate()
+        {
+            Self::compare_saved_root_member_pair(
+                relationship_name,
+                expected_member,
+                actual_member,
+                resolver,
+            )
+            .map_err(|message| format!("{} at index {}", message, index))?;
+        }
+
+        Ok(())
+    }
+
+    fn compare_unordered_saved_root_members(
+        relationship_name: &RelationshipName,
+        expected_members: &[HolonReference],
+        actual_members: &[HolonReference],
+        resolver: &dyn EquivalenceResolver,
+    ) -> Result<(), String> {
+        let mut unmatched_actual = actual_members.to_vec();
+        let mut last_error = None;
+
+        for expected_member in expected_members {
+            let mut matched_index = None;
+            for (index, actual_member) in unmatched_actual.iter().enumerate() {
+                match Self::compare_saved_root_member_pair(
+                    relationship_name,
+                    expected_member,
+                    actual_member,
+                    resolver,
+                ) {
+                    Ok(()) => {
+                        matched_index = Some(index);
+                        break;
+                    }
+                    Err(err) => last_error = Some(err),
+                }
+            }
+
+            match matched_index {
+                Some(index) => {
+                    unmatched_actual.remove(index);
+                }
+                None => {
+                    return Err(format!(
+                        "path: {:?}\nreason: no matching member found for expected member {}:{}. Last mismatch: {}",
+                        relationship_name,
+                        expected_member.reference_kind_string(),
+                        expected_member.reference_id_string(),
+                        last_error.unwrap_or_else(|| "no candidate mismatch details available".to_string())
+                    ));
+                }
+            }
+        }
+
+        if !unmatched_actual.is_empty() {
+            return Err(format!(
+                "path: {:?}\nreason: actual root has {} extra definitional member(s)",
+                relationship_name,
+                unmatched_actual.len()
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn compare_saved_root_member_pair(
+        relationship_name: &RelationshipName,
+        expected_member: &HolonReference,
+        actual_member: &HolonReference,
+        resolver: &dyn EquivalenceResolver,
+    ) -> Result<(), String> {
+        match expected_member.definitional_equivalence_with_resolver(actual_member, resolver) {
+            Ok(EquivalenceOutcome::Equivalent) => Ok(()),
+            Ok(EquivalenceOutcome::Divergent(mut divergence)) => {
+                divergence.path.insert(0, relationship_name.clone());
+                Err(format!(
+                    "path: {}\nreason: {}",
+                    Self::format_divergence_path(&divergence.path),
+                    divergence.reason
+                ))
+            }
+            Err(e) => Err(format!(
+                "path: {:?}\nreason: failed to compare relationship member: {:?}",
+                relationship_name, e
+            )),
+        }
+    }
+
+    fn relationship_members(
+        relationship_map: &RelationshipMap,
+        relationship_name: &RelationshipName,
+    ) -> Result<Vec<HolonReference>, String> {
+        let Some(collection_arc) = relationship_map
+            .iter()
+            .into_iter()
+            .find(|(name, _)| name == relationship_name)
+            .map(|(_, collection_arc)| collection_arc.clone())
+        else {
+            return Ok(Vec::new());
+        };
+
+        let collection = collection_arc.read().map_err(|e| {
+            format!("Failed to acquire read lock for relationship {:?}: {}", relationship_name, e)
+        })?;
+
+        Ok(collection.get_members().clone())
     }
 
     /// Returns whether the expected holon carries the saved-lookup stub marker.

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -14,22 +14,13 @@
 //! The expected snapshot that comes from the executor input token is intent; the resulting reference is 'DHT' reality.
 
 use crate::{
-    ExecutionHolons, ExpectedSnapshot, SnapshotId, TestReference, SAVED_LOOKUP_STUB_MARKER,
+    ExecutionEquivalenceResolver, ExecutionHolons, ExpectedSnapshot, TestReference,
+    SAVED_LOOKUP_STUB_MARKER,
 };
 use holons_core::core_shared_objects::holon::EssentialHolonContent;
 use holons_prelude::prelude::*;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum RelationshipComparisonPolicy {
-    // These variants intentionally bundle three comparison axes: relationship
-    // scope, cardinality semantics, and member match strategy. Keep that
-    // coupling explicit until graph comparison policy is extracted from the
-    // sweettest harness.
-    ExpectedSubsetAllRelationships,
-    ExactDefinitionalRelationships,
-}
 
 #[derive(Clone, Debug)]
 pub struct ExecutionReference {
@@ -110,51 +101,60 @@ impl ExecutionReference {
             .get_holon_reference()
             .expect("Failed to get HolonReference for execution_handle");
         let mut visited_pairs: HashSet<(String, String)> = HashSet::new();
-        Self::compare_holon_graph_eq(
-            &expected_root,
-            &actual_root,
-            &mut visited_pairs,
-            RelationshipComparisonPolicy::ExpectedSubsetAllRelationships,
-            None,
-        )
-        .unwrap_or_else(|message| panic!("{}", message));
+        Self::compare_expected_subset(&expected_root, &actual_root, &mut visited_pairs)
+            .unwrap_or_else(|message| panic!("{}", message));
     }
 
-    /// Assert saved DB content using essential content plus definitional relationships.
+    /// Assert saved DB content using reference-layer definitional equivalence.
     ///
     /// Commit may persist non-definitional navigational edges, such as inverse
-    /// SmartLinks, that were never present in fixture snapshots. Saved content
-    /// comparison therefore derives the actual holon's definitional
-    /// relationship surface from its descriptor, compares that filtered graph
-    /// exactly, and matches relationship members by saved holon identity. Each saved
-    /// fixture holon is still compared as its own root, so member content does
-    /// not need to be recursively revalidated from every relationship edge.
+    /// SmartLinks, that were never present in fixture snapshots. The shared
+    /// comparator derives each side's definitional relationship surface from
+    /// its descriptor and ignores non-definitional edges.
     pub fn assert_saved_content_eq(&self, execution_holons: &ExecutionHolons) {
         let expected_root = HolonReference::from(self.expected_snapshot.snapshot());
         let actual_root = self
             .execution_handle
             .get_holon_reference()
             .expect("Failed to get HolonReference for execution_handle");
-        let mut visited_pairs: HashSet<(String, String)> = HashSet::new();
-        Self::compare_holon_graph_eq(
-            &expected_root,
-            &actual_root,
-            &mut visited_pairs,
-            RelationshipComparisonPolicy::ExactDefinitionalRelationships,
-            Some(execution_holons),
-        )
-        .unwrap_or_else(|message| panic!("{}", message));
+        let resolver = ExecutionEquivalenceResolver::new(execution_holons);
+
+        match expected_root.definitional_equivalence_with_resolver(&actual_root, &resolver) {
+            Ok(EquivalenceOutcome::Equivalent) => {}
+            Ok(EquivalenceOutcome::Divergent(divergence)) => {
+                panic!(
+                    "saved content mismatch for expected {}:{} vs actual {}:{}\npath: {}\nreason: {}",
+                    expected_root.reference_kind_string(),
+                    expected_root.reference_id_string(),
+                    actual_root.reference_kind_string(),
+                    actual_root.reference_id_string(),
+                    Self::format_divergence_path(&divergence.path),
+                    divergence.reason
+                );
+            }
+            Err(e) => {
+                panic!(
+                    "failed to compare saved content for expected {}:{} vs actual {}:{}: {:?}",
+                    expected_root.reference_kind_string(),
+                    expected_root.reference_id_string(),
+                    actual_root.reference_kind_string(),
+                    actual_root.reference_id_string(),
+                    e
+                );
+            }
+        }
     }
 
-    // Legacy subset assertion still compares raw essential content until the
-    // harness-local subset policy is separated from definitional equivalence.
+    /// Harness-local subset assertion for per-step expected-content checks.
+    ///
+    /// Definitional equivalence lives in `holons_core`; this helper intentionally
+    /// keeps the older expected-subset/all-relationships semantics used by
+    /// `assert_essential_content_eq`.
     #[allow(deprecated)]
-    fn compare_holon_graph_eq(
+    fn compare_expected_subset(
         expected: &HolonReference,
         actual: &HolonReference,
         visited_pairs: &mut HashSet<(String, String)>,
-        policy: RelationshipComparisonPolicy,
-        execution_holons: Option<&ExecutionHolons>,
     ) -> Result<(), String> {
         let pair_key = Self::pair_key(expected, actual);
         if !visited_pairs.insert(pair_key) {
@@ -222,44 +222,10 @@ impl ExecutionReference {
         let actual_relationship_map =
             actual_relationship_map.expect("checked above: actual_relationship_map is Some");
 
-        let (expected_relationships, actual_relationships) = match policy {
-            RelationshipComparisonPolicy::ExpectedSubsetAllRelationships => (
-                Self::relationship_entries_with_members(&expected_relationship_map)?,
-                Self::relationship_entries_with_members(&actual_relationship_map)?,
-            ),
-            RelationshipComparisonPolicy::ExactDefinitionalRelationships => {
-                let definitional_relationship_names = Self::definitional_relationship_names(
-                    actual,
-                    &expected_relationship_map,
-                    &actual_relationship_map,
-                )?;
-                (
-                    Self::relationship_entries_for_names(
-                        &expected_relationship_map,
-                        &definitional_relationship_names,
-                    )?,
-                    Self::relationship_entries_for_names(
-                        &actual_relationship_map,
-                        &definitional_relationship_names,
-                    )?,
-                )
-            }
-        };
-
-        if policy == RelationshipComparisonPolicy::ExactDefinitionalRelationships {
-            let expected_relationship_names: HashSet<RelationshipName> = expected_relationships
-                .iter()
-                .map(|(relationship_name, _)| relationship_name.clone())
-                .collect();
-            for (actual_relationship_name, _) in actual_relationships.iter() {
-                if !expected_relationship_names.contains(actual_relationship_name) {
-                    return Err(format!(
-                        "expected relationship map is missing definitional relationship {:?}",
-                        actual_relationship_name
-                    ));
-                }
-            }
-        }
+        let expected_relationships =
+            Self::relationship_entries_with_members(&expected_relationship_map)?;
+        let actual_relationships =
+            Self::relationship_entries_with_members(&actual_relationship_map)?;
 
         for (relationship_name, expected_collection_arc) in expected_relationships {
             let expected_collection = expected_collection_arc.read().map_err(|e| {
@@ -283,29 +249,8 @@ impl ExecutionReference {
             let mut unmatched_actual = actual_collection.get_members().clone();
 
             for expected_member in expected_members {
-                let (matched_index, matched_visited_state, last_error) = match policy {
-                    RelationshipComparisonPolicy::ExpectedSubsetAllRelationships => {
-                        Self::match_by_graph(
-                            &expected_member,
-                            &unmatched_actual,
-                            visited_pairs,
-                            policy,
-                            execution_holons,
-                        )
-                    }
-                    RelationshipComparisonPolicy::ExactDefinitionalRelationships => {
-                        let execution_holons = execution_holons.ok_or_else(|| {
-                            "saved-content identity comparison requires execution registry"
-                                .to_string()
-                        })?;
-                        let (matched_index, last_error) = Self::match_by_saved_identity(
-                            &expected_member,
-                            &unmatched_actual,
-                            execution_holons,
-                        );
-                        (matched_index, None, last_error)
-                    }
-                };
+                let (matched_index, matched_visited_state, last_error) =
+                    Self::match_by_graph(&expected_member, &unmatched_actual, visited_pairs);
 
                 match matched_index {
                     Some(index) => {
@@ -331,16 +276,6 @@ impl ExecutionReference {
                         ));
                     }
                 }
-            }
-
-            if policy == RelationshipComparisonPolicy::ExactDefinitionalRelationships
-                && !unmatched_actual.is_empty()
-            {
-                return Err(format!(
-                    "actual definitional relationship {:?} has {} extra member(s)",
-                    relationship_name,
-                    unmatched_actual.len()
-                ));
             }
         }
 
@@ -392,8 +327,6 @@ impl ExecutionReference {
         expected_member: &HolonReference,
         unmatched_actual: &[HolonReference],
         visited_pairs: &HashSet<(String, String)>,
-        policy: RelationshipComparisonPolicy,
-        execution_holons: Option<&ExecutionHolons>,
     ) -> (Option<usize>, Option<HashSet<(String, String)>>, Option<String>) {
         let mut matched_index: Option<usize> = None;
         let mut matched_visited_state: Option<HashSet<(String, String)>> = None;
@@ -401,12 +334,10 @@ impl ExecutionReference {
 
         for (index, actual_member) in unmatched_actual.iter().enumerate() {
             let mut candidate_visited = visited_pairs.clone();
-            match Self::compare_holon_graph_eq(
+            match Self::compare_expected_subset(
                 expected_member,
                 actual_member,
                 &mut candidate_visited,
-                policy,
-                execution_holons,
             ) {
                 Ok(()) => {
                     matched_index = Some(index);
@@ -420,94 +351,6 @@ impl ExecutionReference {
         }
 
         (matched_index, matched_visited_state, last_error)
-    }
-
-    fn match_by_saved_identity(
-        expected_member: &HolonReference,
-        unmatched_actual: &[HolonReference],
-        execution_holons: &ExecutionHolons,
-    ) -> (Option<usize>, Option<String>) {
-        let mut last_error = None;
-
-        for (index, actual_member) in unmatched_actual.iter().enumerate() {
-            match Self::compare_saved_identity(expected_member, actual_member, execution_holons) {
-                Ok(()) => return (Some(index), None),
-                Err(err) => last_error = Some(err),
-            }
-        }
-
-        (None, last_error)
-    }
-
-    fn compare_saved_identity(
-        expected: &HolonReference,
-        actual: &HolonReference,
-        execution_holons: &ExecutionHolons,
-    ) -> Result<(), String> {
-        let expected_id = Self::expected_saved_holon_id(expected, execution_holons)?;
-        let actual_id = actual.holon_id().map_err(|e| {
-            format!(
-                "failed to read actual member holon id for {}:{}: {:?}",
-                actual.reference_kind_string(),
-                actual.reference_id_string(),
-                e
-            )
-        })?;
-
-        if expected_id == actual_id {
-            Ok(())
-        } else {
-            Err(format!(
-                "member HolonId mismatch: expected {:?}, actual {:?}",
-                expected_id, actual_id
-            ))
-        }
-    }
-
-    fn expected_saved_holon_id(
-        expected: &HolonReference,
-        execution_holons: &ExecutionHolons,
-    ) -> Result<HolonId, String> {
-        match expected {
-            HolonReference::Smart(_) => expected.holon_id().map_err(|e| {
-                format!(
-                    "failed to read expected saved member holon id for {}:{}: {:?}",
-                    expected.reference_kind_string(),
-                    expected.reference_id_string(),
-                    e
-                )
-            }),
-            HolonReference::Transient(transient) => {
-                Self::saved_holon_id_for_snapshot(&transient.temporary_id(), execution_holons)
-            }
-            HolonReference::Staged(staged) => {
-                Self::saved_holon_id_for_snapshot(&staged.temporary_id(), execution_holons)
-            }
-        }
-    }
-
-    fn saved_holon_id_for_snapshot(
-        snapshot_id: &SnapshotId,
-        execution_holons: &ExecutionHolons,
-    ) -> Result<HolonId, String> {
-        let resolved = execution_holons.by_snapshot_id.get(snapshot_id).ok_or_else(|| {
-            format!(
-                "no execution reference recorded for expected relationship member snapshot {}",
-                snapshot_id
-            )
-        })?;
-        let reference = resolved.execution_handle.get_holon_reference().map_err(|e| {
-            format!(
-                "failed to get execution reference for expected relationship member snapshot {}: {:?}",
-                snapshot_id, e
-            )
-        })?;
-        reference.holon_id().map_err(|e| {
-            format!(
-                "expected relationship member snapshot {} did not resolve to a saved holon id: {:?}",
-                snapshot_id, e
-            )
-        })
     }
 
     /// Returns only relationship entries whose collections currently contain
@@ -541,84 +384,18 @@ impl ExecutionReference {
         Ok(entries)
     }
 
-    fn relationship_entries_for_names(
-        relationship_map: &RelationshipMap,
-        relationship_names: &HashSet<RelationshipName>,
-    ) -> Result<Vec<(RelationshipName, Arc<RwLock<HolonCollection>>)>, String> {
-        Ok(Self::relationship_entries_with_members(relationship_map)?
-            .into_iter()
-            .filter(|(relationship_name, _)| relationship_names.contains(relationship_name))
-            .collect())
-    }
-
-    fn definitional_relationship_names(
-        actual: &HolonReference,
-        expected_relationship_map: &RelationshipMap,
-        actual_relationship_map: &RelationshipMap,
-    ) -> Result<HashSet<RelationshipName>, String> {
-        let descriptor = match actual.holon_descriptor() {
-            Ok(descriptor) => descriptor,
-            Err(HolonError::MissingDescribedBy { .. }) => {
-                let expected_relationships =
-                    Self::relationship_entries_with_members(expected_relationship_map)?;
-                let actual_relationships =
-                    Self::relationship_entries_with_members(actual_relationship_map)?;
-                if expected_relationships.is_empty() && actual_relationships.is_empty() {
-                    return Ok(HashSet::new());
-                }
-                return Err(format!(
-                    "cannot derive definitional relationships for undescribed actual holon {}:{} with relationship content",
-                    actual.reference_kind_string(),
-                    actual.reference_id_string()
-                ));
-            }
-            Err(e) => {
-                return Err(format!(
-                    "failed to resolve descriptor for actual holon {}:{} while deriving definitional relationships: {:?}",
-                    actual.reference_kind_string(),
-                    actual.reference_id_string(),
-                    e
-                ));
-            }
-        };
-
-        let mut relationship_names = HashSet::new();
-        for relationship_descriptor in descriptor.instance_relationships().map_err(|e| {
-            format!(
-                "failed to resolve effective instance relationships for actual holon {}:{}: {:?}",
-                actual.reference_kind_string(),
-                actual.reference_id_string(),
-                e
-            )
-        })? {
-            if relationship_descriptor.is_definitional().map_err(|e| {
-                format!(
-                    "failed to read IsDefinitional while deriving saved-content relationship set for actual holon {}:{}: {:?}",
-                    actual.reference_kind_string(),
-                    actual.reference_id_string(),
-                    e
-                )
-            })? {
-                relationship_names.insert(relationship_descriptor.base_relationship_name().map_err(
-                    |e| {
-                        format!(
-                            "failed to read definitional relationship name for actual holon {}:{}: {:?}",
-                            actual.reference_kind_string(),
-                            actual.reference_id_string(),
-                            e
-                        )
-                    },
-                )?);
-            }
-        }
-
-        Ok(relationship_names)
-    }
-
     fn pair_key(expected: &HolonReference, actual: &HolonReference) -> (String, String) {
         (
             format!("{}:{}", expected.reference_kind_string(), expected.reference_id_string()),
             format!("{}:{}", actual.reference_kind_string(), actual.reference_id_string()),
         )
+    }
+
+    fn format_divergence_path(path: &[RelationshipName]) -> String {
+        if path.is_empty() {
+            "<root>".to_string()
+        } else {
+            path.iter().map(|segment| format!("{:?}", segment)).collect::<Vec<_>>().join(" -> ")
+        }
     }
 }

--- a/tests/sweetests/src/harness/execution_support/execution_state.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_state.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::harness::{
     execution_support::{ExecutionHolons, ExecutionReference, ResolveBy},
-    fixtures_support::TestReference,
+    fixtures_support::{FixtureHeadIndex, TestReference},
 };
 use holons_boundary::SerializableHolonPool;
 use holons_prelude::prelude::*;
@@ -31,6 +31,7 @@ pub struct TestExecutionState {
     runtime: Runtime,
     active_tx_id: TxId,
     fixture_transient_holons: SerializableHolonPool,
+    fixture_head_index: FixtureHeadIndex,
     // Registry of realized references keyed by source token's `TemporaryId`.
     execution_holons: ExecutionHolons,
 }
@@ -40,11 +41,13 @@ impl TestExecutionState {
         runtime: Runtime,
         tx_id: TxId,
         fixture_transient_holons: SerializableHolonPool,
+        fixture_head_index: FixtureHeadIndex,
     ) -> Self {
         TestExecutionState {
             runtime,
             active_tx_id: tx_id,
             fixture_transient_holons,
+            fixture_head_index,
             execution_holons: ExecutionHolons::default(),
         }
     }
@@ -147,6 +150,12 @@ impl TestExecutionState {
     #[inline]
     pub fn holons(&self) -> &ExecutionHolons {
         &self.execution_holons
+    }
+
+    /// Borrow frozen fixture head redirection for assertion-time reference translation.
+    #[inline]
+    pub fn fixture_head_index(&self) -> &FixtureHeadIndex {
+        &self.fixture_head_index
     }
 
     /// Borrow the registry (mutable).

--- a/tests/sweetests/src/harness/execution_support/mod.rs
+++ b/tests/sweetests/src/harness/execution_support/mod.rs
@@ -1,7 +1,9 @@
+pub mod equivalence_resolver;
 pub mod execution_holons;
 pub mod execution_reference;
 pub mod execution_state;
 
+pub use equivalence_resolver::*;
 pub use execution_holons::*;
 pub use execution_reference::*;
 pub use execution_state::*;

--- a/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
+++ b/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
@@ -13,6 +13,23 @@ use holons_core::ReadableHolon;
 use sha2::{Digest, Sha256};
 use uuid::{Builder, Uuid};
 
+/// Immutable snapshot-id to current-head snapshot-id lookup for execution-time
+/// consumers that cannot depend on mutable fixture-authoring state.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FixtureHeadIndex {
+    by_snapshot_id: BTreeMap<SnapshotId, SnapshotId>,
+}
+
+impl FixtureHeadIndex {
+    pub fn new(by_snapshot_id: BTreeMap<SnapshotId, SnapshotId>) -> Self {
+        Self { by_snapshot_id }
+    }
+
+    pub fn get(&self, snapshot_id: &SnapshotId) -> Option<&SnapshotId> {
+        self.by_snapshot_id.get(snapshot_id)
+    }
+}
+
 /// Hashes the TemporaryId of the first source snapshot token minted
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FixtureHolonId(pub Uuid);
@@ -201,6 +218,26 @@ impl FixtureHolons {
         let id = token.expected_id();
         let fixture_holon = self.get_fixture_holon_by_snapshot(&id)?;
         Ok(fixture_holon.head_snapshot.snapshot().into())
+    }
+
+    /// Returns the current head snapshot id for the logical holon that owns
+    /// `snapshot_id`, or `None` when the id is not tracked by fixture state.
+    pub fn head_snapshot_id_for(&self, snapshot_id: &SnapshotId) -> Option<SnapshotId> {
+        let fixture_id = self.snapshot_to_fixture_holon.get(snapshot_id)?;
+        Some(self.holons.get(fixture_id)?.head_snapshot.id())
+    }
+
+    /// Freezes fixture head redirection for execution-time consumers.
+    ///
+    /// Head advancement is complete by fixture finalization, so this index is
+    /// stable for the duration of execution.
+    pub fn head_snapshot_index(&self) -> FixtureHeadIndex {
+        FixtureHeadIndex::new(
+            self.snapshot_to_fixture_holon
+                .keys()
+                .filter_map(|id| self.head_snapshot_id_for(id).map(|head_id| (id.clone(), head_id)))
+                .collect(),
+        )
     }
 
     /// Removes relationships from staged head snapshots that target the supplied

--- a/tests/sweetests/src/harness/fixtures_support/test_reference.rs
+++ b/tests/sweetests/src/harness/fixtures_support/test_reference.rs
@@ -176,6 +176,7 @@ impl ExpectedSnapshot {
         SourceSnapshot::new(self.snapshot.clone(), self.state)
     }
 
+    #[allow(deprecated)]
     pub fn essential_content(&self) -> Result<EssentialHolonContent, HolonError> {
         self.snapshot.essential_content()
     }

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -85,11 +85,12 @@ impl DancesTestCase {
     pub fn finalize(
         &mut self,
         fixture_context: &Arc<TransactionContext>,
+        fixture_holons: &FixtureHolons,
     ) -> Result<(), HolonError> {
         if self.is_finalized == true {
             return Err(HolonError::InvalidState("DancesTestCase already finalized!".to_string()));
         }
-        self.load_test_session_state(fixture_context);
+        self.load_test_session_state(fixture_context, fixture_holons);
         self.is_finalized = true;
 
         Ok(())
@@ -106,10 +107,15 @@ impl DancesTestCase {
     /// * `test_session_state` - A mutable reference to the `TestSessionState` that will be updated with transient holons.
     ///
     /// This function is called automatically within `rs_test` and should not be used directly.
-    pub fn load_test_session_state(&mut self, fixture_context: &Arc<TransactionContext>) {
+    pub fn load_test_session_state(
+        &mut self,
+        fixture_context: &Arc<TransactionContext>,
+        fixture_holons: &FixtureHolons,
+    ) {
         let transient_holons = fixture_context.export_transient_holons().unwrap();
         self.test_session_state
             .set_transient_holons(SerializableHolonPool::from(&transient_holons));
+        self.test_session_state.set_fixture_head_index(fixture_holons.head_snapshot_index());
     }
 
     // === Execution Steps === //

--- a/tests/sweetests/src/harness/test_case/test_case.rs
+++ b/tests/sweetests/src/harness/test_case/test_case.rs
@@ -9,7 +9,7 @@
 //! - [`TestSessionState`], which captures transient holon state produced during
 //!   fixture setup and injects it into the test execution context.
 
-use crate::{init_fixture_context, FixtureBindings, FixtureHolons};
+use crate::{init_fixture_context, FixtureBindings, FixtureHeadIndex, FixtureHolons};
 use holons_boundary::SerializableHolonPool;
 use holons_core::core_shared_objects::transactions::TransactionContext;
 use std::sync::Arc;
@@ -60,6 +60,7 @@ impl TestCaseInit {
 #[derive(Clone, Debug, Default)]
 pub struct TestSessionState {
     transient_holons: SerializableHolonPool,
+    fixture_head_index: FixtureHeadIndex,
 }
 
 impl TestSessionState {
@@ -69,5 +70,13 @@ impl TestSessionState {
 
     pub fn get_transient_holons(&self) -> &SerializableHolonPool {
         &self.transient_holons
+    }
+
+    pub fn set_fixture_head_index(&mut self, fixture_head_index: FixtureHeadIndex) {
+        self.fixture_head_index = fixture_head_index;
+    }
+
+    pub fn fixture_head_index(&self) -> &FixtureHeadIndex {
+        &self.fixture_head_index
     }
 }

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -64,7 +64,6 @@ use fixture_cases::ergonomic_add_remove_related_holons_fixture::*;
 use fixture_cases::load_book_person_inverse_schema_fixture::*;
 use fixture_cases::load_core_schema_fixture::*;
 use fixture_cases::load_holons_internal_fixture::*;
-use fixture_cases::load_inverse_oriented_book_person_instances_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
 use fixture_cases::simple_create_holon_fixture::*;
@@ -116,22 +115,29 @@ use holons_prelude::prelude::*;
 #[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
 #[case::load_core_schema_test(load_core_schema_fixture())]
 #[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
+#[case::frozen_member_head_redirect_test(frozen_member_head_redirect_fixture())]
 #[tokio::test(flavor = "multi_thread")]
 async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
-    // Setup
+    run_dance_test_case(input.unwrap()).await;
+}
 
+/// Drives a finalized `DancesTestCase` through runtime setup and step execution.
+///
+/// Shared by the parametrized `rstest_dance_tests` cases and by standalone tests
+/// such as the `#[ignore]`d cross-transaction regression pending issue #556.
+async fn run_dance_test_case(mut test_case: DancesTestCase) {
     // The heavy lifting for this test is in the test data set creation.
 
-    let mut test_case: DancesTestCase = input.unwrap();
     assert!(
         test_case.is_finalized(),
-        "DancesTestCase must be finalized before execution. Call test_case.finalize(&fixture_context) in the fixture."
+        "DancesTestCase must be finalized before execution. Call test_case.finalize(&fixture_context, &fixture_holons) in the fixture."
     );
     // Initialize runtime and execution state
     let fixture_transient_holons = test_case.test_session_state.get_transient_holons().clone();
+    let fixture_head_index = test_case.test_session_state.fixture_head_index().clone();
     let (runtime, tx_id) = init_test_runtime(&mut test_case).await;
     let mut test_execution_state =
-        TestExecutionState::new(runtime, tx_id, fixture_transient_holons);
+        TestExecutionState::new(runtime, tx_id, fixture_transient_holons, fixture_head_index);
 
     info!("\n\n{TEST_CLIENT_PREFIX} ******* STARTING {} TEST CASE WITH {} TEST STEPS ***************************", test_case.name, test_case.steps.len());
     info!("\n   Test Case Description: {}", test_case.description);
@@ -345,4 +351,20 @@ async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
         }
     }
     info!("\n{TEST_CLIENT_PREFIX} ------- END OF {} TEST CASE  ---------------", test_case.name);
+}
+
+/// Cross-transaction frozen-member regression, kept ready for issue #556.
+///
+/// Ignored until the sweettest relationship adders head-resolve execution-step
+/// target tokens (issue #556). Until then the frozen staged Person reference is
+/// carried into a later transaction's commit and correctly rejected by the
+/// production session-import bind. Remove `#[ignore]` once #556 lands.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "unblocked by #556: execution-step token head resolution"]
+async fn frozen_member_head_redirect_cross_tx_test() {
+    run_dance_test_case(
+        frozen_member_head_redirect_cross_tx_fixture()
+            .expect("cross-tx frozen-member fixture should build"),
+    )
+    .await;
 }

--- a/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
@@ -267,6 +267,7 @@ fn dump_error_holons_from_response(response_reference: &TransientReference) -> S
 }
 
 /// Compact dump of essential holon content (property map, key, errors).
+#[allow(deprecated)]
 fn dump_essential(holon_reference: &impl ReadableHolon) -> String {
     let essential_content_result = holon_reference.essential_content();
 

--- a/tests/sweetests/tests/execution_steps/load_holons_internal_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_holons_internal_executor.rs
@@ -34,6 +34,7 @@ fn read_string_property(
 
 /// Dump the `EssentialHolonContent` for any holon-like reference in a stable,
 /// human-readable format (test debugging aid).
+#[allow(deprecated)]
 fn dump_essential(_state: &mut TestExecutionState, holon_reference: &impl ReadableHolon) -> String {
     let essential_content = match holon_reference.essential_content() {
         Ok(content) => content,

--- a/tests/sweetests/tests/execution_steps/match_db_content_executor.rs
+++ b/tests/sweetests/tests/execution_steps/match_db_content_executor.rs
@@ -51,7 +51,7 @@ pub async fn execute_match_db_content(state: &mut TestExecutionState) {
                 expected_snapshot: resolved_reference.expected_snapshot.clone(),
                 execution_handle: ExecutionHandle::from(rebound_reference.clone()),
             };
-            rebound_exec_ref.assert_saved_content_eq(state.holons());
+            rebound_exec_ref.assert_saved_content_eq(state.holons(), state.fixture_head_index());
             info!(
                 "SUCCESS! DB fetched holon matched expected for: \n {:?}",
                 rebound_reference.summarize()

--- a/tests/sweetests/tests/execution_steps/stage_new_version_executor.rs
+++ b/tests/sweetests/tests/execution_steps/stage_new_version_executor.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info};
 ///
 /// Version lineage is established at commit time, not stage time, so this step
 /// intentionally does not assert a staged `Predecessor` relationship.
+#[allow(deprecated)]
 pub async fn execute_stage_new_version(
     state: &mut TestExecutionState,
     step_token: TestReference,

--- a/tests/sweetests/tests/fixture_cases/abandon_staged_changes_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/abandon_staged_changes_fixture.rs
@@ -168,7 +168,7 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     // )?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
@@ -72,7 +72,7 @@ pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
     // test_case.add_ensure_database_count_step( fixture_holons.count_saved())?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
@@ -13,7 +13,7 @@ use type_names::{CorePropertyTypeName::Description, ToPropertyName};
 pub fn ergonomic_add_remove_properties_fixture() -> Result<DancesTestCase, HolonError> {
     // == Init == //
 
-    let TestCaseInit { mut test_case, fixture_context, fixture_holons: _fixture_holons, fixture_bindings: _fixture_bindings } = TestCaseInit::new(
+    let TestCaseInit { mut test_case, fixture_context, fixture_holons, fixture_bindings: _fixture_bindings } = TestCaseInit::new(
         "Ergonomic Add / Remove Holon Properties Testcase".to_string(),
         "Tests the adding and removing of Holon properties using all combinations of ergonomic values".to_string(),
     );
@@ -133,7 +133,7 @@ pub fn ergonomic_add_remove_properties_fixture() -> Result<DancesTestCase, Holon
     assert_eq!(staged_essential_after_remove, book_staged_reference.essential_content()?);
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
@@ -9,6 +9,7 @@ use rstest::*;
 use type_names::{CorePropertyTypeName::Description, ToPropertyName};
 
 #[fixture]
+#[allow(deprecated)]
 pub fn ergonomic_add_remove_properties_fixture() -> Result<DancesTestCase, HolonError> {
     // == Init == //
 

--- a/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_related_holons_fixture.rs
@@ -12,7 +12,7 @@ use type_names::{CoreRelationshipTypeName::DescribedBy, ToRelationshipName};
 #[fixture]
 pub fn ergonomic_add_remove_related_holons_fixture() -> Result<DancesTestCase, HolonError> {
     // == Init == //
-    let TestCaseInit { mut test_case, fixture_context, fixture_holons: _fixture_holons, fixture_bindings: _fixture_bindings } = TestCaseInit::new(
+    let TestCaseInit { mut test_case, fixture_context, fixture_holons, fixture_bindings: _fixture_bindings } = TestCaseInit::new(
         "Ergonomic Add / Remove Related Holons Testcase".to_string(),
         "Tests the adding and removing of related Holons, using all combinations of ergonomic relationship names, for both Transient & Staged Holons".to_string(),
     );
@@ -187,7 +187,7 @@ pub fn ergonomic_add_remove_related_holons_fixture() -> Result<DancesTestCase, H
     // == //
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -133,7 +133,261 @@ pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, Holon
     test_case.add_match_saved_content_step()?;
     test_case.add_verify_book_person_instance_links_step(None)?;
 
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}
+
+/// Regression fixture for saved-content comparison of frozen relationship members
+/// (issue #555 head-redirect).
+///
+/// Book and Person are staged together and `Book --AuthoredBy--> Person` is
+/// authored while Person is still staged, so Book's expected `AuthoredBy` member
+/// is frozen at Person's *staged* snapshot. Committing the transaction advances
+/// Person's head to its Saved snapshot under a new id, leaving that frozen member
+/// id stale. The saved-content assertion must redirect the frozen member through
+/// the fixture head index to the committed Person before comparing it to the DB
+/// member. Everything stays in a single transaction so the cross-transaction
+/// execution-step binding path (issue #556) is not exercised here.
+pub fn frozen_member_head_redirect_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, .. } = TestCaseInit::new(
+        "frozen_member_head_redirect",
+        "Saved-content assertion redirects a frozen staged relationship member to its committed head",
+    );
+
+    test_case.add_load_core_schema_step(None)?;
+    test_case.add_begin_transaction_step(None, None)?;
+    test_case.add_load_book_person_inverse_test_schema_step(None)?;
+
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction for staged Book and Person instances".to_string()),
+    )?;
+
+    // Resolve the loader-saved type descriptors so they can be DescribedBy targets.
+    let book_type_stub =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_DESCRIPTOR_KEY.to_string())))?;
+    let book_type_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        book_type_stub,
+        MapString(BOOK_DESCRIPTOR_KEY.to_string()),
+        None,
+        None,
+    )?;
+    let person_type_stub =
+        fixture_context.mutation().new_holon(Some(MapString(PERSON_DESCRIPTOR_KEY.to_string())))?;
+    let person_type_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        person_type_stub,
+        MapString(PERSON_DESCRIPTOR_KEY.to_string()),
+        None,
+        None,
+    )?;
+
+    // Stage Person, then Book, in the same transaction.
+    let person_source =
+        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let mut person_properties = PropertyMap::new();
+    person_properties
+        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    let person_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        person_source,
+        person_properties,
+        Some(MapString(PERSON_1_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let person_token =
+        test_case.add_stage_holon_step(&mut fixture_holons, person_token, None, None)?;
+
+    let book_source =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let mut book_properties = PropertyMap::new();
+    book_properties
+        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    let book_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        book_source,
+        book_properties,
+        Some(MapString(BOOK_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let book_token = test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
+
+    // Describe both instances, then freeze Book --AuthoredBy--> the staged Person.
+    let book_token = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_token,
+        CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
+        vec![book_type_token],
+        None,
+        Some("Describe Book by Book.HolonType".to_string()),
+    )?;
+    let person_token = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        person_token,
+        CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
+        vec![person_type_token],
+        None,
+        Some("Describe Person by Person.HolonType".to_string()),
+    )?;
+    test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_token,
+        RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
+        vec![person_token],
+        None,
+        Some("Freeze Book --AuthoredBy--> staged Person before commit".to_string()),
+    )?;
+
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Commit Book and Person together; heads advance to Saved".to_string()),
+    )?;
+
+    let expected_db_count = MapInteger(
+        fixture_holons.count_saved().0
+            + CORE_SCHEMA_METRICS.committed
+            + BOOK_PERSON_INVERSE_METRICS.committed,
+    );
+    test_case.add_ensure_database_count_step(expected_db_count, None)?;
+    test_case.add_match_saved_content_step()?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}
+
+/// Cross-transaction variant of the frozen-member regression, pending issue #556.
+///
+/// Person is staged and committed in one transaction; Book — authored with a
+/// frozen reference to Person's *staged* snapshot — is staged and committed in a
+/// *later* transaction. The frozen staged Person reference is carried into the
+/// later commit, where the production session-import bind correctly rejects it as
+/// a cross-transaction reference. This cannot pass until the sweettest
+/// relationship adders head-resolve execution-step target tokens (issue #556); it
+/// is driven by the `#[ignore]`d `frozen_member_head_redirect_cross_tx_test`.
+pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, .. } = TestCaseInit::new(
+        "frozen_member_head_redirect_cross_tx",
+        "Cross-transaction frozen relationship member (pending issue #556)",
+    );
+
+    test_case.add_load_core_schema_step(None)?;
+    test_case.add_begin_transaction_step(None, None)?;
+    test_case.add_load_book_person_inverse_test_schema_step(None)?;
+
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction for staged Person and transient Book".to_string()),
+    )?;
+
+    let book_type_stub =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_DESCRIPTOR_KEY.to_string())))?;
+    let book_type_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        book_type_stub,
+        MapString(BOOK_DESCRIPTOR_KEY.to_string()),
+        None,
+        None,
+    )?;
+    let person_type_stub =
+        fixture_context.mutation().new_holon(Some(MapString(PERSON_DESCRIPTOR_KEY.to_string())))?;
+    let person_type_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        person_type_stub,
+        MapString(PERSON_DESCRIPTOR_KEY.to_string()),
+        None,
+        None,
+    )?;
+
+    let person_source =
+        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let mut person_properties = PropertyMap::new();
+    person_properties
+        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    let person_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        person_source,
+        person_properties,
+        Some(MapString(PERSON_1_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let person_token =
+        test_case.add_stage_holon_step(&mut fixture_holons, person_token, None, None)?;
+    let person_token = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        person_token,
+        CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
+        vec![person_type_token],
+        None,
+        Some("Describe Person before first commit".to_string()),
+    )?;
+
+    let book_source =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let mut book_properties = PropertyMap::new();
+    book_properties
+        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    let book_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        book_source,
+        book_properties,
+        Some(MapString(BOOK_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let book_token = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_token,
+        CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
+        vec![book_type_token],
+        None,
+        Some("Describe transient Book before first commit".to_string()),
+    )?;
+    let book_token = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_token,
+        RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
+        vec![person_token],
+        None,
+        Some("Freeze Book --AuthoredBy--> staged Person before Person commit".to_string()),
+    )?;
+
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Commit Person while Book remains transient".to_string()),
+    )?;
+
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction to stage and commit Book after Person is saved".to_string()),
+    )?;
+    let _book_token =
+        test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Commit Book with frozen Person relationship member".to_string()),
+    )?;
+
+    let expected_db_count = MapInteger(
+        fixture_holons.count_saved().0
+            + CORE_SCHEMA_METRICS.committed
+            + BOOK_PERSON_INVERSE_METRICS.committed,
+    );
+    test_case.add_ensure_database_count_step(expected_db_count, None)?;
+    test_case.add_match_saved_content_step()?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_core_schema_fixture.rs
@@ -8,7 +8,7 @@ use holons_test::{DancesTestCase, TestCaseInit};
 /// `holons_loader_client::load_holons_from_files`, so this covers the same
 /// loader-client path that the earlier `loader_client_fixture` was built to exercise.
 pub fn load_core_schema_fixture() -> Result<DancesTestCase, HolonError> {
-    let TestCaseInit { mut test_case, fixture_context, .. } =
+    let TestCaseInit { mut test_case, fixture_context, fixture_holons, .. } =
         TestCaseInit::new("load_core_schema", "Load MAP core schema via LoadCoreSchema step");
 
     test_case.add_load_core_schema_step(None)?;
@@ -17,7 +17,7 @@ pub fn load_core_schema_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_verify_core_schema_command_affordances_step(None)?;
     test_case.add_verify_core_schema_value_semantics_step(None)?;
 
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
@@ -338,7 +338,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_ensure_database_count_step(MapInteger(1 + n_nodes as i64), None)?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/load_inverse_oriented_book_person_instances_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_inverse_oriented_book_person_instances_fixture.rs
@@ -5,7 +5,7 @@ use holons_test::{DancesTestCase, TestCaseInit};
 /// that public loader ingress rejects authoring an instance relationship through
 /// the inverse `Authors` descriptor.
 pub fn load_inverse_oriented_book_person_instances_fixture() -> Result<DancesTestCase, HolonError> {
-    let TestCaseInit { mut test_case, fixture_context, .. } = TestCaseInit::new(
+    let TestCaseInit { mut test_case, fixture_context, fixture_holons, .. } = TestCaseInit::new(
         "load_inverse_oriented_book_person_instances",
         "Load core and Book/Person schemas, then reject an inverse-oriented Authors import",
     );
@@ -24,7 +24,7 @@ pub fn load_inverse_oriented_book_person_instances_fixture() -> Result<DancesTes
     )?;
     test_case.add_load_inverse_oriented_book_person_instances_expect_failure_step(None)?;
 
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_properties_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_properties_fixture.rs
@@ -136,7 +136,7 @@ pub fn simple_add_remove_properties_fixture() -> Result<DancesTestCase, HolonErr
     // -- ADD (Again) STEP -- // Confirming add succeeds after removal of things
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
@@ -190,7 +190,7 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     )?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/simple_create_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_create_holon_fixture.rs
@@ -56,7 +56,7 @@ pub fn simple_create_holon_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_match_saved_content_step()?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
@@ -147,7 +147,7 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_match_saved_content_step()?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -313,7 +313,7 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }

--- a/tests/sweetests/tests/fixture_cases/transaction_lifecycle_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/transaction_lifecycle_fixture.rs
@@ -141,7 +141,7 @@ pub fn transaction_lifecycle_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // Finalize
-    test_case.finalize(&fixture_context)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
 
     Ok(test_case)
 }


### PR DESCRIPTION
**Summary**

Adds reference-layer definitional equivalence for `HolonReference` and migrates saved-content sweettest comparison onto it.  Closes #555.

- Added `ReadableHolon::is_definitionally_equivalent()`, diagnostic equivalence outcome, resolver seam, and no-op resolver in `holons_core`.
- Implemented recursive definitional comparison in the reference layer with saved-id short-circuiting, internal property-map comparison, descriptor-derived definitional relationship sets, ordered/unordered member matching, and cycle handling.
- Deprecated `ReadableHolon::essential_content()` while leaving it functional.
- Migrated `MatchSavedContent` to the shared comparator via a sweettest resolver, while retaining the separate harness-local subset comparison for `assert_essential_content_eq`.
- Added fixture head redirection support so saved-content assertions can resolve frozen expected relationship members to their current committed heads.
- Added coverage for the core equivalence rules and a sweettest regression fixture for frozen-member head redirection.
- Note: one dance test case is marked ignored for follow-up work in the next issue.

**Validation**

- `npm run fmt:check`
- `npm run check`
- `npm run test:unit`
- `npm run sweetest`