### PR TITLE
issue 556 implementation

### DIFF
--- a/tests/sweetests/src/harness/execution_support/execution_holons.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_holons.rs
@@ -198,6 +198,51 @@ impl ExecutionHolons {
         }
         Ok(references)
     }
+
+    /// Resolves relationship-target tokens, rejecting staged targets bound to a
+    /// transaction other than the active one.
+    ///
+    /// Build-time head resolution (see `FixtureHolons::resolve_target_token_to_head`)
+    /// leaves only one way for a stale staged target to reach this point: the target
+    /// was never committed before the fixture crossed a transaction boundary. Without
+    /// this guard that misuse only surfaces later as an opaque `Conflict` during
+    /// commit session-import; here it fails at the authoring site, naming the
+    /// relationship and target key.
+    pub fn resolve_relationship_targets(
+        &self,
+        context: &Arc<TransactionContext>,
+        relationship_name: &RelationshipName,
+        tokens: &[TestReference],
+    ) -> Result<Vec<HolonReference>, HolonError> {
+        let mut references = Vec::new();
+        for token in tokens {
+            let reference =
+                self.resolve_execution_reference(context, ResolveBy::Expected, token)?;
+            if let HolonReference::Staged(staged_reference) = &reference {
+                if staged_reference.tx_id() != context.tx_id() {
+                    let target_key = token
+                        .expected_reference()
+                        .key()
+                        .ok()
+                        .flatten()
+                        .map(|key| key.0)
+                        .unwrap_or_else(|| format!("{:?}", token.expected_id()));
+                    return Err(HolonError::CrossTransactionReference {
+                        reference_kind: format!("relationship '{}' target", relationship_name),
+                        reference_id: format!(
+                            "'{}' (staged in tx {}, never committed)",
+                            target_key,
+                            staged_reference.tx_id().value()
+                        ),
+                        reference_tx: staged_reference.tx_id().value(),
+                        context_tx: context.tx_id().value(),
+                    });
+                }
+            }
+            references.push(reference);
+        }
+        Ok(references)
+    }
 }
 
 // -- HELPERS -- //

--- a/tests/sweetests/src/harness/execution_support/execution_state.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_state.rs
@@ -211,4 +211,17 @@ impl TestExecutionState {
     ) -> Result<Vec<HolonReference>, HolonError> {
         self.execution_holons.resolve_execution_references(context, resolution_type, tokens)
     }
+
+    /// Resolves relationship-target tokens, rejecting staged targets bound to a
+    /// transaction other than the active one with an authoring-oriented error
+    /// naming the relationship and target key.
+    #[inline]
+    pub fn resolve_relationship_targets(
+        &self,
+        context: &Arc<TransactionContext>,
+        relationship_name: &RelationshipName,
+        tokens: &[TestReference],
+    ) -> Result<Vec<HolonReference>, HolonError> {
+        self.execution_holons.resolve_relationship_targets(context, relationship_name, tokens)
+    }
 }

--- a/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
+++ b/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
@@ -220,6 +220,28 @@ impl FixtureHolons {
         Ok(fixture_holon.head_snapshot.snapshot().into())
     }
 
+    /// Resolves a relationship-target token to its logical holon's current head token.
+    ///
+    /// Relationship adders use this so execution steps carry the target's current
+    /// head (e.g. the post-commit Saved snapshot) instead of a stale author-supplied
+    /// snapshot whose runtime realization may be bound to an earlier transaction.
+    /// Tokens whose expected snapshot already is the head — including same-transaction
+    /// staged targets and SavedLookup stubs — are returned unchanged.
+    pub fn resolve_target_token_to_head(
+        &self,
+        token: &TestReference,
+    ) -> Result<TestReference, HolonError> {
+        let fixture_holon = self.get_fixture_holon_by_snapshot(&token.expected_id())?;
+        let head = &fixture_holon.head_snapshot;
+        if head.id() == token.expected_id() {
+            return Ok(token.clone());
+        }
+        // The head token is deliberately not pushed onto the `tokens` ledger,
+        // mirroring commit-minted tokens: it re-labels an already-registered head
+        // snapshot rather than introducing a new one.
+        Ok(TestReference::new(head.as_source(), head.clone()))
+    }
+
     /// Returns the current head snapshot id for the logical holon that owns
     /// `snapshot_id`, or `None` when the id is not tracked by fixture state.
     pub fn head_snapshot_id_for(&self, snapshot_id: &SnapshotId) -> Option<SnapshotId> {
@@ -429,4 +451,85 @@ pub struct FixtureHolonCounts {
     pub transient: i64,
     pub staged: i64,
     pub saved: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::init_fixture_context;
+    use base_types::MapString;
+    use holons_core::core_shared_objects::transactions::TransactionContext;
+    use std::sync::Arc;
+
+    /// Registers a new Staged FixtureHolon and mints its authoring token,
+    /// mirroring the snapshot flow used by `add_stage_holon_step`.
+    fn mint_staged_token(
+        context: &Arc<TransactionContext>,
+        fixture_holons: &mut FixtureHolons,
+        key: &str,
+    ) -> TestReference {
+        let transient = context
+            .mutation()
+            .new_holon(Some(MapString(key.to_string())))
+            .expect("new_holon should succeed");
+        let staged = ExpectedSnapshot::new(
+            transient.clone_holon().expect("clone_holon should succeed"),
+            TestHolonState::Staged,
+        );
+        fixture_holons.create_fixture_holon(staged.clone()).expect("create_fixture_holon");
+        fixture_holons
+            .mint_test_reference(SourceSnapshot::new(transient, TestHolonState::Transient), staged)
+    }
+
+    #[test]
+    fn head_advanced_token_resolves_to_saved_head() {
+        let context = init_fixture_context();
+        let mut fixture_holons = FixtureHolons::new();
+        let staged_token = mint_staged_token(&context, &mut fixture_holons, "book-key");
+
+        fixture_holons.commit().expect("commit should advance staged heads");
+
+        let head_token = fixture_holons
+            .resolve_target_token_to_head(&staged_token)
+            .expect("head resolution should succeed");
+        assert_eq!(head_token.expected_snapshot().state(), TestHolonState::Saved);
+        assert_ne!(head_token.expected_id(), staged_token.expected_id());
+        assert_eq!(
+            Some(head_token.expected_id()),
+            fixture_holons.head_snapshot_id_for(&staged_token.expected_id())
+        );
+    }
+
+    #[test]
+    fn same_head_token_is_returned_unchanged() {
+        let context = init_fixture_context();
+        let mut fixture_holons = FixtureHolons::new();
+        let staged_token = mint_staged_token(&context, &mut fixture_holons, "person-key");
+
+        let resolved = fixture_holons
+            .resolve_target_token_to_head(&staged_token)
+            .expect("head resolution should succeed");
+        assert_eq!(resolved, staged_token);
+    }
+
+    #[test]
+    fn untracked_token_errors() {
+        let context = init_fixture_context();
+        let mut fixture_holons = FixtureHolons::new();
+        // Mint a token without registering a FixtureHolon for its snapshot.
+        let transient = context
+            .mutation()
+            .new_holon(Some(MapString("orphan-key".to_string())))
+            .expect("new_holon should succeed");
+        let expected = ExpectedSnapshot::new(
+            transient.clone_holon().expect("clone_holon should succeed"),
+            TestHolonState::Staged,
+        );
+        let token = fixture_holons.mint_test_reference(
+            SourceSnapshot::new(transient, TestHolonState::Transient),
+            expected,
+        );
+
+        assert!(fixture_holons.resolve_target_token_to_head(&token).is_err());
+    }
 }

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -497,6 +497,12 @@ impl DancesTestCase {
     ) -> Result<TestReference, HolonError> {
         self.ensure_not_finalized()?;
         let description = description.unwrap_or_else(|| "Add related holons".to_string());
+        // Head-resolve target tokens so the execution step carries each logical
+        // holon's current head, consistent with the expected-graph resolution below.
+        let holons_to_add = holons_to_add
+            .iter()
+            .map(|token| fixture_holons.resolve_target_token_to_head(token))
+            .collect::<Result<Vec<_>, HolonError>>()?;
         // Cloning new source to create the expected snapshot
         let new_source = fixture_holons.derive_next_source(&step_token)?;
         let mut new_snapshot = new_source.snapshot().clone_holon()?;
@@ -573,6 +579,12 @@ impl DancesTestCase {
     ) -> Result<TestReference, HolonError> {
         self.ensure_not_finalized()?;
         let description = description.unwrap_or_else(|| "Remove related holons".to_string());
+        // Head-resolve target tokens so the execution step carries each logical
+        // holon's current head, consistent with the expected-graph resolution below.
+        let holons_to_remove = holons_to_remove
+            .iter()
+            .map(|token| fixture_holons.resolve_target_token_to_head(token))
+            .collect::<Result<Vec<_>, HolonError>>()?;
         // Cloning new source to create the expected snapshot
         let new_source = fixture_holons.derive_next_source(&step_token)?;
         let mut new_snapshot = new_source.snapshot().clone_holon()?;

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -116,15 +116,16 @@ use holons_prelude::prelude::*;
 #[case::load_core_schema_test(load_core_schema_fixture())]
 #[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
 #[case::frozen_member_head_redirect_test(frozen_member_head_redirect_fixture())]
+#[case::frozen_member_head_redirect_cross_tx_test(frozen_member_head_redirect_cross_tx_fixture())]
+#[case::cross_transaction_staged_target_diagnostic_test(
+    cross_transaction_staged_target_diagnostic_fixture()
+)]
 #[tokio::test(flavor = "multi_thread")]
 async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
     run_dance_test_case(input.unwrap()).await;
 }
 
 /// Drives a finalized `DancesTestCase` through runtime setup and step execution.
-///
-/// Shared by the parametrized `rstest_dance_tests` cases and by standalone tests
-/// such as the `#[ignore]`d cross-transaction regression pending issue #556.
 async fn run_dance_test_case(mut test_case: DancesTestCase) {
     // The heavy lifting for this test is in the test data set creation.
 
@@ -351,20 +352,4 @@ async fn run_dance_test_case(mut test_case: DancesTestCase) {
         }
     }
     info!("\n{TEST_CLIENT_PREFIX} ------- END OF {} TEST CASE  ---------------", test_case.name);
-}
-
-/// Cross-transaction frozen-member regression, kept ready for issue #556.
-///
-/// Ignored until the sweettest relationship adders head-resolve execution-step
-/// target tokens (issue #556). Until then the frozen staged Person reference is
-/// carried into a later transaction's commit and correctly rejected by the
-/// production session-import bind. Remove `#[ignore]` once #556 lands.
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "unblocked by #556: execution-step token head resolution"]
-async fn frozen_member_head_redirect_cross_tx_test() {
-    run_dance_test_case(
-        frozen_member_head_redirect_cross_tx_fixture()
-            .expect("cross-tx frozen-member fixture should build"),
-    )
-    .await;
 }

--- a/tests/sweetests/tests/execution_steps/add_related_holons_executor.rs
+++ b/tests/sweetests/tests/execution_steps/add_related_holons_executor.rs
@@ -18,11 +18,26 @@ pub async fn execute_add_related_holons(
 ) {
     let context = state.context();
 
-    // 1. LOOKUP — resolve source and target holons
+    // 1. LOOKUP — resolve source and target holons. Target resolution rejects
+    // cross-transaction staged targets, so its errors flow through the
+    // expected_error path like dispatch errors.
     let source_reference: HolonReference =
         state.resolve_execution_reference(&context, ResolveBy::Source, &step_token).unwrap();
     let holons_to_add: Vec<HolonReference> =
-        state.resolve_execution_references(&context, ResolveBy::Expected, &holons).unwrap();
+        match state.resolve_relationship_targets(&context, &relationship_name, &holons) {
+            Ok(references) => references,
+            Err(e) => {
+                let actual = HolonErrorKind::from(&e);
+                assert_eq!(
+                    Some(actual),
+                    expected_error,
+                    "add_related_holons: target resolution failed unexpectedly: {:?}",
+                    e,
+                );
+                info!("Success! add_related_holons target resolution failed as expected: {}", e);
+                return;
+            }
+        };
 
     // 2. DISPATCH
     let command = MapCommand::Holon(HolonCommand {

--- a/tests/sweetests/tests/execution_steps/remove_related_holon_executor.rs
+++ b/tests/sweetests/tests/execution_steps/remove_related_holon_executor.rs
@@ -18,11 +18,26 @@ pub async fn execute_remove_related_holons(
 ) {
     let context = state.context();
 
-    // 1. LOOKUP — resolve source and target holons
+    // 1. LOOKUP — resolve source and target holons. Target resolution rejects
+    // cross-transaction staged targets, so its errors flow through the
+    // expected_error path like dispatch errors.
     let source_reference: HolonReference =
         state.resolve_execution_reference(&context, ResolveBy::Source, &step_token).unwrap();
     let holons_to_remove: Vec<HolonReference> =
-        state.resolve_execution_references(&context, ResolveBy::Expected, &holons).unwrap();
+        match state.resolve_relationship_targets(&context, &relationship_name, &holons) {
+            Ok(references) => references,
+            Err(e) => {
+                let actual = HolonErrorKind::from(&e);
+                assert_eq!(
+                    Some(actual),
+                    expected_error,
+                    "remove_related_holons: target resolution failed unexpectedly: {:?}",
+                    e,
+                );
+                info!("Success! remove_related_holons target resolution failed as expected: {}", e);
+                return;
+            }
+        };
 
     // 2. DISPATCH
     let command = MapCommand::Holon(HolonCommand {

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -262,19 +262,20 @@ pub fn frozen_member_head_redirect_fixture() -> Result<DancesTestCase, HolonErro
     Ok(test_case)
 }
 
-/// Cross-transaction variant of the frozen-member regression, pending issue #556.
+/// Cross-transaction variant of the frozen-member regression (issue #556).
 ///
-/// Person is staged and committed in one transaction; Book — authored with a
-/// frozen reference to Person's *staged* snapshot — is staged and committed in a
-/// *later* transaction. The frozen staged Person reference is carried into the
-/// later commit, where the production session-import bind correctly rejects it as
-/// a cross-transaction reference. This cannot pass until the sweettest
-/// relationship adders head-resolve execution-step target tokens (issue #556); it
-/// is driven by the `#[ignore]`d `frozen_member_head_redirect_cross_tx_test`.
+/// Person is staged, described, and committed in one transaction. Book is staged
+/// in a *later* transaction and related `Book --AuthoredBy--> Person` using the
+/// original staged-era Person token. The relationship adder must resolve that
+/// token to Person's current head (the committed Saved snapshot) so the execution
+/// step carries a reference that rebinds to the active transaction; embedding the
+/// raw staged token would round-trip a stale cross-transaction `StagedReference`
+/// into the later commit, which the production session-import bind correctly
+/// rejects.
 pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, HolonError> {
     let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, .. } = TestCaseInit::new(
         "frozen_member_head_redirect_cross_tx",
-        "Cross-transaction frozen relationship member (pending issue #556)",
+        "Relate a later-transaction Book to a committed Person via the original staged-era token",
     );
 
     test_case.add_load_core_schema_step(None)?;
@@ -283,18 +284,9 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
 
     test_case.add_begin_transaction_step(
         None,
-        Some("Begin transaction for staged Person and transient Book".to_string()),
+        Some("Begin transaction for staged Person".to_string()),
     )?;
 
-    let book_type_stub =
-        fixture_context.mutation().new_holon(Some(MapString(BOOK_DESCRIPTOR_KEY.to_string())))?;
-    let book_type_token = test_case.add_lookup_saved_holon_by_key_step(
-        &mut fixture_holons,
-        book_type_stub,
-        MapString(BOOK_DESCRIPTOR_KEY.to_string()),
-        None,
-        None,
-    )?;
     let person_type_stub =
         fixture_context.mutation().new_holon(Some(MapString(PERSON_DESCRIPTOR_KEY.to_string())))?;
     let person_type_token = test_case.add_lookup_saved_holon_by_key_step(
@@ -320,13 +312,37 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
     )?;
     let person_token =
         test_case.add_stage_holon_step(&mut fixture_holons, person_token, None, None)?;
+    // The last staged-era Person token; reused as a relationship target after the
+    // commit below advances Person's head to Saved.
     let person_token = test_case.add_add_related_holons_step(
         &mut fixture_holons,
         person_token,
         CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
         vec![person_type_token],
         None,
-        Some("Describe Person before first commit".to_string()),
+        Some("Describe Person before commit".to_string()),
+    )?;
+
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Commit Person; head advances to Saved".to_string()),
+    )?;
+
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction to stage Book after Person is saved".to_string()),
+    )?;
+
+    let book_type_stub =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_DESCRIPTOR_KEY.to_string())))?;
+    let book_type_token = test_case.add_lookup_saved_holon_by_key_step(
+        &mut fixture_holons,
+        book_type_stub,
+        MapString(BOOK_DESCRIPTOR_KEY.to_string()),
+        None,
+        None,
     )?;
 
     let book_source =
@@ -342,41 +358,29 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
         None,
         None,
     )?;
+    let book_token = test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
     let book_token = test_case.add_add_related_holons_step(
         &mut fixture_holons,
         book_token,
         CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
         vec![book_type_token],
         None,
-        Some("Describe transient Book before first commit".to_string()),
+        Some("Describe staged Book".to_string()),
     )?;
-    let book_token = test_case.add_add_related_holons_step(
+    test_case.add_add_related_holons_step(
         &mut fixture_holons,
         book_token,
         RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
         vec![person_token],
         None,
-        Some("Freeze Book --AuthoredBy--> staged Person before Person commit".to_string()),
+        Some("Relate Book --AuthoredBy--> Person via the staged-era token".to_string()),
     )?;
 
     test_case.add_commit_step(
         &mut fixture_holons,
         ExpectedCommitStatus::Complete,
         None,
-        Some("Commit Person while Book remains transient".to_string()),
-    )?;
-
-    test_case.add_begin_transaction_step(
-        None,
-        Some("Begin transaction to stage and commit Book after Person is saved".to_string()),
-    )?;
-    let _book_token =
-        test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
-    test_case.add_commit_step(
-        &mut fixture_holons,
-        ExpectedCommitStatus::Complete,
-        None,
-        Some("Commit Book with frozen Person relationship member".to_string()),
+        Some("Commit Book; AuthoredBy must anchor to the committed Person".to_string()),
     )?;
 
     let expected_db_count = MapInteger(
@@ -386,6 +390,75 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
     );
     test_case.add_ensure_database_count_step(expected_db_count, None)?;
     test_case.add_match_saved_content_step()?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}
+
+/// Negative case for the cross-transaction relationship-target diagnostic (issue #556).
+///
+/// Person is staged but *never committed* before the fixture crosses a transaction
+/// boundary, so its head never advances and build-time head resolution passes the
+/// staged token through unchanged. Relating a later-transaction Book to it must
+/// fail at the add step with an authoring-oriented `CrossTransactionReference`
+/// naming the relationship and target — not as an opaque `Conflict` at commit
+/// session-import.
+pub fn cross_transaction_staged_target_diagnostic_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, .. } = TestCaseInit::new(
+        "cross_transaction_staged_target_diagnostic",
+        "Relating to a never-committed staged holon from an earlier transaction fails fast",
+    );
+
+    let person_source =
+        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let mut person_properties = PropertyMap::new();
+    person_properties
+        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    let person_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        person_source,
+        person_properties,
+        Some(MapString(PERSON_1_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let person_token =
+        test_case.add_stage_holon_step(&mut fixture_holons, person_token, None, None)?;
+
+    // Cross the transaction boundary without committing Person.
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction while Person remains staged in the previous one".to_string()),
+    )?;
+
+    let book_source =
+        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let mut book_properties = PropertyMap::new();
+    book_properties
+        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    let book_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        book_source,
+        book_properties,
+        Some(MapString(BOOK_KEY.to_string())),
+        None,
+        None,
+    )?;
+    let book_token = test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
+
+    test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_token,
+        RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
+        vec![person_token],
+        Some(HolonErrorKind::CrossTransactionReference),
+        Some(
+            "Relate Book to the never-committed staged Person; expect the cross-transaction \
+             diagnostic"
+                .to_string(),
+        ),
+    )?;
 
     test_case.finalize(&fixture_context, &fixture_holons)?;
 

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -7,7 +7,7 @@ use rstest::*;
 use super::setup_undescribed_book_people_publisher_steps_with_context;
 use holons_test::harness::helpers::{
     BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_PERSON_INVERSE_METRICS, BOOK_TO_PERSON_RELATIONSHIP,
-    CORE_SCHEMA_METRICS, PERSON_1_KEY,
+    CORE_SCHEMA_METRICS,
 };
 
 // TODO: add/remove relationships
@@ -239,19 +239,13 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
         None,
         Some("With Properties -- first version cloned from book.".to_string()),
     )?;
-    // Resolve the AuthoredBy target through a saved-key lookup so it binds to the active
-    // (version-producing) transaction, mirroring the Book.HolonType / Title.PropertyType
-    // lookups above. Reusing the setup-phase staged `Person1` token here would embed a stale
-    // cross-transaction staged reference and fail strict bind on the commit (issue #515).
-    let person_stub =
-        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
-    let person_1_token = test_case.add_lookup_saved_holon_by_key_step(
-        &mut fixture_holons,
-        person_stub,
-        MapString(PERSON_1_KEY.to_string()),
-        None,
-        None,
-    )?;
+    // Reuse the setup-phase staged Person1 token directly: the relationship adder
+    // resolves it to Person1's committed head (issue #556), so no saved-key lookup
+    // workaround is needed for the cross-transaction target (formerly issue #515).
+    let person_1_token = fixture_bindings
+        .get_token(&MapString("Person1".to_string()))
+        .expect("Expected setup fixture return_items to contain a staged-intent token associated with 'Person1' label")
+        .clone();
     test_case.add_add_related_holons_step(
         &mut fixture_holons,
         staged_clone,


### PR DESCRIPTION
## Resolve execution-step relationship target tokens to the logical holon's current head

Closes #556

### Summary

Completes the token-head resolution model in the sweettest harness. The relationship adders (`add_add_related_holons_step` / `add_remove_related_holons_step`) now resolve their **execution-step** target tokens to each target logical holon's current head — consistent with the expected-graph side (#546) and assertion-side comparison (#555), which were already head-resolved.

Previously the execution step embedded the raw author-supplied token. A token minted while the target was staged in an earlier transaction resolved at runtime through the Staged arm of `ExecutionHolons::resolve_execution_reference`, returning a `StagedReference` still bound to the originating transaction — which the production strict session-import bind correctly rejected at a later commit with an opaque cross-transaction `Conflict`. Test-harness-only change; the production guard is untouched.

### Changes

**Build-time head resolution**
- `FixtureHolons::resolve_target_token_to_head` — token-returning sibling of `resolve_expected_relationship_target`. Returns the current-head token (post-commit `Saved` snapshot) for head-advanced targets; returns the token unchanged when it already is the head (same-transaction staged targets, `SavedLookup` stubs). Covered by three in-module unit tests.
- Both relationship adders map `holons_to_add` / `holons_to_remove` through the resolver before building the expected graph and pushing the `DanceTestStep`, so the two surfaces cannot drift. At runtime a head token resolves through the Saved arm, which already rebinds the recorded `SmartReference` to the active transaction.

**Authoring-oriented cross-transaction diagnostic**
- `ExecutionHolons::resolve_relationship_targets` (+ `TestExecutionState` passthrough) — rejects a resolved staged target whose transaction differs from the active one. This is the one misuse head resolution cannot repair: relating to a holon staged in an earlier transaction that was **never committed**. It now fails fast at the add/remove step with the existing `HolonError::CrossTransactionReference`, naming the relationship and target key (e.g. `relationship 'AuthoredBy' target('Person1' (staged in tx 3, never committed))`) instead of a cryptic `Conflict` at commit session-import. No `shared_crates` changes.
- Both relationship executors route target-resolution errors through the `expected_error` assertion path instead of `.unwrap()`, making the diagnostic assertable in fixtures.

**Fixtures / tests**
- `frozen_member_head_redirect_cross_tx_fixture` reworked to the pattern this issue fixes and **un-ignored**: Person is staged, described, and committed in one transaction; Book is staged in a later transaction and related `Book --AuthoredBy--> Person` using the original staged-era Person token; the commit anchors the edge to the committed Person. (As previously committed, the fixture froze the stale staged reference inside a *transient* Book before Person's commit — a shape build-time adder resolution cannot fix, since Person's head hadn't advanced at authoring time of the add. That never-committed-across-tx shape is exactly what the new diagnostic catches instead.)
- New negative case `cross_transaction_staged_target_diagnostic_fixture`: Person staged but never committed, transaction boundary crossed, relate expecting `HolonErrorKind::CrossTransactionReference`.
- Both run as regular `#[case]`s in `rstest_dance_tests`; the standalone `#[ignore]`d test is removed.
- `stage_new_version_fixture`: the #515 tactical workaround (saved-key lookup for the `AuthoredBy` Person target) is removed; the fixture reuses the setup-phase `Person1` binding token directly. The `Book.HolonType` / `Name.PropertyType` saved-key lookups remain — those target schema-loaded holons outside the fixture ledger, which stays `add_lookup_saved_holon_by_key_step`'s legitimate job.

### Definition of Done

- [x] `FixtureHolons` exposes a token-returning current-head resolver for relationship targets
- [x] Both relationship adders embed head-resolved target tokens, consistent with the expected-graph resolution
- [x] `frozen_member_head_redirect_cross_tx_test` passes with `#[ignore]` removed
- [x] Same-transaction staged targets resolve unchanged (resolver no-op; full suite green)
- [x] `stage_new_version_fixture` passes without the manual saved-lookup workaround
- [x] Cross-transaction target misuse produces an authoring-oriented diagnostic naming the relationship/target
- [x] Full sweettest suite passes (`npm run sweetest`)
- [x] Harness documentation updated

### Testing

- `cargo test -p holons_test --lib` — 3 new `FixtureHolons` resolver unit tests pass
- `npm run sweetest` — full suite green, including the un-ignored cross-tx regression and the new negative diagnostic case
- `npm run check`, `npm run fmt:check` — clean
