### PR TITLE
Implement TDL R4 semantic validation and Canonical Holon IR diffnpm

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,6 +132,82 @@ _Avoid_: Internal execution state
 The future materialization boundary that converts bound navigation state into descriptor-defined projection output.
 _Avoid_: Implicit row materialization by order, distinct, skip, or limit
 
+**Source Adapter**:
+A format-specific translator that lowers authored or imported content into the Canonical Holon IR or projects it out to a concrete output format.
+_Avoid_: Semantic core, IR owner
+
+**Validation Layer**:
+A named responsibility boundary for diagnostics, such as syntax, IR structural, schema-aware, or runtime-loader boundary validation.
+_Avoid_: Unclassified diagnostic bucket
+
+**Diagnostic Origin**:
+The source location, symbol, or authored/imported element that a diagnostic should be attributed to.
+_Avoid_: Validation responsibility category
+
+**Canonical Holon IR**:
+The source-neutral semantic middle shared by MAP schema tooling, validation, diffing, code generation, and future editor services.
+_Avoid_: JSON model, TDL AST, loader DTO
+
+**Semantic Diff**:
+A review-oriented comparison derived from valid Canonical Holon IR models rather than concrete source text.
+_Avoid_: JSON text diff, parser recovery diff
+
+**Semantic Fidelity Check**:
+A source-neutral comparison of normalized Canonical Holon IR models used to verify compile/decompile or adapter round-trips without treating formatting, ordering, or shorthand syntax as semantic differences.
+_Avoid_: Textual round-trip equality
+
+**Runtime Loader Projectability**:
+The Issue 578 boundary check that Canonical Holon IR can be projected into the existing loader/import shape without changing loader behavior or creating a new runtime import path.
+_Avoid_: Loader unification, runtime validation rewrite
+
+**TypeKind-Compatible Inheritance**:
+The schema-authoring rule that a type descriptor may extend another type descriptor only when both descriptors have the same TypeKind.
+_Avoid_: Non-extensible descriptor rule as the primary inheritance test
+
+**Projected TypeKind**:
+The TypeKind derived from a descriptor's source-neutral semantic kind for validation and comparison.
+_Avoid_: Treating authored `instance_type_kind` as the sole semantic authority
+
+**Relationship Pair Completeness**:
+The schema-authoring invariant that every declared relationship descriptor has exactly one inverse relationship descriptor paired with it.
+_Avoid_: Optional inverse metadata for declared relationships
+
+**Optional Property Suffix**:
+The `?` suffix on a descriptor property name that marks the property as optional in schema authoring.
+_Avoid_: Treating missing required properties as implicitly optional
+
+**Required Slot Table**:
+The fixed Issue 578 validation table that names required semantic slots per descriptor kind without deriving optionality from the full meta-descriptor graph.
+_Avoid_: Full meta-schema requiredness engine
+
+**Post-Lowering Requiredness**:
+The rule that required descriptor slots are validated on Canonical Holon IR after a source adapter has applied only the explicit defaults and conveniences of its source format.
+_Avoid_: Inventing semantic defaults during IR validation
+
+**Closed-World Authoring Uniqueness**:
+The Issue 578 uniqueness boundary that checks duplicates only inside the model being validated, not across the persisted MAP runtime or broader social graph.
+_Avoid_: Global MAP uniqueness validation
+
+**Blocking Semantic Diagnostic**:
+An Issue 578 validation finding that makes the Canonical Holon IR unsuitable for successful check, compile, or semantic diff.
+_Avoid_: Treating invalid schema semantics as warnings
+
+**Effective Descriptor View**:
+The flattened descriptor structure produced by following a descriptor's Extends chain and combining inherited structural declarations and affordances.
+_Avoid_: Local-only descriptor surface
+
+**Descriptor Flattener**:
+An existing descriptor-layer operation that computes effective inherited descriptor members, such as instance properties, instance relationships, commands, or dances.
+_Avoid_: Reimplemented inheritance flattening in schema tooling
+
+**Effective Key Rule**:
+The key rule selected for a descriptor or instance after resolving authored `UsesKeyRule`, applicable `Extends` lineage, and `DescribedBy`/type fallback according to MAP schema key-generation semantics.
+_Avoid_: General inherited descriptor flattening
+
+**Descriptor Semantics Service**:
+A small source-neutral service for descriptor-shaped graph rules that must be shared by TDL IR validation and runtime descriptor behavior.
+_Avoid_: Broad descriptor engine, ad hoc schema-tooling clone
+
 ## Relationships
 
 - Query PRO3 removes the transaction-level query envelope family rather than replacing it with a new command-owned query envelope.
@@ -160,6 +236,24 @@ _Avoid_: Implicit row materialization by order, distinct, skip, or limit
 - Without a future **ProjectStep**, navigation results should remain holon-native and selected by the **Output Binding**.
 - **Old-World Relationship Traversal Types** may remain for compatibility, but **New-World Query Contract** design must not depend on them.
 - A **Spec Revision Session** closes when the team produces a stable artifact for one coherent design slice, such as a revised issue body.
+- A **Source Adapter** owns format-specific parsing and syntax validation; the **Canonical Holon IR** owns source-neutral semantics.
+- A **Validation Layer** may classify diagnostics from adapters or derived semantic services, but adapter-specific validation responsibilities must not contaminate **Canonical Holon IR** semantics.
+- A diagnostic's **Validation Layer** identifies which responsibility boundary failed; its **Diagnostic Origin** identifies where the author or tool should look.
+- A **Semantic Diff** compares only valid **Canonical Holon IR** models; invalid inputs produce layered diagnostics instead of partial semantic differences.
+- A **Semantic Fidelity Check** compares canonical semantics, not source formatting, JSON field order, or equivalent adapter shorthand.
+- **Runtime Loader Projectability** checks whether schema-authoring semantics can flow into the existing loader/import shape without changing loader behavior.
+- **TypeKind-Compatible Inheritance** allows multi-step `Extends` chains, but rejects inheritance across TypeKind boundaries.
+- **Projected TypeKind** is used for **TypeKind-Compatible Inheritance**; authored `instance_type_kind` values are preserved and validated against the projection when present.
+- **Relationship Pair Completeness** requires every declared relationship to have exactly one inverse and every inverse relationship to point back to a declared relationship.
+- **Optional Property Suffix** is the authoring signal for property optionality; properties without the suffix are required by the corresponding meta-descriptor.
+- An **Effective Descriptor View** includes inherited instance properties, instance relationships, commands, dances, key rules, operators, and related structural declarations according to each descriptor family.
+- A **Descriptor Flattener** is the authoritative implementation for effective inherited descriptor members when inherited member validation is in scope; TDL R4 defers general member flattening.
+- **Effective Key Rule** resolution is the narrow TDL R4 inheritance exception because Airtable already performs key generation by walking `Extends` and, when needed, `DescribedBy`/type fallback.
+- A **Descriptor Semantics Service** is deferred for TDL R4 unless a required validation cannot be expressed without it.
+- The **Required Slot Table** is the R4 source for descriptor-kind requiredness checks.
+- **Post-Lowering Requiredness** keeps source-format defaults in the adapter and treats missing required Canonical Holon IR slots as validation diagnostics.
+- **Closed-World Authoring Uniqueness** covers duplicate canonical symbols or keys, duplicate local property names, duplicate local relationship names, and duplicate inverse ownership in the current input model.
+- **Blocking Semantic Diagnostics** include missing required slots, unresolved references, duplicate symbols, wrong descriptor or meta-kind, relationship inverse-pair violations, inheritance graph violations, TypeKind mismatches, effective-key failures, and generated-key mismatches.
 
 ## Example dialogue
 
@@ -190,3 +284,20 @@ _Avoid_: Implicit row materialization by order, distinct, skip, or limit
 - Pipeline ordering is relationship order in PRO3. Resolved: ordered **Pipeline Steps** use `HolonCollection` member order rather than per-step index properties or linked-list relationships.
 - Minimal plan shape is holon-native in PRO3. Resolved: **ExecutionPlan** has **Output Binding** and **RootNode**; a pipeline **PlanNode** has ordered **Pipeline Steps**; step kind is conveyed by step subtype descriptor/facade rather than a `PlanStepKind` property.
 - **Step Parameters** follow MAP holon modeling. Resolved: scalar parameters are properties; holon-reference-valued parameters are relationships.
+- "validation" in TDL R4 can refer to syntax, IR structural, schema-aware, or runtime-loader boundary checks. Resolved: use **Validation Layer** for the classification and keep source-adapter responsibilities separate from **Canonical Holon IR** semantics.
+- Partial semantic diff over invalid input is deferred. Resolved: R4 `diff` requires diagnostic-free lowering on both sides and reports layered diagnostics instead of attempting recovery.
+- "extensibility" in TDL R4 should not mean a blanket ban on extending property or relationship descriptors. Resolved: use **TypeKind-Compatible Inheritance** as the authoring validation rule.
+- `instance_type_kind` can be authored or imported, but it should not override the descriptor's semantic declaration kind. Resolved: R4 uses **Projected TypeKind** for inheritance checks and reports contradictions when authored/imported `instance_type_kind` disagrees.
+- Inverse metadata for declared relationships is not optional schema-authoring information. Resolved: use **Relationship Pair Completeness** and require exactly one inverse per declared relationship in R4.
+- Relationship descriptor cardinality bounds are required meta-descriptor properties. Resolved: R4 should require both `min_cardinality` and `max_cardinality` for relationship descriptors and validate `min_cardinality <= max_cardinality`.
+- Descriptor inheritance flattening is deferred for Issue 578. Resolved: Airtable does not appear to provide inherited-effective validation, so R4 should validate local/schema-authoring structure without adding a new **Descriptor Semantics Service**.
+- Duplicate local property names and relationship names are authoring errors in R4; duplicate inherited effective members are deferred with inheritance flattening.
+- Inheritance graph health remains in scope for Issue 578. Resolved: R4 validates single-parent `Extends`, acyclic `Extends` chains, resolved `Extends` targets, and **TypeKind-Compatible Inheritance** without flattening inherited members.
+- Full meta-descriptor requiredness derivation is deferred for Issue 578. Resolved: R4 uses a fixed **Required Slot Table**, including at least one variant for enum descriptors.
+- Effective key validation is in scope for Issue 578 as the only inheritance-flattening exception. Resolved: R4 should validate Airtable-equivalent **Effective Key Rule** resolution, including `Extends` preference, `DescribedBy`/type fallback, known key-rule kinds, required key-rule inputs, and generated-key mismatch when an authored key is present; this does not reopen general property, relationship, command, dance, or operator flattening.
+- Required descriptor slots are validated after source-adapter lowering. Resolved: TDL may apply explicit syntax-level conveniences or defaults, but Canonical Holon IR validation must report missing required semantic slots rather than inventing adapter-specific defaults.
+- Uniqueness validation is closed-world for Issue 578. Resolved: R4 flags duplicates within the TDL, JSON, or Canonical Holon IR model under validation, but does not check whether another persisted MAP schema already uses the same key or symbol.
+- Issue 578 semantic validation failures are errors. Resolved: all scoped schema-semantic invalidity produces **Blocking Semantic Diagnostics**; warnings are reserved for compatibility aliases or non-canonical source-adapter observations that do not make the Canonical Holon IR invalid.
+- Diagnostics should carry both **Validation Layer** and **Diagnostic Origin**. Resolved: R4 should add an explicit layer field for responsibility classification while preserving origin for source location, symbol, or element attribution.
+- Compile/decompile fidelity is semantic for Issue 578. Resolved: R4 compares normalized **Canonical Holon IR** content, including descriptors, projected kinds, references, required slots, key-rule semantics, relationship pairs, cardinalities, and literal semantic values, while ignoring source formatting, source ordering, and equivalent source-format shorthand.
+- Runtime-loader boundary validation is limited to **Runtime Loader Projectability**. Resolved: R4 should catch Canonical Holon IR facts that make projection to the existing loader/import shape impossible or malformed, without refactoring loader validation, changing Nursery/PVL semantics, or introducing a new runtime import path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4938,6 +4938,9 @@ dependencies = [
 [[package]]
 name = "map_schema_semantic"
 version = "0.1.0"
+dependencies = [
+ "descriptor_semantics",
+]
 
 [[package]]
 name = "matchers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "descriptor_semantics"
+version = "0.1.0"
+
+[[package]]
 name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +3437,7 @@ dependencies = [
  "base_types",
  "core_types",
  "derive-new",
+ "descriptor_semantics",
  "quick_cache",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 
     # Shared
     "shared_crates/holon_dance_builders",
+    "shared_crates/descriptor_semantics",
     "shared_crates/map_schema_semantic",
     "shared_crates/holons_core",
     "shared_crates/holons_prelude",
@@ -55,6 +56,7 @@ map_commands_runtime = { path = "host/crates/map_commands_runtime" }
 
 # Shared
 holon_dance_builders = { path = "shared_crates/holon_dance_builders" }
+descriptor_semantics = { path = "shared_crates/descriptor_semantics" }
 map_schema_semantic = { path = "shared_crates/map_schema_semantic" }
 holons_core = { path = "shared_crates/holons_core" }
 holons_prelude = { path = "shared_crates/holons_prelude" }

--- a/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -216,13 +216,13 @@
       "key": "BytesValueType",
       "type": "TypeDescriptor.HolonType",
       "properties": {
+        "is_abstract_type": true,
         "type_name": "BytesValueType",
         "type_name_plural": "BytesValueTypes",
         "display_name": "BytesValueType",
         "display_name_plural": "BytesValueTypes",
         "description": "Abstract type for byte sequence value types.",
         "instance_type_kind": "TypeKind.Value.Bytes",
-        "is_abstract_type": true,
         "allows_additional_properties": false,
         "allows_additional_relationships": false
       },
@@ -321,13 +321,13 @@
       "key": "ValueArrayValueType",
       "type": "TypeDescriptor.HolonType",
       "properties": {
+        "is_abstract_type": true,
         "type_name": "ValueArrayValueType",
         "type_name_plural": "ValueArrayValueTypes",
         "display_name": "ValueArrayType",
         "display_name_plural": "ValueArrayTypes",
         "description": "Abstract type for value array types.",
         "instance_type_kind": "TypeKind.Value.Array",
-        "is_abstract_type": true,
         "allows_additional_properties": false,
         "allows_additional_relationships": false
       },

--- a/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.911151Z",
+    "generated_at": "2026-07-22T12:12:39.820905Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-abstract-value-types.tdl"
@@ -95,7 +95,9 @@
         "display_name": "StringValueType",
         "display_name_plural": "StringValueTypes",
         "description": "Abstract type for string-based value types.",
-        "instance_type_kind": "TypeKind.Value.String"
+        "instance_type_kind": "TypeKind.Value.String",
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -139,7 +141,9 @@
         "display_name": "IntegerValueType",
         "display_name_plural": "IntegerValueTypes",
         "description": "Abstract type for integer-based value types.",
-        "instance_type_kind": "TypeKind.Value.Integer"
+        "instance_type_kind": "TypeKind.Value.Integer",
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -183,7 +187,9 @@
         "display_name": "BooleanValueType",
         "display_name_plural": "BooleanValueTypes",
         "description": "Abstract type for boolean-based value types.",
-        "instance_type_kind": "TypeKind.Value.Boolean"
+        "instance_type_kind": "TypeKind.Value.Boolean",
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -216,7 +222,9 @@
         "display_name_plural": "BytesValueTypes",
         "description": "Abstract type for byte sequence value types.",
         "instance_type_kind": "TypeKind.Value.Bytes",
-        "is_abstract_type": true
+        "is_abstract_type": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -249,7 +257,9 @@
         "display_name": "EnumValueType",
         "display_name_plural": "EnumValueTypes",
         "description": "Abstract type for enum-based value types.",
-        "instance_type_kind": "TypeKind.Value.Enum"
+        "instance_type_kind": "TypeKind.Value.Enum",
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -288,7 +298,9 @@
         "display_name_plural": "EnumVariant Value Types",
         "description": "Abstract type for variants of enum-based value types.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": true
+        "is_abstract_type": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -315,7 +327,9 @@
         "display_name_plural": "ValueArrayTypes",
         "description": "Abstract type for value array types.",
         "instance_type_kind": "TypeKind.Value.Array",
-        "is_abstract_type": true
+        "is_abstract_type": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-command-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-command-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.911517Z",
+    "generated_at": "2026-07-22T12:12:39.821148Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-command-types.tdl"
@@ -1085,7 +1085,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1131,11 +1133,14 @@
         "description": "Inverse of AffordsCommand, relationship from CommandType to HolonType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1180,7 +1185,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1226,11 +1233,14 @@
         "description": "Inverse of CommandPayloadType, from HolonType to CommandType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-concrete-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-concrete-value-types.json
@@ -1,14 +1,15 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.912447Z",
+    "generated_at": "2026-07-22T12:12:39.821664Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-concrete-value-types.tdl"
     ],
     "load_with": [
       "MAP Schema Types-map-core-schema-abstract-value-types.json",
-      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-root.json"
     ]
   },
   "holons": [
@@ -22,7 +23,9 @@
         "display_name_plural": "MapStringValueTypes",
         "description": "Concrete value type representing strings.",
         "instance_type_kind": "TypeKind.Value.String",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -55,7 +58,9 @@
         "display_name_plural": "MapIntegerValueTypes",
         "description": "Concrete value type representing integers.",
         "instance_type_kind": "TypeKind.Value.Integer",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -88,7 +93,9 @@
         "display_name_plural": "MapBooleanValueTypes",
         "description": "Concrete value type representing booleans.",
         "instance_type_kind": "TypeKind.Value.Boolean",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -121,7 +128,9 @@
         "display_name_plural": "MapBytesValueTypes",
         "description": "Concrete value type representing byte sequences.",
         "instance_type_kind": "TypeKind.Value.Bytes",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -154,7 +163,9 @@
         "display_name_plural": "MapEnumValueTypes",
         "description": "Concrete value type representing enums.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -187,7 +198,9 @@
         "display_name_plural": "MapEnumVariant Value Types",
         "description": "Abstract type for variants of enum-based value types.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -220,7 +233,9 @@
         "display_name_plural": "MapValueArrayTypes",
         "description": "Concrete value type representing arrays of values.",
         "instance_type_kind": "TypeKind.Value.Array",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -253,7 +268,9 @@
         "display_name_plural": "DeletionSemantics",
         "description": "Enum value type for deletion semantics.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -293,7 +310,9 @@
         "display_name": "Allow",
         "description": "Allow the source holon to be deleted regardless of any related target holons; deleting the source has no effect on the targets.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -319,7 +338,9 @@
         "display_name": "Block",
         "description": "Prevent deletion of the source holon if any target holons are related through this relationship.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -345,7 +366,9 @@
         "display_name": "Cascade",
         "description": "If the source holon is deleted, also delete any related target holons.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -372,7 +395,9 @@
         "display_name_plural": "TypeKinds",
         "description": "Enum value type for distinguishing kinds of types (e.g., Holon, Property, Relationship).",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -439,7 +464,9 @@
         "display_name": "Property",
         "description": "Represents a property type. Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -465,7 +492,9 @@
         "display_name": "Relationship",
         "description": "Represents a relationship type. Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -491,7 +520,9 @@
         "display_name": "EnumVariant",
         "description": "Represents an enum variant type. Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -517,7 +548,9 @@
         "display_name": "Holon",
         "description": "Represents a holon type.  Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -543,7 +576,9 @@
         "display_name": "Collection",
         "description": "Represents a collection type. Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -569,7 +604,9 @@
         "display_name": "Dance",
         "description": "Represents a dance service type. Variant of the TypeKind enum.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -595,7 +632,9 @@
         "display_name": "Value.String",
         "description": "Value type wrapping base type representing strings.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -621,7 +660,9 @@
         "display_name": "Value.Array",
         "description": "Value type wrapping an array of base type items.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -647,7 +688,9 @@
         "display_name": "Value.Integer",
         "description": "Value type wrapping base type representing integers.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -673,7 +716,9 @@
         "display_name": "Value.Boolean",
         "description": "Value type wrapping base type representing booleans.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -699,7 +744,9 @@
         "display_name": "Value.Enum",
         "description": "Value type wrapping base type representing enumerations.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -725,7 +772,9 @@
         "display_name": "Value.Bytes",
         "description": "Value type wrapping base type representing byte sequences.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -752,7 +801,9 @@
         "display_name_plural": "Collection Types",
         "description": "Enum value type for selecting the runtime wrapper used to inflate a persisted collection holon.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -785,7 +836,9 @@
         "display_name_plural": "Holon Array",
         "description": "Collection wrapper variant for ordered or index-addressable array-style holon collections.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -812,7 +865,9 @@
         "display_name_plural": "HolonIdValueTypes",
         "description": "Concrete bytes value type representing the canonical serialized form of a HolonId.",
         "instance_type_kind": "TypeKind.Value.Bytes",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-dance-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-dance-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.913116Z",
+    "generated_at": "2026-07-22T12:12:39.822099Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-dance-schema.tdl"
@@ -359,7 +359,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -405,11 +407,14 @@
         "description": "Inverse of AffordsDance, from DanceType to HolonType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -454,7 +459,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -500,11 +507,14 @@
         "description": "Inverse of ImplementsDance, from DanceImplementation to TypeDescriptor.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -549,7 +559,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -595,11 +607,14 @@
         "description": "Inverse of ForDance, from DanceType to DanceImplementation.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -644,7 +659,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -690,11 +707,14 @@
         "description": "Inverse of DanceInput, from HolonType to DanceType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -739,7 +759,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -785,11 +807,14 @@
         "description": "Inverse of Response, from DanceResponseType to DanceType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -834,7 +859,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -880,11 +907,14 @@
         "description": "Inverse of ResponseBody, from HolonType to DanceResponseType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -929,7 +959,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -975,11 +1007,14 @@
         "description": "Inverse of InvokesDance, from DanceType to DanceInvocation.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1024,7 +1059,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1070,11 +1107,14 @@
         "description": "Inverse of AffordingHolon, from HolonType to DanceInvocation.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1119,7 +1159,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1165,11 +1207,14 @@
         "description": "Inverse of Request, from HolonType to DanceInvocation.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1214,7 +1259,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1260,11 +1307,14 @@
         "description": "Inverse of Diagnostics, from DanceDiagnostic to DanceResponseType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1303,7 +1353,10 @@
         "display_name_plural": "dance_names",
         "description": "Unique string identifier for a DanceType descriptor, used in dispatch tables.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1336,7 +1389,10 @@
         "display_name_plural": "dance_descriptions",
         "description": "Human-readable explanation of what the dance does or when it should be invoked.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1369,7 +1425,10 @@
         "display_name_plural": "contexts",
         "description": "Ingress context for a DanceInvocation, recorded as an InvocationSource enum value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1402,7 +1461,10 @@
         "display_name_plural": "dance_diagnostic_severities",
         "description": "Severity classification for a DanceDiagnostic holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1435,7 +1497,10 @@
         "display_name_plural": "diagnostic_codes",
         "description": "Stable machine-readable code for a DanceDiagnostic holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1468,7 +1533,10 @@
         "display_name_plural": "diagnostic_messages",
         "description": "Human-readable message for a DanceDiagnostic holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1501,7 +1569,10 @@
         "display_name_plural": "response_status_codes",
         "description": "Machine-readable status code indicating the result of the dance.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1534,7 +1605,10 @@
         "display_name_plural": "engines",
         "description": "Execution engine for the implementation (e.g., WasmWasi, Process, RustDylib, Builtin).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1567,7 +1641,10 @@
         "display_name_plural": "module_refs",
         "description": "Content-address or locator of the executable module (e.g., hash/URL/capability address).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1600,7 +1677,10 @@
         "display_name_plural": "entrypoints",
         "description": "Function/export name to invoke inside the module.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1633,7 +1713,10 @@
         "display_name_plural": "abi_ids",
         "description": "Identifier of the stable smart contract ABI expected by the module/entrypoint.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1666,7 +1749,10 @@
         "display_name_plural": "versions",
         "description": "Semantic version or content hash pin of the implementation.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1699,7 +1785,10 @@
         "display_name_plural": "compats",
         "description": "Compatibility range or constraints (e.g., ABI or schema versions).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1732,7 +1821,10 @@
         "display_name_plural": "dance_summaries",
         "description": "Human-readable summary of a dance outcome.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1765,7 +1857,10 @@
         "display_name_plural": "implementation_names",
         "description": "Unique name of a DanceImplementation instance.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1798,7 +1893,9 @@
         "display_name_plural": "Invocation Sources",
         "description": "Enum value type that records how a DanceInvocation entered the runtime.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1839,7 +1936,9 @@
         "display_name_plural": "Client Commands",
         "description": "Invocation entered the runtime through a client command ingress path.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1866,7 +1965,9 @@
         "display_name_plural": "Trust Channels",
         "description": "Invocation entered the runtime through a trust-channel ingress path.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1893,7 +1994,9 @@
         "display_name_plural": "Internals",
         "description": "Invocation originated from trusted internal runtime code.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1920,7 +2023,9 @@
         "display_name_plural": "Dance Diagnostic Severities",
         "description": "Enum value type for the severity of a DanceDiagnostic holon.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1958,7 +2063,9 @@
         "display_name_plural": "Infos",
         "description": "Informational non-fatal diagnostic note.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1985,7 +2092,9 @@
         "display_name_plural": "Warnings",
         "description": "Warning-level non-fatal diagnostic note.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2012,7 +2121,9 @@
         "display_name_plural": "Response Status Codes",
         "description": "Deprecated old-world enum value type for dance status codes. New-world success and failure are expressed by the outer Result contract.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2077,7 +2188,9 @@
         "display_name_plural": "OKs",
         "description": "200 — Request succeeded.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2104,7 +2217,9 @@
         "display_name_plural": "Accepteds",
         "description": "202 — Request accepted but not yet processed.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2131,7 +2246,9 @@
         "display_name_plural": "Bad Requests",
         "description": "400 — The request was malformed or invalid.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2158,7 +2275,9 @@
         "display_name_plural": "Unauthorized",
         "description": "401 — The requester is not authenticated.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2185,7 +2304,9 @@
         "display_name_plural": "Forbidden",
         "description": "403 — The requester lacks permission.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2212,7 +2333,9 @@
         "display_name_plural": "Not Founds",
         "description": "404 — The target resource was not found.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2239,7 +2362,9 @@
         "display_name_plural": "Conflicts",
         "description": "409 — Conflict with the current state of the resource.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2266,7 +2391,9 @@
         "display_name_plural": "Unprocessable Entities",
         "description": "422 — Semantic validation failed.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2293,7 +2420,9 @@
         "display_name_plural": "Server Errors",
         "description": "500 — Unexpected internal error.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2320,7 +2449,9 @@
         "display_name_plural": "Not Implemented",
         "description": "501 — Functionality required to fulfill the request is not supported.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2347,7 +2478,9 @@
         "display_name_plural": "Service Unavailable",
         "description": "503 — The server is currently unable to handle the request (overload/maintenance).",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2374,7 +2507,9 @@
         "display_name_plural": "Dance Engines",
         "description": "Enum value type for execution engines used by DanceImplementations.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2418,7 +2553,9 @@
         "display_name_plural": "WasmWasi",
         "description": "Execute a WASM module under WASI (preferred).",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2445,7 +2582,9 @@
         "display_name_plural": "Processes",
         "description": "Spawn a separate OS process with protocol pipes.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2472,7 +2611,9 @@
         "display_name_plural": "RustDylibs",
         "description": "Dynamically load a Rust dylib via FFI (platform-coupled).",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2499,7 +2640,9 @@
         "display_name_plural": "Builtins",
         "description": "Call a registered host builtin function.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2601,7 +2744,10 @@
         "display_name_plural": "commits_attempted",
         "description": "Number of holons the commit operation attempted to save.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2634,7 +2780,9 @@
         "display_name_plural": "CommitRequestStatus",
         "description": "Enum value type for commit request outcomes (Complete, Incomplete).",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2672,7 +2820,9 @@
         "display_name_plural": "Completes",
         "description": "All staged holons committed; no staged holons remain.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2699,7 +2849,9 @@
         "display_name_plural": "Incompletes",
         "description": "One or more staged holons could not be committed; some may remain in New or Changed state pending error resolution.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2726,7 +2878,10 @@
         "display_name_plural": "commit_request_statuses",
         "description": "Overall status of the commit request (Complete or Incomplete).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2765,7 +2920,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2811,11 +2968,14 @@
         "description": "Inverse of SavedHolons. Links a holon to a CommitResponse that successfully saved it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2860,7 +3020,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2906,11 +3068,14 @@
         "description": "Inverse of AbandonedHolons.  Links a holon to a CommitResponse that did not successfully save it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-keyrules-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-keyrules-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.914551Z",
+    "generated_at": "2026-07-22T12:12:39.823097Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-keyrules-schema.tdl"
@@ -368,7 +368,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -414,11 +416,14 @@
         "description": "Inverse of UsesKeyRule, from KeyRuleType to TypeDescriptor.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-loader-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-loader-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.914956Z",
+    "generated_at": "2026-07-22T12:12:39.823334Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-loader-types.tdl"
@@ -352,7 +352,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -398,11 +400,14 @@
         "description": "Inverse of HasRelationshipReference. Points from LoaderRelationshipReference back to the originating LoaderHolon.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -447,7 +452,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -493,11 +500,14 @@
         "description": "Inverse of ReferenceSource. Points from LoaderHolonReference to the LoaderRelationshipReference where it acts as the source.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -542,7 +552,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -588,11 +600,14 @@
         "description": "Inverse of ReferenceTarget. Points from LoaderHolonReference to the LoaderRelationshipReference where it acts as a target.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -637,7 +652,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -683,11 +700,14 @@
         "description": "Inverse of BundleMembers. Points from LoaderHolon back to the containing HolonLoaderBundle.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -732,7 +752,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -778,11 +800,14 @@
         "description": "Inverse of HasLoadError. Points from HolonError back to the response that reported it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -827,7 +852,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -873,11 +900,14 @@
         "description": "Inverse of BundleMembers. Points from LoaderHolon back to the containing HolonLoaderBundle.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -916,7 +946,9 @@
         "display_name_plural": "LoadCommitStatuses",
         "description": "An enum representing the commit outcome of a holon load.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -956,7 +988,9 @@
         "display_name": "Complete",
         "description": "An enum variant indicating a complete commit.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -982,7 +1016,9 @@
         "display_name": "Incomplete",
         "description": "An enum variant indicating an incomplete commit.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1008,7 +1044,9 @@
         "display_name": "Skipped",
         "description": "An enum variant indicating that commit was skipped.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1035,7 +1073,10 @@
         "display_name_plural": "relationship_names",
         "description": "Name of the relationship as declared in the JSON input.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1068,7 +1109,10 @@
         "display_name_plural": "holon_keys",
         "description": "Local key for the referenced holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1101,7 +1145,10 @@
         "display_name_plural": "proxy_keys",
         "description": "Key of the ProxySpace through which this external reference is routed.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1134,7 +1181,10 @@
         "display_name_plural": "proxy_ids",
         "description": "ActionHash of the ProxySpace holon, used to route external references.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1167,7 +1217,10 @@
         "display_name_plural": "holons_stageds",
         "description": "Number of holons staged during the load operation.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1200,7 +1253,10 @@
         "display_name_plural": "holons_committeds",
         "description": "Number of holons successfully committed.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1233,7 +1289,10 @@
         "display_name_plural": "links_createds",
         "description": "Number of links successfully created.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1266,7 +1325,10 @@
         "display_name_plural": "filenames",
         "description": "The name of a file.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1299,7 +1361,10 @@
         "display_name_plural": "loader_holon_keys",
         "description": "Key to reference a loader holon within a load set.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1332,7 +1397,10 @@
         "display_name_plural": "start_utf8_byte_offsets",
         "description": "Byte offset that signifies the start of a segment of a source file.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1365,7 +1433,10 @@
         "display_name_plural": "load_commit_statuses",
         "description": "Represents the commit status for a holon loading operation.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.915636Z",
+    "generated_at": "2026-07-22T12:12:39.823807Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-operator-types.tdl"
@@ -76,7 +76,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -122,11 +124,14 @@
         "description": "Inverse of AffordsOperator, relationship from OperatorType to ValueType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -165,7 +170,9 @@
         "display_name_plural": "OperatorCategories",
         "description": "Enum value type categorizing operators (e.g., Comparison, StringMatch).",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -202,7 +209,9 @@
         "display_name": "Equality",
         "description": "Operators that test whether two values of the same type are equal or unequal. Applicable to all scalar value types.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -228,7 +237,9 @@
         "display_name": "Ordering",
         "description": "Operators that compare the relative order of two values of the same type. Applicable only to value types with a defined total order (e.g., integer, string).",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -255,7 +266,10 @@
         "display_name_plural": "arities",
         "description": "Number of operands the operator accepts (1 = unary, 2 = binary).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -288,7 +302,10 @@
         "display_name_plural": "operator_categories",
         "description": "Categorical grouping of an operator (e.g., Comparison, StringMatch).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.91597Z",
+    "generated_at": "2026-07-22T12:12:39.824003Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-property-types.tdl"
@@ -23,7 +23,10 @@
         "display_name_plural": "allows_duplicates",
         "description": "True if duplicate keys are allowed in the collection of target holons are permitted. If 'false' and is_ordered is also 'false' then the target holons collection is a Set.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -56,7 +59,10 @@
         "display_name_plural": "allows_additional_properties",
         "description": "If true, instances may include properties not explicitly listed by the descriptor.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -89,7 +95,10 @@
         "display_name_plural": "allows_additional_relationships",
         "description": "If true, instances may include relationships not explicitly listed by the descriptor.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -122,7 +131,10 @@
         "display_name_plural": "deletion_semantics",
         "description": "Specifies behavior for how to handle requests to delete the source holon from this relationship.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -155,7 +167,10 @@
         "display_name_plural": "descriptions",
         "description": "A human-readable explanation of the purpose or role of this type.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -188,7 +203,10 @@
         "display_name_plural": "displayNames",
         "description": "The human-readable label used for this property",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -221,7 +239,10 @@
         "display_name_plural": "displayNamePlurals",
         "description": "The plural form of the label for use in lists or summaries.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -254,7 +275,10 @@
         "display_name_plural": "isAbstractTypes",
         "description": "Indicates whether the type is abstract (cannot be instantiated).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -287,7 +311,10 @@
         "display_name_plural": "isDefinitional",
         "description": "Indicates whether the relationship contributes to the identity of the target holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -320,7 +347,10 @@
         "display_name_plural": "isOrdered",
         "description": "True if the order of related holons is significant.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -353,7 +383,10 @@
         "display_name_plural": "IsRequired",
         "description": "True if a value for this property type is required for the holon having this property.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -386,7 +419,10 @@
         "display_name_plural": "mapBooleans",
         "description": "Boolean scalar value (true/false).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -419,7 +455,10 @@
         "display_name_plural": "mapBytes",
         "description": "Binary data (blob of bytes).",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -452,7 +491,10 @@
         "display_name_plural": "mapIntegers",
         "description": "Integer scalar value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -485,7 +527,10 @@
         "display_name_plural": "mapStrings",
         "description": "Textual scalar value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -518,7 +563,10 @@
         "display_name_plural": "max_cardinalities",
         "description": "Maximum number of target holons allowed for the relationship.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -551,7 +599,10 @@
         "display_name_plural": "min_cardinalities",
         "description": "Minimum number of target holons allowed for the relationship.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -584,7 +635,10 @@
         "display_name_plural": "type_kinds",
         "description": "Specifies the kind of type this descriptor represents.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -617,7 +671,10 @@
         "display_name_plural": "typeNames",
         "description": "The unique identifier for a type, typically in ClassCase.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -650,7 +707,10 @@
         "display_name_plural": "schemaNames",
         "description": "The name of a type schema.  Defines a collection of type descriptor holons.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -683,7 +743,10 @@
         "display_name_plural": "typeNamePlurals",
         "description": "The plural form of the type's identifier used for display or grouping.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -716,7 +779,10 @@
         "display_name_plural": "error_types",
         "description": "Indicates the type of error.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -749,7 +815,10 @@
         "display_name_plural": "error_messages",
         "description": "A descriptive message explaining an error.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -782,7 +851,10 @@
         "display_name_plural": "error_counts",
         "description": "Number of errors encountered.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -815,7 +887,10 @@
         "display_name_plural": "template_strings",
         "description": "A format string that defines how a value should be constructed from one or more properties. It uses positional placeholders ($0, $1, $2, …) that are substituted in order with values from a related list of parameters. This pattern can be applied to derive identifiers, labels, paths, or other structured strings.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -848,7 +923,10 @@
         "display_name_plural": "collection_types",
         "description": "Selects the runtime wrapper used to inflate a persisted collection holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -881,7 +959,10 @@
         "display_name_plural": "keys",
         "description": "Identifying key of a holon instance.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -914,7 +995,10 @@
         "display_name_plural": "holon_ids",
         "description": "ActionHash identifier of a referenced holon.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
@@ -564,7 +564,7 @@
         "description": "Maximum number of target holons allowed for the relationship.",
         "instance_type_kind": "TypeKind.Property",
         "is_abstract_type": false,
-        "is_required": true,
+        "is_required": false,
         "allows_additional_properties": false,
         "allows_additional_relationships": false
       },

--- a/generated/json-imports/MAP Schema Types-map-core-schema-query-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-query-schema.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.916522Z",
+    "generated_at": "2026-07-22T12:12:39.824553Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-query-schema.tdl"
@@ -562,7 +562,10 @@
         "display_name_plural": "Query Names",
         "description": "Human-facing name of a QueryGraph.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -595,7 +598,10 @@
         "display_name_plural": "Query Descriptions",
         "description": "Human-readable description of what a QueryGraph means.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -628,7 +634,10 @@
         "display_name_plural": "Binding Names",
         "description": "Symbolic variable name carried by a QueryBinding.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -661,7 +670,10 @@
         "display_name_plural": "Step Ordinals",
         "description": "Ordinal position of a QueryStep within its QueryGraph.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -694,7 +706,10 @@
         "display_name_plural": "Step Labels",
         "description": "Optional human-readable label for a QueryStep.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -727,7 +742,10 @@
         "display_name_plural": "Execution Statuses",
         "description": "Status of an ExecutionInstance, recorded as an ExecutionStatus enum value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -760,7 +778,9 @@
         "display_name_plural": "Execution Statuses",
         "description": "Enum value type for the lifecycle status of an ExecutionInstance.",
         "instance_type_kind": "TypeKind.Value.Enum",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -804,7 +824,9 @@
         "display_name_plural": "Pendings",
         "description": "Execution has been created but not yet started.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -831,7 +853,9 @@
         "display_name_plural": "Runnings",
         "description": "Execution is in progress.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -858,7 +882,9 @@
         "display_name_plural": "Completes",
         "description": "Execution finished successfully.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -885,7 +911,9 @@
         "display_name_plural": "Faileds",
         "description": "Execution terminated with a failure.",
         "instance_type_kind": "TypeKind.EnumVariant",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -918,7 +946,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -964,11 +994,14 @@
         "description": "Inverse of QueryGraph, from QueryGraph to QueryDanceRequest.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1013,7 +1046,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1059,11 +1094,14 @@
         "description": "Inverse of InitialBindings, from ExecutionBinding to QueryDanceRequest.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1108,7 +1146,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1154,11 +1194,14 @@
         "description": "Inverse of QuerySteps, from QueryStep to QueryGraph.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1203,7 +1246,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1249,11 +1294,14 @@
         "description": "Inverse of DeclaredInputBindings, from QueryBinding to QueryGraph.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1298,7 +1346,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1344,11 +1394,14 @@
         "description": "Inverse of DeclaredResultBinding, from QueryBinding to QueryGraph.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1393,7 +1446,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1439,11 +1494,14 @@
         "description": "Inverse of StepKind, from QueryStepKind to QueryStep.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1488,7 +1546,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1534,11 +1594,14 @@
         "description": "Inverse of UsesInitialBinding, from QueryBinding to QueryStep.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1583,7 +1646,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1629,11 +1694,14 @@
         "description": "Inverse of StepOutputBinding, from QueryBinding to QueryStep.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1678,7 +1746,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1724,11 +1794,14 @@
         "description": "Inverse of StepParameters, from Projection to QueryStep.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1773,7 +1846,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1819,11 +1894,14 @@
         "description": "Inverse of StepDependsOn, from a QueryStep to the successor QuerySteps that depend on it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1868,7 +1946,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1914,11 +1994,14 @@
         "description": "Inverse of StepInputType, from HolonCollection to QueryStepKind.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1963,7 +2046,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2009,11 +2094,14 @@
         "description": "Inverse of StepResultType, from HolonCollection to QueryStepKind.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2058,7 +2146,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2104,11 +2194,14 @@
         "description": "Inverse of StepParameterType, from Projection to QueryStepKind.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2153,7 +2246,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2199,11 +2294,14 @@
         "description": "Inverse of ExecutesRequest, from QueryDanceRequest to ExecutionInstance.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2248,7 +2346,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2294,11 +2394,14 @@
         "description": "Inverse of ExecutionBindings, from ExecutionBinding to ExecutionInstance.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2343,7 +2446,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2389,11 +2494,14 @@
         "description": "Inverse of BindsQueryVariable, from QueryBinding to ExecutionBinding.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2438,7 +2546,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2484,11 +2594,14 @@
         "description": "Inverse of BoundCollection, from HolonCollection to ExecutionBinding.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2533,7 +2646,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -2579,11 +2694,14 @@
         "description": "Inverse of ExecutionResult, from HolonCollection to ExecutionInstance.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-relationship-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-relationship-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.918027Z",
+    "generated_at": "2026-07-22T12:12:39.825539Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-relationship-types.tdl"
@@ -29,7 +29,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -75,11 +77,14 @@
         "description": "Inverse of ComponentOf, from SchemaType to TypeDescriptor.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -124,7 +129,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -170,11 +177,14 @@
         "description": "Inverse of InstanceProperties, from PropertyType to TypeDescriptor.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -219,7 +229,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -265,11 +277,14 @@
         "description": "Inverse of InstanceRelationships, from DeclaredRelationshipType to TypeDescriptor.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -314,7 +329,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -360,11 +377,14 @@
         "description": "Inverse of DescribedBy, from TypeDescriptor to an instance of that type.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -409,7 +429,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -455,11 +477,14 @@
         "description": "Inverse of OwnedBy, from HolonSpace to Holon.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -504,7 +529,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -550,11 +577,14 @@
         "description": "Inverse of Properties, from PropertyType to HolonType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -599,7 +629,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -645,11 +677,14 @@
         "description": "Inverse of ValueType, from ValueType to PropertyType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -694,7 +729,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -740,11 +777,14 @@
         "description": "Inverse of SourceType, from holon to relationship type.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -789,7 +829,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -835,11 +877,14 @@
         "description": "Inverse of TargetType, from HolonType to MetaRelationshipType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -884,7 +929,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -930,11 +977,14 @@
         "description": "Links an inverse relationship type to the declared relationship it reverses.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -979,7 +1029,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1025,11 +1077,14 @@
         "description": "Inverse of Variants, from EnumVariantType to EnumValueType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1074,7 +1129,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1120,11 +1177,14 @@
         "description": "Inverse of DependsOn, indicating which schemas depend on this one.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1169,7 +1229,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1215,11 +1277,14 @@
         "description": "Inverse of ElementValueType, from ValueType to ValueArrayType.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1264,7 +1329,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1310,11 +1377,14 @@
         "description": "Inverse of Extends, the parent TypeDescriptor is extended by zero or more children.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1359,7 +1429,9 @@
         "is_ordered": true,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1405,11 +1477,14 @@
         "description": "Inverse of TemplateParameters, indicates that this PropertyType is used as a positional parameter in one or more Format.KeyRuleType instances.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1454,7 +1529,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1500,11 +1577,14 @@
         "description": "Inverse of AffordsTransactionModel, from TransactionType back to the HolonSpaceType that affords it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1549,7 +1629,9 @@
         "is_ordered": true,
         "allows_duplicates": true,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1595,11 +1677,14 @@
         "description": "Inverse of CollectionMembers. Links a holon to a persisted collection holon that contains it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1644,7 +1729,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 1,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1690,11 +1777,14 @@
         "description": "Inverse of ElementType. Links a holon type to persisted collection types that declare it as their element type.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1739,7 +1829,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 1
+        "max_cardinality": 1,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -1785,11 +1877,14 @@
         "description": "Inverse of Predecessor, from a holon version to later versions derived from it.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-root.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-root.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.91905Z",
+    "generated_at": "2026-07-22T12:12:39.826218Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-root.tdl"
@@ -171,7 +171,8 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_required": false
       },
       "relationships": [
         {
@@ -206,7 +207,10 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {
@@ -241,7 +245,10 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {
@@ -417,7 +424,8 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_required": false
       },
       "relationships": [
         {
@@ -458,7 +466,10 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {
@@ -518,7 +529,10 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {
@@ -559,7 +573,10 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": true,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {
@@ -830,7 +847,9 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": false,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "is_ordered": false,
+        "allows_duplicates": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.919564Z",
+    "generated_at": "2026-07-22T12:12:39.826519Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-core-schema-value-constraint-types.tdl"
@@ -271,7 +271,8 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": false,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "constraint_is_inclusive": false
       },
       "relationships": [
         {
@@ -311,7 +312,8 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": false,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "constraint_is_inclusive": false
       },
       "relationships": [
         {
@@ -421,7 +423,8 @@
         "instance_type_kind": "TypeKind.Holon",
         "is_abstract_type": false,
         "allows_additional_properties": false,
-        "allows_additional_relationships": false
+        "allows_additional_relationships": false,
+        "constraint_enabled": false
       },
       "relationships": [
         {
@@ -454,7 +457,10 @@
         "display_name_plural": "Constraint Lengths",
         "description": "Limit of allowed character count for a string value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -487,7 +493,10 @@
         "display_name_plural": "Constraint Integer Values",
         "description": "Limit of an integer value.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -520,7 +529,10 @@
         "display_name_plural": "Constraint Item Counts",
         "description": "Limit on the number of items in an array.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -553,7 +565,10 @@
         "display_name_plural": "IsInclusive Constraints",
         "description": "If the limit value included in the allowed range.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -586,7 +601,10 @@
         "display_name_plural": "Constraint Enabled Values",
         "description": "Boolean parameter indicating whether a boolean-style constraint rule is active.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -625,7 +643,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -676,7 +696,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -727,7 +749,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -778,7 +802,9 @@
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -824,11 +850,14 @@
         "description": "Inverse of Constraints, from a string value constraint to the string value type it constrains.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -868,11 +897,14 @@
         "description": "Inverse of Constraints, from an integer value constraint to the integer value type it constrains.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -912,11 +944,14 @@
         "description": "Inverse of Constraints, from a bytes value constraint to the bytes value type it constrains.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -956,11 +991,14 @@
         "description": "Inverse of Constraints, from a value array constraint to the value array type it constrains.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/generated/json-imports/MAP Schema Types-map-test-schema-book-person-inverse.json
+++ b/generated/json-imports/MAP Schema Types-map-test-schema-book-person-inverse.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "generator": "MAP Schema Compiler",
-    "generated_at": "2026-07-21T21:23:50.920064Z",
+    "generated_at": "2026-07-22T12:12:39.826864Z",
     "export_mode": "by-file",
     "source_files": [
       "MAP Schema Types-map-test-schema-book-person-inverse.tdl"
@@ -107,11 +107,14 @@
         "description": "Defines the author of a book.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": true,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -157,11 +160,14 @@
         "description": "Specifies a book that a Person has authored.  Inverse of AuthoredBy.",
         "instance_type_kind": "TypeKind.Relationship",
         "is_abstract_type": false,
+        "deletion_semantic": "Allow",
         "is_definitional": false,
         "is_ordered": false,
         "allows_duplicates": false,
         "min_cardinality": 0,
-        "max_cardinality": 32767
+        "max_cardinality": 32767,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -200,7 +206,10 @@
         "display_name_plural": "Names",
         "description": "Proper name.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {
@@ -233,7 +242,10 @@
         "display_name_plural": "Title",
         "description": "A title.",
         "instance_type_kind": "TypeKind.Property",
-        "is_abstract_type": false
+        "is_abstract_type": false,
+        "is_required": true,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
       },
       "relationships": [
         {

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -284,6 +284,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "descriptor_semantics"
+version = "0.1.0"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +701,7 @@ dependencies = [
  "base_types",
  "core_types",
  "derive-new",
+ "descriptor_semantics",
  "quick_cache",
  "serde",
  "serde_json",

--- a/happ/crates/holons_loader/src/errors.rs
+++ b/happ/crates/holons_loader/src/errors.rs
@@ -217,3 +217,145 @@ fn resolve_holon_error_type_descriptor(
         Err(e) => Err(e),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_types::LocalId;
+    use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
+    use holons_core::core_shared_objects::{Holon, ServiceRoutingPolicy};
+    use holons_core::HolonServiceApi;
+    use std::any::Any;
+
+    #[derive(Debug)]
+    struct TestHolonService;
+
+    fn unreachable_in_loader_error_tests<T>() -> Result<T, HolonError> {
+        Err(HolonError::NotImplemented("TestHolonService".to_string()))
+    }
+
+    impl HolonServiceApi for TestHolonService {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn commit_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _staged_references: &[StagedReference],
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+
+        fn delete_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _local_id: &LocalId,
+        ) -> Result<(), HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+
+        fn fetch_all_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+        ) -> Result<RelationshipMap, HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+
+        fn fetch_holon_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _id: &HolonId,
+        ) -> Result<Holon, HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+
+        fn fetch_related_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _source_id: &HolonId,
+            _relationship_name: &RelationshipName,
+        ) -> Result<HolonCollection, HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+
+        fn get_all_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+        ) -> Result<HolonCollection, HolonError> {
+            Ok(HolonCollection::new_saved())
+        }
+
+        fn load_holons_internal(
+            &self,
+            _context: &Arc<TransactionContext>,
+            _bundle: TransientReference,
+        ) -> Result<TransientReference, HolonError> {
+            unreachable_in_loader_error_tests()
+        }
+    }
+
+    fn build_context() -> Arc<TransactionContext> {
+        let holon_service: Arc<dyn HolonServiceApi> = Arc::new(TestHolonService);
+        let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
+            None,
+            holon_service,
+            None,
+            ServiceRoutingPolicy::BlockExternal,
+        ));
+
+        space_manager
+            .get_transaction_manager()
+            .open_new_transaction(Arc::clone(&space_manager))
+            .expect("test transaction should open")
+    }
+
+    #[test]
+    fn make_error_holons_enriches_loader_key_filename_and_offset() -> Result<(), HolonError> {
+        let context = build_context();
+        let loader_key = MapString("Person.HolonType".to_string());
+        let mut provenance = ProvenanceIndex::new();
+        provenance.insert(
+            loader_key.clone(),
+            FileProvenance {
+                filename: MapString("bad-schema.json".to_string()),
+                start_utf8_byte_offset: Some(1724),
+            },
+        );
+
+        let errors = vec![ErrorWithContext::new(HolonError::InvalidType(
+            "LoaderRelationshipReference could not be resolved after fixed-point retries: name=ComponentOf, source=Person.HolonType, targets=[BookAuthorInverseSchemata]".to_string(),
+        ))
+        .with_loader_key(loader_key.clone())];
+
+        let mut holons = make_error_holons_best_effort(&context, &errors, Some(&provenance))?;
+        assert_eq!(holons.len(), 1);
+
+        let error_holon = holons.pop().expect("one error holon");
+        assert_eq!(
+            error_holon.property_value(CorePropertyTypeName::LoaderHolonKey.as_property_name())?,
+            Some(BaseValue::StringValue(loader_key))
+        );
+        assert_eq!(
+            error_holon.property_value(CorePropertyTypeName::Filename.as_property_name())?,
+            Some(BaseValue::StringValue(MapString("bad-schema.json".to_string())))
+        );
+        assert_eq!(
+            error_holon
+                .property_value(CorePropertyTypeName::StartUtf8ByteOffset.as_property_name())?,
+            Some(BaseValue::IntegerValue(MapInteger(1724)))
+        );
+
+        let message = error_holon
+            .property_value(ErrorMessage.as_property_name())?
+            .expect("error message property");
+        assert!(matches!(
+            message,
+            BaseValue::StringValue(MapString(text))
+                if text.contains("BookAuthorInverseSchemata")
+        ));
+
+        Ok(())
+    }
+}

--- a/happ/crates/holons_loader/src/loader_ref_resolver.rs
+++ b/happ/crates/holons_loader/src/loader_ref_resolver.rs
@@ -1139,7 +1139,14 @@ impl LoaderRefResolver {
     fn brief_lrr_summary(lrr: &TransientReference) -> String {
         let name = Self::extract_relationship_metadata(lrr)
             .unwrap_or_else(|_| RelationshipName(MapString("<unknown>".into())));
-        format!("name={}", name)
+        let source = Self::source_loader_key_of_lrr(lrr)
+            .map(|key| key.0)
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let targets = Self::target_loader_keys_of_lrr(lrr);
+        let formatted_targets =
+            if targets.is_empty() { "<none>".to_string() } else { targets.join(", ") };
+
+        format!("name={name}, source={source}, targets=[{formatted_targets}]")
     }
 
     /// Deferrable errors are those that might succeed after earlier writes land.
@@ -1166,6 +1173,29 @@ impl LoaderRefResolver {
             Some(BaseValue::StringValue(k)) if !k.0.is_empty() => Some(k),
             _ => None,
         }
+    }
+
+    /// Extract the LoaderHolon target keys from the LRR's ReferenceTarget collection.
+    fn target_loader_keys_of_lrr(lrr: &TransientReference) -> Vec<String> {
+        let target_rel = CoreRelationshipTypeName::ReferenceTarget.as_relationship_name();
+        let key_prop = CorePropertyTypeName::HolonKey.as_property_name();
+        let handle = match lrr.related_holons(target_rel) {
+            Ok(handle) => handle,
+            Err(_) => return Vec::new(),
+        };
+        let guard = match handle.read() {
+            Ok(guard) => guard,
+            Err(_) => return Vec::new(),
+        };
+
+        guard
+            .get_members()
+            .iter()
+            .filter_map(|reference| match reference.property_value(&key_prop).ok()? {
+                Some(BaseValue::StringValue(key)) if !key.0.is_empty() => Some(key.0),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Wrap a HolonError with contextual loader key (if available).
@@ -1890,6 +1920,60 @@ mod tests {
             .get_members()
             .clone();
         assert!(related_members.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn brief_lrr_summary_includes_source_and_targets() -> Result<(), HolonError> {
+        let context = build_context();
+        let relationship_reference = loader_relationship_reference(
+            &context,
+            "ComponentOf",
+            "Person.HolonType",
+            &["BookAuthorInverseSchemata"],
+        )?;
+
+        let summary = LoaderRefResolver::brief_lrr_summary(&relationship_reference);
+
+        assert!(summary.contains("name=ComponentOf"));
+        assert!(summary.contains("source=Person.HolonType"));
+        assert!(summary.contains("targets=[BookAuthorInverseSchemata]"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_relationships_reports_unresolved_target_with_bad_target_name(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let _source = stage(&context, new_holon(&context, "Person.HolonType")?)?;
+        let relationship_reference = loader_relationship_reference(
+            &context,
+            "ComponentOf",
+            "Person.HolonType",
+            &["BookAuthorInverseSchemata"],
+        )?;
+
+        let outcome =
+            LoaderRefResolver::resolve_relationships(&context, vec![relationship_reference])?;
+
+        assert_eq!(outcome.links_created, 0);
+        assert_eq!(outcome.errors.len(), 1);
+        assert_eq!(
+            outcome.errors[0].source_loader_key,
+            Some(MapString("Person.HolonType".to_string()))
+        );
+
+        match &outcome.errors[0].error {
+            HolonError::InvalidType(message) => {
+                assert!(message.contains("could not be resolved after fixed-point retries"));
+                assert!(message.contains("name=ComponentOf"));
+                assert!(message.contains("source=Person.HolonType"));
+                assert!(message.contains("targets=[BookAuthorInverseSchemata]"));
+            }
+            other => panic!("expected InvalidType unresolved-reference error, got {other:?}"),
+        }
 
         Ok(())
     }

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -1897,6 +1897,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "descriptor_semantics"
+version = "0.1.0"
+
+[[package]]
 name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,6 +4084,7 @@ dependencies = [
  "base_types",
  "core_types",
  "derive-new",
+ "descriptor_semantics",
  "quick_cache",
  "serde",
  "serde_json",

--- a/host/crates/holons_loader_client/src/parser.rs
+++ b/host/crates/holons_loader_client/src/parser.rs
@@ -12,13 +12,12 @@ use crate::builder::{
     collect_relationship_specs_for_loader_holon, create_loader_bundle_for_file,
     create_loader_holon_from_raw, normalize_ref_key, RawLoaderHolon, RawLoaderMeta,
 };
-use core_types::{ContentSet, FileData, ValidationError};
+use core_types::{ContentSet, FileData};
 use holons_core::core_shared_objects::transactions::TransactionContext;
 use holons_prelude::prelude::*;
 use json_schema_validation::json_schema_validator::validate_json_str_against_schema_str;
 use serde::Deserialize;
 use serde_json::value::RawValue;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -128,15 +127,12 @@ pub fn parse_files_into_load_set(
     // We collect all per-file issues rather than failing fast so the caller
     // can report a comprehensive summary to the user.
     let mut issues: Vec<ImportFileParsingIssue> = Vec::new();
-    let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
-
     for import_file in &content_set.files_to_load {
-        if let Err(issue) = parse_single_import_file_into_bundle_with_tracker(
+        if let Err(issue) = parse_single_import_file_into_bundle(
             context,
             &load_set_ref,
             import_file,
             &content_set.schema.raw_contents,
-            &mut inverse_target_tracker,
         ) {
             issues.push(issue);
         }
@@ -183,24 +179,19 @@ pub fn create_holon_load_set(
 ///
 /// On success, the `HolonLoadSet` now contains a new bundle for this file.
 /// On failure, a single `ImportFileParsingIssue` is returned.
-fn parse_single_import_file_into_bundle_with_tracker(
+pub fn parse_single_import_file_into_bundle(
     context: &Arc<TransactionContext>,
     load_set_ref: &HolonReference,
     import_file: &FileData,
     schema_json: &str,
-    inverse_target_tracker: &mut HasInverseTargetUniquenessTracker,
 ) -> Result<(), ImportFileParsingIssue> {
     let raw_json = import_file.raw_contents.as_str();
     let file_path = PathBuf::from(import_file.filename.clone());
 
     // 2) Validate against the loader JSON Schema and deserialize into
     //    `RawLoaderFileWithSlices<'_>`.
-    let (raw_file_with_slices, has_inverse_pairs) =
-        match validate_and_deserialize_loader_file_with_pairs(
-            raw_json,
-            schema_json,
-            &import_file.filename,
-        ) {
+    let raw_file_with_slices =
+        match validate_and_deserialize_loader_file(raw_json, schema_json, &import_file.filename) {
             Ok(wrapper) => wrapper,
             Err(err) => {
                 return Err(ImportFileParsingIssue {
@@ -214,24 +205,6 @@ fn parse_single_import_file_into_bundle_with_tracker(
                 });
             }
         };
-
-    for pair in has_inverse_pairs {
-        if let Err(err) = inverse_target_tracker.record(
-            &import_file.filename,
-            &pair.declared_source_key,
-            &pair.inverse_target_key,
-        ) {
-            return Err(ImportFileParsingIssue {
-                file_path: file_path.clone(),
-                kind: ImportFileParsingIssueKind::SchemaValidationFailure,
-                message: format!(
-                    "Loader import file '{}' failed relationship-pair validation: {}",
-                    import_file.filename, err
-                ),
-                source_error: Some(err),
-            });
-        }
-    }
 
     // 3) Create the HolonLoaderBundle for this file and attach it to
     //    the HolonLoadSet.
@@ -368,21 +341,11 @@ fn parse_single_import_file_into_bundle_with_tracker(
 /// - Run schema validation using the `json_schema_validation` crate.
 /// - On success, deserialize into `RawLoaderFileWithSlices`.
 /// - On failure, return `HolonError::ValidationError`.
-#[cfg(test)]
-fn validate_and_deserialize_loader_file<'a>(
+pub fn validate_and_deserialize_loader_file<'a>(
     raw_json: &'a str,
     schema_json: &str,
     filename: &str,
 ) -> Result<RawLoaderFileWithSlices<'a>, HolonError> {
-    validate_and_deserialize_loader_file_with_pairs(raw_json, schema_json, filename)
-        .map(|(raw_file, _pairs)| raw_file)
-}
-
-fn validate_and_deserialize_loader_file_with_pairs<'a>(
-    raw_json: &'a str,
-    schema_json: &str,
-    filename: &str,
-) -> Result<(RawLoaderFileWithSlices<'a>, Vec<HasInversePair>), HolonError> {
     // 1. First run schema validation using in-memory schema + instance JSON.
     match validate_json_str_against_schema_str(schema_json, raw_json) {
         Ok(()) => { /* schema validation succeeded */ }
@@ -393,167 +356,12 @@ fn validate_and_deserialize_loader_file_with_pairs<'a>(
     }
 
     // 2. JSON is valid; now deserialize *borrowed* RawValue slices.
-    let raw_file =
-        serde_json::from_str::<RawLoaderFileWithSlices<'a>>(raw_json).map_err(|err| {
-            HolonError::InvalidParameter(format!(
-                "Failed to decode loader import JSON after schema validation (file '{}'): {}",
-                filename, err
-            ))
-        })?;
-
-    let has_inverse_pairs = validate_relationship_pair_metadata_authoring(&raw_file, filename)?;
-
-    Ok((raw_file, has_inverse_pairs))
-}
-
-#[derive(Debug)]
-struct RelationshipDescriptorImportMetadata {
-    extends_declared_relationship_type: bool,
-    extends_inverse_relationship_type: bool,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct HasInversePair {
-    declared_source_key: String,
-    inverse_target_key: String,
-}
-
-#[derive(Debug, Clone)]
-struct HasInverseTargetClaim {
-    filename: String,
-    declared_source_key: String,
-}
-
-#[derive(Debug, Default)]
-struct HasInverseTargetUniquenessTracker {
-    targets: HashMap<String, HasInverseTargetClaim>,
-}
-
-impl HasInverseTargetUniquenessTracker {
-    fn record(
-        &mut self,
-        filename: &str,
-        declared_source_key: &str,
-        inverse_target_key: &str,
-    ) -> Result<(), HolonError> {
-        if let Some(previous) = self.targets.get(inverse_target_key) {
-            return Err(import_relationship_validation_error(format!(
-                "Inverse relationship descriptor '{}' is targeted by more than one declared relationship descriptor via HasInverse: '{}' in '{}' and '{}' in '{}'",
-                inverse_target_key,
-                previous.declared_source_key,
-                previous.filename,
-                declared_source_key,
-                filename
-            )));
-        }
-
-        self.targets.insert(
-            inverse_target_key.to_string(),
-            HasInverseTargetClaim {
-                filename: filename.to_string(),
-                declared_source_key: declared_source_key.to_string(),
-            },
-        );
-        Ok(())
-    }
-}
-
-fn validate_relationship_pair_metadata_authoring(
-    raw_file: &RawLoaderFileWithSlices<'_>,
-    filename: &str,
-) -> Result<Vec<HasInversePair>, HolonError> {
-    let mut decoded_holons = Vec::with_capacity(raw_file.holons.len());
-    let mut relationship_descriptors = HashMap::new();
-    let mut has_inverse_pairs = Vec::new();
-    let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
-
-    for raw_value in &raw_file.holons {
-        let raw_holon = serde_json::from_str::<RawLoaderHolon>(raw_value.get()).map_err(|err| {
-            HolonError::InvalidParameter(format!(
-                "Failed to decode loader holon JSON during relationship-pair validation (file '{}'): {}",
-                filename, err
-            ))
-        })?;
-
-        let extends_declared_relationship_type = relationship_targets(&raw_holon, "Extends")
-            .any(|target| target == "DeclaredRelationshipType");
-        let extends_inverse_relationship_type = relationship_targets(&raw_holon, "Extends")
-            .any(|target| target == "InverseRelationshipType");
-
-        if extends_declared_relationship_type || extends_inverse_relationship_type {
-            relationship_descriptors.insert(
-                raw_holon.key.clone(),
-                RelationshipDescriptorImportMetadata {
-                    extends_declared_relationship_type,
-                    extends_inverse_relationship_type,
-                },
-            );
-        }
-
-        decoded_holons.push(raw_holon);
-    }
-
-    for raw_holon in &decoded_holons {
-        if let Some(inverse_of) =
-            raw_holon.relationships.iter().find(|relationship| relationship.name == "InverseOf")
-        {
-            return Err(import_relationship_validation_error(format!(
-                "Loader import file '{}' authors InverseOf on '{}'. Relationship-pair metadata must be authored from the declared relationship side with HasInverse; offending target(s): {:?}",
-                filename, raw_holon.key, inverse_of.targets
-            )));
-        }
-
-        let Some(metadata) = relationship_descriptors.get(&raw_holon.key) else {
-            continue;
-        };
-        if !metadata.extends_declared_relationship_type {
-            continue;
-        }
-
-        let has_inverse_targets =
-            relationship_targets(raw_holon, "HasInverse").cloned().collect::<Vec<_>>();
-        if has_inverse_targets.len() != 1 {
-            return Err(import_relationship_validation_error(format!(
-                "Declared relationship descriptor '{}' in '{}' must author exactly one HasInverse target; found {}",
-                raw_holon.key,
-                filename,
-                has_inverse_targets.len()
-            )));
-        }
-
-        let target_key = &has_inverse_targets[0];
-        if let Some(target_metadata) = relationship_descriptors.get(target_key) {
-            if !target_metadata.extends_inverse_relationship_type {
-                return Err(import_relationship_validation_error(format!(
-                    "Declared relationship descriptor '{}' in '{}' has HasInverse target '{}', but that target does not extend InverseRelationshipType",
-                    raw_holon.key, filename, target_key
-                )));
-            }
-        }
-
-        inverse_target_tracker.record(filename, &raw_holon.key, &target_key)?;
-        has_inverse_pairs.push(HasInversePair {
-            declared_source_key: raw_holon.key.clone(),
-            inverse_target_key: target_key.clone(),
-        });
-    }
-
-    Ok(has_inverse_pairs)
-}
-
-fn relationship_targets<'a>(
-    raw_holon: &'a RawLoaderHolon,
-    relationship_name: &'static str,
-) -> impl Iterator<Item = &'a String> {
-    raw_holon
-        .relationships
-        .iter()
-        .filter(move |relationship| relationship.name == relationship_name)
-        .flat_map(|relationship| relationship.targets.iter())
-}
-
-fn import_relationship_validation_error(message: String) -> HolonError {
-    HolonError::ValidationError(ValidationError::RelationshipError(message))
+    serde_json::from_str::<RawLoaderFileWithSlices<'a>>(raw_json).map_err(|err| {
+        HolonError::InvalidParameter(format!(
+            "Failed to decode loader import JSON after schema validation (file '{}'): {}",
+            filename, err
+        ))
+    })
 }
 
 /// Convenience helper for computing a 0-based UTF-8 byte offset into a file
@@ -579,48 +387,22 @@ pub fn compute_holon_start_offset(file_buffer: &str, holon_slice: &str) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
 
     const BOOTSTRAP_SCHEMA: &str =
         include_str!("../../../import_files/map-schema/bootstrap-import.schema.json");
 
-    fn relationship_pair_import(
-        declared_relationships: &str,
-        inverse_relationships: &str,
-    ) -> String {
-        format!(
-            r#"{{
-              "holons": [
-                {{
-                  "key": "(BookType)-[Authors]->(PersonType)",
-                  "type": "TypeDescriptor.HolonType",
-                  "properties": {{
-                    "instance_type_kind": "TypeKind.Relationship"
-                  }},
-                  "relationships": [
-                    {{ "name": "Extends", "target": {{ "$ref": "DeclaredRelationshipType" }} }}
-                    {declared_relationships}
-                  ]
-                }},
-                {{
-                  "key": "(PersonType)-[AuthoredBy]->(BookType)",
-                  "type": "TypeDescriptor.HolonType",
-                  "properties": {{
-                    "instance_type_kind": "TypeKind.Relationship"
-                  }},
-                  "relationships": [
-                    {{ "name": "Extends", "target": {{ "$ref": "InverseRelationshipType" }} }}
-                    {inverse_relationships}
-                  ]
-                }}
-              ]
-            }}"#
-        )
-    }
-
-    fn shared_inverse_target_import() -> String {
-        r#"{
+    #[test]
+    fn loader_import_adapter_accepts_schema_valid_descriptor_semantics() {
+        let raw_json = r#"{
           "holons": [
+            {
+              "key": "Person.HolonType",
+              "type": "TypeDescriptor.HolonType",
+              "properties": {
+                "instance_type_kind": "TypeKind.HolonFoo"
+              },
+              "relationships": []
+            },
             {
               "key": "(BookType)-[Authors]->(PersonType)",
               "type": "TypeDescriptor.HolonType",
@@ -628,236 +410,22 @@ mod tests {
                 "instance_type_kind": "TypeKind.Relationship"
               },
               "relationships": [
-                { "name": "Extends", "target": { "$ref": "DeclaredRelationshipType" } },
                 {
-                  "name": "HasInverse",
-                  "target": {
-                    "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
-                  }
+                  "name": "Extends",
+                  "target": { "$ref": "DeclaredRelationshipType" }
                 }
-              ]
-            },
-            {
-              "key": "(BookType)-[Editors]->(PersonType)",
-              "type": "TypeDescriptor.HolonType",
-              "properties": {
-                "instance_type_kind": "TypeKind.Relationship"
-              },
-              "relationships": [
-                { "name": "Extends", "target": { "$ref": "DeclaredRelationshipType" } },
-                {
-                  "name": "HasInverse",
-                  "target": {
-                    "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
-                  }
-                }
-              ]
-            },
-            {
-              "key": "(PersonType)-[AuthoredBy]->(BookType)",
-              "type": "TypeDescriptor.HolonType",
-              "properties": {
-                "instance_type_kind": "TypeKind.Relationship"
-              },
-              "relationships": [
-                { "name": "Extends", "target": { "$ref": "InverseRelationshipType" } }
               ]
             }
           ]
-        }"#
-        .to_string()
-    }
+        }"#;
 
-    fn assert_relationship_validation_error<T: std::fmt::Debug>(
-        result: Result<T, HolonError>,
-    ) -> String {
-        match result {
-            Err(HolonError::ValidationError(ValidationError::RelationshipError(message))) => {
-                message
-            }
-            other => panic!("expected relationship validation error, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn loader_import_validation_accepts_declared_has_inverse_without_inverse_of() {
-        let raw_json = relationship_pair_import(
-            r#",
-                    {
-                      "name": "HasInverse",
-                      "target": {
-                        "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
-                      }
-                    }"#,
-            "",
-        );
-
-        let parsed = validate_and_deserialize_loader_file(&raw_json, BOOTSTRAP_SCHEMA, "pair.json")
-            .expect("declared HasInverse authoring should validate");
+        let parsed = validate_and_deserialize_loader_file(
+            raw_json,
+            BOOTSTRAP_SCHEMA,
+            "schema-valid-semantic-input.json",
+        )
+        .expect("the loader adapter should not own descriptor-semantic validation");
 
         assert_eq!(parsed.holons.len(), 2);
-    }
-
-    #[test]
-    fn canonical_core_schema_imports_satisfy_relationship_pair_authoring_validation() {
-        let core_schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join("..")
-            .join("import_files")
-            .join("map-schema")
-            .join("core-schema");
-
-        let mut schema_paths = fs::read_dir(&core_schema_dir)
-            .unwrap_or_else(|error| {
-                panic!("failed to read core schema dir {}: {error}", core_schema_dir.display())
-            })
-            .map(|entry| {
-                entry
-                    .unwrap_or_else(|error| panic!("failed to read core schema dir entry: {error}"))
-                    .path()
-            })
-            .filter(|path| {
-                path.extension().and_then(|extension| extension.to_str()) == Some("json")
-            })
-            .collect::<Vec<_>>();
-        schema_paths.sort();
-
-        let mut inverse_target_tracker = HasInverseTargetUniquenessTracker::default();
-        for schema_path in schema_paths {
-            let raw_json = fs::read_to_string(&schema_path).unwrap_or_else(|error| {
-                panic!("failed to read core schema export {}: {error}", schema_path.display())
-            });
-            let (_raw_file, has_inverse_pairs) = validate_and_deserialize_loader_file_with_pairs(
-                &raw_json,
-                BOOTSTRAP_SCHEMA,
-                &schema_path.display().to_string(),
-            )
-            .unwrap_or_else(|error| {
-                panic!(
-                    "core schema export {} failed relationship-pair validation: {error}",
-                    schema_path.display()
-                )
-            });
-            for pair in has_inverse_pairs {
-                inverse_target_tracker
-                    .record(
-                        &schema_path.display().to_string(),
-                        &pair.declared_source_key,
-                        &pair.inverse_target_key,
-                    )
-                    .unwrap_or_else(|error| {
-                        panic!(
-                            "core schema export {} failed cross-file inverse uniqueness validation: {error}",
-                            schema_path.display()
-                        )
-                    });
-            }
-        }
-    }
-
-    #[test]
-    fn loader_import_validation_rejects_shared_inverse_target() {
-        let raw_json = shared_inverse_target_import();
-
-        let message = assert_relationship_validation_error(validate_and_deserialize_loader_file(
-            &raw_json,
-            BOOTSTRAP_SCHEMA,
-            "shared-inverse-target.json",
-        ));
-
-        assert!(message.contains("targeted by more than one declared relationship descriptor"));
-        assert!(message.contains("(BookType)-[Authors]->(PersonType)"));
-        assert!(message.contains("(BookType)-[Editors]->(PersonType)"));
-        assert!(message.contains("(PersonType)-[AuthoredBy]->(BookType)"));
-    }
-
-    #[test]
-    fn inverse_target_uniqueness_tracker_rejects_cross_file_duplicate() {
-        let mut tracker = HasInverseTargetUniquenessTracker::default();
-        tracker
-            .record(
-                "authors.json",
-                "(BookType)-[Authors]->(PersonType)",
-                "(PersonType)-[AuthoredBy]->(BookType)",
-            )
-            .expect("first declared relationship should claim inverse target");
-
-        let message = assert_relationship_validation_error(tracker.record(
-            "editors.json",
-            "(BookType)-[Editors]->(PersonType)",
-            "(PersonType)-[AuthoredBy]->(BookType)",
-        ));
-
-        assert!(message.contains("authors.json"));
-        assert!(message.contains("editors.json"));
-        assert!(message.contains("(BookType)-[Authors]->(PersonType)"));
-        assert!(message.contains("(BookType)-[Editors]->(PersonType)"));
-        assert!(message.contains("(PersonType)-[AuthoredBy]->(BookType)"));
-    }
-
-    #[test]
-    fn loader_import_validation_rejects_declared_relationship_without_has_inverse() {
-        let raw_json = relationship_pair_import("", "");
-
-        let message = assert_relationship_validation_error(validate_and_deserialize_loader_file(
-            &raw_json,
-            BOOTSTRAP_SCHEMA,
-            "missing-has-inverse.json",
-        ));
-
-        assert!(message.contains("must author exactly one HasInverse target"));
-        assert!(message.contains("found 0"));
-    }
-
-    #[test]
-    fn loader_import_validation_rejects_has_inverse_target_with_wrong_kind() {
-        let raw_json = relationship_pair_import(
-            r#",
-                    {
-                      "name": "HasInverse",
-                      "target": {
-                        "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
-                      }
-                    }"#,
-            "",
-        )
-        .replace("InverseRelationshipType", "DeclaredRelationshipType");
-
-        let message = assert_relationship_validation_error(validate_and_deserialize_loader_file(
-            &raw_json,
-            BOOTSTRAP_SCHEMA,
-            "wrong-kind-has-inverse.json",
-        ));
-
-        assert!(message.contains("does not extend InverseRelationshipType"));
-    }
-
-    #[test]
-    fn loader_import_validation_rejects_authored_inverse_of_relationship() {
-        let raw_json = relationship_pair_import(
-            r#",
-                    {
-                      "name": "HasInverse",
-                      "target": {
-                        "$ref": "(PersonType)-[AuthoredBy]->(BookType)"
-                      }
-                    }"#,
-            r#",
-                    {
-                      "name": "InverseOf",
-                      "target": {
-                        "$ref": "(BookType)-[Authors]->(PersonType)"
-                      }
-                    }"#,
-        );
-
-        let message = assert_relationship_validation_error(validate_and_deserialize_loader_file(
-            &raw_json,
-            BOOTSTRAP_SCHEMA,
-            "authored-inverse-of.json",
-        ));
-
-        assert!(message.contains("authors InverseOf"));
-        assert!(message.contains("HasInverse"));
     }
 }

--- a/host/import_files/map-schema/error-fixtures/README.md
+++ b/host/import_files/map-schema/error-fixtures/README.md
@@ -9,7 +9,12 @@ Suggested manual checks:
   Expected: load fails and the error message names the unresolved target
   `BookAuthorInverseSchemata`.
 
-The fixture is derived from the small `BookAuthorInverseSchema` test schema so
+- `diagnostic-zoo.json`
+  Manual JSON projection of `tools/map-schema/examples/diagnostic-zoo.tdl` for uploader testing.
+  It intentionally preserves invalid declarations, so load is expected to report multiple errors
+  and skip commit.
+
+The unresolved-target fixture is derived from the small `BookAuthorInverseSchema` test schema so
 it stays easy to reason about during manual testing. Schema-authoring errors,
 including invalid projected TypeKinds, belong in the TDL compiler diagnostic
 corpus at `tools/map-schema/examples/diagnostic-zoo.tdl`.

--- a/host/import_files/map-schema/error-fixtures/README.md
+++ b/host/import_files/map-schema/error-fixtures/README.md
@@ -1,0 +1,15 @@
+Loader error fixture for manual `npm start` testing.
+
+These files are intentionally invalid MAP loader imports meant to exercise
+human-facing diagnostics in the JSON uploader UI.
+
+Suggested manual checks:
+
+- `book-person-inverse-invalid-target.json`
+  Expected: load fails and the error message names the unresolved target
+  `BookAuthorInverseSchemata`.
+
+The fixture is derived from the small `BookAuthorInverseSchema` test schema so
+it stays easy to reason about during manual testing. Schema-authoring errors,
+including invalid projected TypeKinds, belong in the TDL compiler diagnostic
+corpus at `tools/map-schema/examples/diagnostic-zoo.tdl`.

--- a/host/import_files/map-schema/error-fixtures/book-person-inverse-invalid-target.json
+++ b/host/import_files/map-schema/error-fixtures/book-person-inverse-invalid-target.json
@@ -1,0 +1,264 @@
+{
+  "meta": {
+    "generator": "Manual loader error fixture",
+    "purpose": "Exercise unresolved relationship target diagnostics",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json"
+    ]
+  },
+  "holons": [
+    {
+      "key": "BookAuthorInverseSchema",
+      "type": "Schema.HolonType",
+      "properties": {
+        "description": "Manual error fixture for unresolved relationship target diagnostics.",
+        "schema_name": "BookAuthorInverseSchema"
+      },
+      "relationships": [
+        {
+          "name": "DependsOn",
+          "target": {
+            "$ref": "MAP Core Schema-v0.0.7"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Book.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Book",
+        "type_name_plural": "Books",
+        "display_name": "Book",
+        "display_name_plural": "Books",
+        "description": "A book.",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "Title.PropertyType"
+          }
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": {
+            "$ref": "(Book.HolonType)-[AuthoredBy]->(Person.HolonType)"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Person.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Person",
+        "type_name_plural": "Persons",
+        "display_name": "Person",
+        "display_name_plural": "People",
+        "description": "A person.",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchemata"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "Name.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(Book.HolonType)-[AuthoredBy]->(Person.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "AuthoredBy",
+        "type_name_plural": "AuthoredByRelationships",
+        "display_name": "AuthoredBy",
+        "display_name_plural": "AuthoredBy Relationships",
+        "description": "Defines the author of a book.",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "HasInverse",
+          "target": {
+            "$ref": "(Person.HolonType)-[Authors]->(Book.HolonType)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "Book.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "Person.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(Person.HolonType)-[Authors]->(Book.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Authors",
+        "type_name_plural": "AuthorsRelationships",
+        "display_name": "Authors",
+        "display_name_plural": "Authors Relationships",
+        "description": "Specifies a book that a Person has authored. Inverse of AuthoredBy.",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "InverseRelationshipType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "Person.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "Book.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Name.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Name",
+        "type_name_plural": "Names",
+        "display_name": "Name",
+        "display_name_plural": "Names",
+        "description": "Proper name.",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "PropertyType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "MapStringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "Title.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Title",
+        "type_name_plural": "Titles",
+        "display_name": "Title",
+        "display_name_plural": "Title",
+        "description": "A title.",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "BookAuthorInverseSchema"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "PropertyType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "MapStringValueType"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/host/import_files/map-schema/error-fixtures/diagnostic-zoo.json
+++ b/host/import_files/map-schema/error-fixtures/diagnostic-zoo.json
@@ -1,0 +1,599 @@
+{
+  "meta": {
+    "generator": "Manual projection of tools/map-schema/examples/diagnostic-zoo.tdl",
+    "purpose": "Exercise accumulated loader diagnostics with intentionally invalid schema data",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json"
+    ]
+  },
+  "holons": [
+    {
+      "key": "Diagnostic Zoo-v0.0.1",
+      "type": "Schema.HolonType",
+      "properties": {
+        "schema_name": "Diagnostic Zoo-v0.0.1",
+        "description": "Intentional semantic diagnostic corpus."
+      },
+      "relationships": [
+        {
+          "name": "DependsOn",
+          "target": {
+            "$ref": "MAP Core Schema-v0.0.7"
+          }
+        }
+      ]
+    },
+    {
+      "key": "ZooBook.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "ZooBook",
+        "type_name_plural": "ZooBooks",
+        "display_name": "ZooBook",
+        "display_name_plural": "ZooBooks",
+        "description": "Local holon used as a deliberately wrong property value type.",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "LocalName.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "LocalName",
+        "type_name_plural": "LocalNames",
+        "display_name": "LocalName",
+        "display_name_plural": "LocalNames",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false,
+        "is_required": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "PropertyType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "MapStringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "DuplicateSymbolThing.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "DuplicateSymbolThing",
+        "type_name_plural": "DuplicateSymbolThings",
+        "display_name": "DuplicateSymbolThing",
+        "display_name_plural": "DuplicateSymbolThings",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "LocalName.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "DuplicateSymbolThing.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "DuplicateSymbolThing",
+        "type_name_plural": "DuplicateSymbolThings",
+        "display_name": "DuplicateSymbolThing",
+        "display_name_plural": "DuplicateSymbolThings",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": {
+            "$ref": "LocalName.PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "MissingValueType.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "MissingValueType",
+        "type_name_plural": "MissingValueTypes",
+        "display_name": "MissingValueType",
+        "display_name_plural": "MissingValueTypes",
+        "description": "Intentionally omits ValueType.",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false,
+        "is_required": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "PropertyType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "WrongValueType.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "WrongValueType",
+        "type_name_plural": "WrongValueTypes",
+        "display_name": "WrongValueType",
+        "display_name_plural": "WrongValueTypes",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false,
+        "is_required": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "PropertyType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "ZooBook.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "DuplicateMembers.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "DuplicateMembers",
+        "type_name_plural": "DuplicateMemberses",
+        "display_name": "DuplicateMembers",
+        "display_name_plural": "DuplicateMemberses",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "LocalName.PropertyType"
+            },
+            {
+              "$ref": "LocalName.PropertyType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyExtendsHolon.PropertyType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "PropertyExtendsHolon",
+        "type_name_plural": "PropertyExtendsHolons",
+        "display_name": "PropertyExtendsHolon",
+        "display_name_plural": "PropertyExtendsHolons",
+        "instance_type_kind": "TypeKind.Property",
+        "is_abstract_type": false,
+        "is_required": true
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "ZooBook.HolonType"
+          }
+        },
+        {
+          "name": "ValueType",
+          "target": {
+            "$ref": "MapStringValueType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "WrongProjectedKind.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "WrongProjectedKind",
+        "type_name_plural": "WrongProjectedKinds",
+        "display_name": "WrongProjectedKind",
+        "display_name_plural": "WrongProjectedKinds",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "CycleA.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "CycleA",
+        "type_name_plural": "CycleAs",
+        "display_name": "CycleA",
+        "display_name_plural": "CycleAs",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "CycleB.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "CycleB.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "CycleB",
+        "type_name_plural": "CycleBs",
+        "display_name": "CycleB",
+        "display_name_plural": "CycleBs",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "CycleA.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(TypeDescriptor.HolonType)-[MissingInverseRelationship]->(Schema.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "MissingInverseRelationship",
+        "type_name_plural": "MissingInverseRelationships",
+        "display_name": "MissingInverseRelationship",
+        "display_name_plural": "MissingInverseRelationships",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 5,
+        "max_cardinality": 1,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "TypeDescriptor.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "Schema.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(TypeDescriptor.HolonType)-[DeclaredWrongFlavorA]->(Schema.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "DeclaredWrongFlavorA",
+        "type_name_plural": "DeclaredWrongFlavorAs",
+        "display_name": "DeclaredWrongFlavorA",
+        "display_name_plural": "DeclaredWrongFlavorAs",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "HasInverse",
+          "target": {
+            "$ref": "(Schema.HolonType)-[SharedInverse]->(TypeDescriptor.HolonType)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "TypeDescriptor.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "Schema.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(TypeDescriptor.HolonType)-[DeclaredWrongFlavorB]->(Schema.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "DeclaredWrongFlavorB",
+        "type_name_plural": "DeclaredWrongFlavorBs",
+        "display_name": "DeclaredWrongFlavorB",
+        "display_name_plural": "DeclaredWrongFlavorBs",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": true,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "DeclaredRelationshipType"
+          }
+        },
+        {
+          "name": "HasInverse",
+          "target": {
+            "$ref": "(Schema.HolonType)-[SharedInverse]->(TypeDescriptor.HolonType)"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "TypeDescriptor.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "Schema.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "(Schema.HolonType)-[SharedInverse]->(TypeDescriptor.HolonType)",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "SharedInverse",
+        "type_name_plural": "SharedInverses",
+        "display_name": "SharedInverse",
+        "display_name_plural": "SharedInverses",
+        "instance_type_kind": "TypeKind.Relationship",
+        "is_abstract_type": false,
+        "is_definitional": false,
+        "is_ordered": false,
+        "allows_duplicates": false,
+        "min_cardinality": 0,
+        "max_cardinality": 32767,
+        "deletion_semantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "InverseRelationshipType"
+          }
+        },
+        {
+          "name": "SourceType",
+          "target": {
+            "$ref": "Schema.HolonType"
+          }
+        },
+        {
+          "name": "TargetType",
+          "target": {
+            "$ref": "TypeDescriptor.HolonType"
+          }
+        }
+      ]
+    },
+    {
+      "key": "UnsupportedRuleThing.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "UnsupportedRuleThing",
+        "type_name_plural": "UnsupportedRuleThings",
+        "display_name": "UnsupportedRuleThing",
+        "display_name_plural": "UnsupportedRuleThings",
+        "instance_type_kind": "TypeKind.Holon",
+        "is_abstract_type": false,
+        "allows_additional_properties": false,
+        "allows_additional_relationships": false
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": {
+            "$ref": "Diagnostic Zoo-v0.0.1"
+          }
+        },
+        {
+          "name": "Extends",
+          "target": {
+            "$ref": "HolonType"
+          }
+        },
+        {
+          "name": "UsesKeyRule",
+          "target": {
+            "$ref": "FormatRule.KeyRuleType"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/host/map-sdk/src/internal/errors.ts
+++ b/host/map-sdk/src/internal/errors.ts
@@ -75,5 +75,39 @@ export class DomainError extends MapError {
  */
 export function parseDomainError(wire: HolonErrorWire): DomainError {
   const [variant, payload] = Object.entries(wire)[0] ?? ['UnknownDomainError', undefined];
-  return new DomainError(variant, payload);
+  return new DomainError(variant, payload, formatDomainErrorMessage(variant, payload));
+}
+
+function formatDomainErrorMessage(variant: string, payload: unknown): string {
+  const detail = formatDomainErrorPayload(payload);
+  return detail ? `${variant}: ${detail}` : `MAP domain error: ${variant}`;
+}
+
+function formatDomainErrorPayload(payload: unknown): string {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (Array.isArray(payload)) {
+    return payload.map((item) => formatDomainErrorPayload(item)).join(': ');
+  }
+
+  if (payload && typeof payload === 'object') {
+    const entries = Object.entries(payload as Record<string, unknown>);
+    if (entries.length === 1) {
+      const [key, value] = entries[0];
+      const nested = formatDomainErrorPayload(value);
+      return nested ? `${key}: ${nested}` : key;
+    }
+
+    return entries
+      .map(([key, value]) => `${key}=${formatDomainErrorPayload(value)}`)
+      .join(', ');
+  }
+
+  if (payload === null || payload === undefined) {
+    return '';
+  }
+
+  return String(payload);
 }

--- a/host/map-sdk/tests/errors.test.ts
+++ b/host/map-sdk/tests/errors.test.ts
@@ -62,6 +62,7 @@ describe('errors', () => {
     expect(error.code).toBe('DOMAIN_ERROR');
     expect(error.variant).toBe('HolonNotFound');
     expect(error.payload).toBe('missing-holon');
+    expect(error.message).toBe('HolonNotFound: missing-holon');
   });
 
   it('parses a structured wire domain error payload', () => {
@@ -94,5 +95,16 @@ describe('errors', () => {
     expect(error.payload).toEqual({
       PropertyError: 'title is required',
     });
+    expect(error.message).toBe('ValidationError: PropertyError: title is required');
+  });
+
+  it('formats tuple-style error payloads into readable messages', () => {
+    const error = parseDomainError({
+      InvalidRelationship: ['ComponentOf', 'target BookAuthorInverseSchemata was not found'],
+    });
+
+    expect(error.message).toBe(
+      'InvalidRelationship: ComponentOf: target BookAuthorInverseSchemata was not found',
+    );
   });
 });

--- a/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
+++ b/host/ui/src/app/components/json-data-uploader/json-data-uploader.component.ts
@@ -8,7 +8,7 @@ import { environment } from '../../../environments/environment.mock';
 import { ContentSet, FileData } from '../../models/shared-types';
 import { ContentStoreInstance } from '../../stores/content.store';
 import { ContentController } from '../../contollers/content.controller';
-import { type HolonReference } from '../../../dahn/deps/map-sdk';
+import { DomainError, type HolonReference } from '../../../dahn/deps/map-sdk';
 import { presentLoaderResult, type LoaderResultView } from './loader-result.presenter';
 
 // Helper function to check if the app is running in a Tauri window
@@ -266,7 +266,13 @@ export class JsonDataUploader implements OnInit {
         this.clearForms();
         this.cdr.markForCheck();
       } catch (error) {
-        this.errorMessage = `Tauri Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        if (error instanceof DomainError) {
+          this.errorMessage = error.message;
+        } else if (error instanceof Error) {
+          this.errorMessage = `Tauri Error: ${error.message}`;
+        } else {
+          this.errorMessage = 'Tauri Error: Unknown error';
+        }
         this.cdr.markForCheck();
       } finally {
         this.isLoading = false;

--- a/host/ui/src/dahn/deps/map-sdk.ts
+++ b/host/ui/src/dahn/deps/map-sdk.ts
@@ -17,6 +17,7 @@ export type {
 } from '../../../../map-sdk/src';
 
 export {
+  DomainError,
   MapClient,
   MapTransaction,
   extractNumber,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fmt:sweetests": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all",
     "fmt:sweetests:check": "cargo fmt --manifest-path tests/sweetests/Cargo.toml --all --check",
 
-    "test": "npm run test:unit && npm run sweetest",
+    "test": "npm run map-schema:check:coreschema && npm run test:unit && npm run sweetest",
     "test:unit": "npm run test:unit:shared && npm run test:unit -w map-host && npm run test:unit:no-run -w map-happ && npm run web:typecheck && npm run web:test && npm run typecheck -w map-sdk && npm run test -w map-sdk",
     "test:unit:shared": "cargo test --manifest-path shared_crates/type_system/base_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/integrity_core_types/Cargo.toml && cargo test --manifest-path shared_crates/type_system/type_names/Cargo.toml && cargo test --manifest-path shared_crates/shared_validation/Cargo.toml && cargo test --manifest-path shared_crates/holons_core/Cargo.toml && cargo test --manifest-path shared_crates/holons_boundary/Cargo.toml && cargo test --manifest-path shared_crates/holons_prelude/Cargo.toml && cargo test --manifest-path shared_crates/holon_dance_builders/Cargo.toml && cargo test --manifest-path shared_crates/holons_trust_channel/Cargo.toml && cargo test --manifest-path shared_crates/json_schema_validation/Cargo.toml",
 

--- a/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
@@ -85,13 +85,13 @@ abstract value BooleanValueType {
 
 abstract value BytesValueType {
   properties {
+    is_abstract_type: true
     type_name: "BytesValueType"
     type_name_plural: "BytesValueTypes"
     display_name: "BytesValueType"
     display_name_plural: "BytesValueTypes"
     description: "Abstract type for byte sequence value types."
     instance_type_kind: "TypeKind.Value.Bytes"
-    is_abstract_type: true
   }
   header {
     description: "Abstract type for byte sequence value types."
@@ -137,13 +137,13 @@ abstract variant EnumVariantValueType {
 
 abstract value ValueArrayValueType {
   properties {
+    is_abstract_type: true
     type_name: "ValueArrayValueType"
     type_name_plural: "ValueArrayValueTypes"
     display_name: "ValueArrayType"
     display_name_plural: "ValueArrayTypes"
     description: "Abstract type for value array types."
     instance_type_kind: "TypeKind.Value.Array"
-    is_abstract_type: true
   }
   header {
     description: "Abstract type for value array types."

--- a/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
@@ -84,6 +84,15 @@ abstract value BooleanValueType {
 
 
 abstract value BytesValueType {
+  properties {
+    type_name: "BytesValueType"
+    type_name_plural: "BytesValueTypes"
+    display_name: "BytesValueType"
+    display_name_plural: "BytesValueTypes"
+    description: "Abstract type for byte sequence value types."
+    instance_type_kind: "TypeKind.Value.Bytes"
+    is_abstract_type: true
+  }
   header {
     description: "Abstract type for byte sequence value types."
     display_name: "BytesValueType"
@@ -127,6 +136,15 @@ abstract variant EnumVariantValueType {
 
 
 abstract value ValueArrayValueType {
+  properties {
+    type_name: "ValueArrayValueType"
+    type_name_plural: "ValueArrayValueTypes"
+    display_name: "ValueArrayType"
+    display_name_plural: "ValueArrayTypes"
+    description: "Abstract type for value array types."
+    instance_type_kind: "TypeKind.Value.Array"
+    is_abstract_type: true
+  }
   header {
     description: "Abstract type for value array types."
     display_name: "ValueArrayType"

--- a/schema-src/MAP Schema Types-map-core-schema-dance-schema.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-dance-schema.tdl
@@ -404,7 +404,7 @@ property DanceName {
 }
 
 
-property DanceDescription {
+property DanceDescription? {
   value MapStringValueType
   header {
     description: "Human-readable explanation of what the dance does or when it should be invoked."
@@ -426,7 +426,7 @@ property Context {
 }
 
 
-property DanceDiagnosticSeverity {
+property DanceDiagnosticSeverity? {
   value DanceDiagnosticSeverity
   header {
     description: "Severity classification for a DanceDiagnostic holon."
@@ -437,7 +437,7 @@ property DanceDiagnosticSeverity {
 }
 
 
-property DiagnosticCode {
+property DiagnosticCode? {
   value MapStringValueType
   header {
     description: "Stable machine-readable code for a DanceDiagnostic holon."
@@ -448,7 +448,7 @@ property DiagnosticCode {
 }
 
 
-property DiagnosticMessage {
+property DiagnosticMessage? {
   value MapStringValueType
   header {
     description: "Human-readable message for a DanceDiagnostic holon."
@@ -459,7 +459,7 @@ property DiagnosticMessage {
 }
 
 
-property ResponseStatusCode {
+property ResponseStatusCode? {
   value ResponseStatusCode
   header {
     description: "Machine-readable status code indicating the result of the dance."
@@ -470,7 +470,7 @@ property ResponseStatusCode {
 }
 
 
-property Engine {
+property Engine? {
   value DanceEngine
   header {
     description: "Execution engine for the implementation (e.g., WasmWasi, Process, RustDylib, Builtin)."
@@ -481,7 +481,7 @@ property Engine {
 }
 
 
-property ModuleRef {
+property ModuleRef? {
   value MapStringValueType
   header {
     description: "Content-address or locator of the executable module (e.g., hash/URL/capability address)."
@@ -492,7 +492,7 @@ property ModuleRef {
 }
 
 
-property Entrypoint {
+property Entrypoint? {
   value MapStringValueType
   header {
     description: "Function/export name to invoke inside the module."
@@ -503,7 +503,7 @@ property Entrypoint {
 }
 
 
-property AbiId {
+property AbiId? {
   value MapStringValueType
   header {
     description: "Identifier of the stable smart contract ABI expected by the module/entrypoint."
@@ -514,7 +514,7 @@ property AbiId {
 }
 
 
-property Version {
+property Version? {
   value MapStringValueType
   header {
     description: "Semantic version or content hash pin of the implementation."
@@ -525,7 +525,7 @@ property Version {
 }
 
 
-property Compat {
+property Compat? {
   value MapStringValueType
   header {
     description: "Compatibility range or constraints (e.g., ABI or schema versions)."
@@ -536,7 +536,7 @@ property Compat {
 }
 
 
-property DanceSummary {
+property DanceSummary? {
   value MapStringValueType
   header {
     description: "Human-readable summary of a dance outcome."

--- a/schema-src/MAP Schema Types-map-core-schema-loader-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-loader-types.tdl
@@ -334,7 +334,7 @@ property RelationshipName {
 }
 
 
-property HolonKey {
+property HolonKey? {
   value MapStringValueType
   header {
     description: "Local key for the referenced holon."
@@ -345,7 +345,7 @@ property HolonKey {
 }
 
 
-property ProxyKey {
+property ProxyKey? {
   value MapStringValueType
   header {
     description: "Key of the ProxySpace through which this external reference is routed."
@@ -356,7 +356,7 @@ property ProxyKey {
 }
 
 
-property ProxyId {
+property ProxyId? {
   value MapBytesValueType
   header {
     description: "ActionHash of the ProxySpace holon, used to route external references."
@@ -411,7 +411,7 @@ property Filename {
 }
 
 
-property LoaderHolonKey {
+property LoaderHolonKey? {
   value MapStringValueType
   header {
     description: "Key to reference a loader holon within a load set."
@@ -422,7 +422,7 @@ property LoaderHolonKey {
 }
 
 
-property StartUtf8ByteOffset {
+property StartUtf8ByteOffset? {
   value MapIntegerValueType
   header {
     description: "Byte offset that signifies the start of a segment of a source file."

--- a/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
@@ -164,7 +164,7 @@ property MapString? {
 }
 
 
-property MaxCardinality {
+property MaxCardinality? {
   value MapIntegerValueType
   header {
     description: "Maximum number of target holons allowed for the relationship."

--- a/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
@@ -65,7 +65,7 @@ property DisplayName {
 }
 
 
-property DisplayNamePlural {
+property DisplayNamePlural? {
   value MapStringValueType
   header {
     description: "The plural form of the label for use in lists or summaries."
@@ -120,7 +120,7 @@ property IsRequired {
 }
 
 
-property MapBoolean {
+property MapBoolean? {
   value MapBooleanValueType
   header {
     description: "Boolean scalar value (true/false)."
@@ -131,7 +131,7 @@ property MapBoolean {
 }
 
 
-property MapBytes {
+property MapBytes? {
   value MapBytesValueType
   header {
     description: "Binary data (blob of bytes)."
@@ -142,7 +142,7 @@ property MapBytes {
 }
 
 
-property MapInteger {
+property MapInteger? {
   value MapIntegerValueType
   header {
     description: "Integer scalar value."
@@ -153,7 +153,7 @@ property MapInteger {
 }
 
 
-property MapString {
+property MapString? {
   value MapStringValueType
   header {
     description: "Textual scalar value."
@@ -219,7 +219,7 @@ property SchemaName {
 }
 
 
-property TypeNamePlural {
+property TypeNamePlural? {
   value MapStringValueType
   header {
     description: "The plural form of the type's identifier used for display or grouping."
@@ -285,7 +285,7 @@ property CollectionType {
 }
 
 
-property Key {
+property Key? {
   value MapStringValueType
   header {
     description: "Identifying key of a holon instance."
@@ -296,7 +296,7 @@ property Key {
 }
 
 
-property HolonId {
+property HolonId? {
   value HolonIdValueType
   header {
     description: "ActionHash identifier of a referenced holon."

--- a/schema-src/MAP Schema Types-map-core-schema-query-schema.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-query-schema.tdl
@@ -228,7 +228,7 @@ property QueryName {
 }
 
 
-property QueryDescription {
+property QueryDescription? {
   value MapStringValueType
   header {
     description: "Human-readable description of what a QueryGraph means."
@@ -239,7 +239,7 @@ property QueryDescription {
 }
 
 
-property BindingName {
+property BindingName? {
   value MapStringValueType
   header {
     description: "Symbolic variable name carried by a QueryBinding."
@@ -261,7 +261,7 @@ property StepOrdinal {
 }
 
 
-property StepLabel {
+property StepLabel? {
   value MapStringValueType
   header {
     description: "Optional human-readable label for a QueryStep."
@@ -272,7 +272,7 @@ property StepLabel {
 }
 
 
-property ExecutionStatus {
+property ExecutionStatus? {
   value ExecutionStatus
   header {
     description: "Status of an ExecutionInstance, recorded as an ExecutionStatus enum value."

--- a/shared_crates/descriptor_semantics/Cargo.toml
+++ b/shared_crates/descriptor_semantics/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "descriptor_semantics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/shared_crates/descriptor_semantics/src/conformance.rs
+++ b/shared_crates/descriptor_semantics/src/conformance.rs
@@ -1,18 +1,13 @@
 use std::collections::HashSet;
 
-/// Requiredness derived from a descriptor property name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PropertyRequirement<'a> {
-    pub name: &'a str,
-    pub required: bool,
-}
-
-/// Interprets the MAP optional-property `?` suffix without owning source syntax.
-pub fn property_requirement(name: &str) -> PropertyRequirement<'_> {
-    match name.strip_suffix('?') {
-        Some(name) => PropertyRequirement { name, required: false },
-        None => PropertyRequirement { name, required: true },
-    }
+/// Composes an inherited openness policy restrictively.
+///
+/// A `false` value anywhere in the type lineage closes the corresponding surface. `None` means
+/// no descriptor in the supplied lineage declared the required policy value.
+pub fn compose_restrictive_boolean(values: impl IntoIterator<Item = bool>) -> Option<bool> {
+    let mut values = values.into_iter();
+    let first = values.next()?;
+    Some(values.fold(first, |effective, value| effective && value))
 }
 
 /// Source-neutral literal shape consumed by descriptor conformance.
@@ -246,15 +241,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn optional_suffix_is_descriptor_data() {
-        assert_eq!(
-            property_requirement("description?"),
-            PropertyRequirement { name: "description", required: false }
-        );
-        assert_eq!(
-            property_requirement("type_name"),
-            PropertyRequirement { name: "type_name", required: true }
-        );
+    fn openness_composes_restrictively() {
+        assert_eq!(compose_restrictive_boolean([true, true]), Some(true));
+        assert_eq!(compose_restrictive_boolean([true, false, true]), Some(false));
+        assert_eq!(compose_restrictive_boolean([]), None);
     }
 
     #[test]

--- a/shared_crates/descriptor_semantics/src/conformance.rs
+++ b/shared_crates/descriptor_semantics/src/conformance.rs
@@ -1,0 +1,60 @@
+/// Requiredness derived from a descriptor property name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PropertyRequirement<'a> {
+    pub name: &'a str,
+    pub required: bool,
+}
+
+/// Interprets the MAP optional-property `?` suffix without owning source syntax.
+pub fn property_requirement(name: &str) -> PropertyRequirement<'_> {
+    match name.strip_suffix('?') {
+        Some(name) => PropertyRequirement { name, required: false },
+        None => PropertyRequirement { name, required: true },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CardinalityViolation {
+    pub actual: usize,
+    pub minimum: usize,
+    pub maximum: usize,
+}
+
+pub fn validate_cardinality(
+    actual: usize,
+    minimum: usize,
+    maximum: usize,
+) -> Result<(), CardinalityViolation> {
+    if actual >= minimum && actual <= maximum {
+        Ok(())
+    } else {
+        Err(CardinalityViolation { actual, minimum, maximum })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn optional_suffix_is_descriptor_data() {
+        assert_eq!(
+            property_requirement("description?"),
+            PropertyRequirement { name: "description", required: false }
+        );
+        assert_eq!(
+            property_requirement("type_name"),
+            PropertyRequirement { name: "type_name", required: true }
+        );
+    }
+
+    #[test]
+    fn cardinality_is_inclusive() {
+        assert!(validate_cardinality(1, 1, 2).is_ok());
+        assert!(validate_cardinality(2, 1, 2).is_ok());
+        assert_eq!(
+            validate_cardinality(3, 1, 2),
+            Err(CardinalityViolation { actual: 3, minimum: 1, maximum: 2 })
+        );
+    }
+}

--- a/shared_crates/descriptor_semantics/src/conformance.rs
+++ b/shared_crates/descriptor_semantics/src/conformance.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 /// Requiredness derived from a descriptor property name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PropertyRequirement<'a> {
@@ -11,6 +13,211 @@ pub fn property_requirement(name: &str) -> PropertyRequirement<'_> {
         Some(name) => PropertyRequirement { name, required: false },
         None => PropertyRequirement { name, required: true },
     }
+}
+
+/// Source-neutral literal shape consumed by descriptor conformance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConformanceValue {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Number(String),
+    String(String),
+    Array,
+    Object,
+}
+
+/// Value policy resolved from a property's `ValueType` descriptor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValuePolicy {
+    Any,
+    Boolean,
+    Integer,
+    String,
+    Enum { variants: Vec<String> },
+}
+
+/// Resolves primitive/enum policy from the descriptor-authored TypeKind identity.
+///
+/// Unknown and structural value kinds remain unconstrained here; adapters may still validate them
+/// through relationships or constraint descriptors without inventing a primitive classification.
+pub fn value_policy_for_type_kind(
+    type_kind: Option<&str>,
+    enum_variants: Vec<String>,
+) -> ValuePolicy {
+    match type_kind {
+        Some("TypeKind.Value.Boolean") => ValuePolicy::Boolean,
+        Some("TypeKind.Value.Integer") => ValuePolicy::Integer,
+        Some("TypeKind.Value.String") => ValuePolicy::String,
+        Some("TypeKind.Value.Enum") => ValuePolicy::Enum { variants: enum_variants },
+        _ => ValuePolicy::Any,
+    }
+}
+
+/// Effective property declaration supplied by a descriptor graph adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyDeclaration {
+    pub name: String,
+    pub required: bool,
+    pub value_policy: ValuePolicy,
+}
+
+/// Effective relationship declaration supplied by a descriptor graph adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelationshipDeclaration {
+    pub name: String,
+    pub minimum: usize,
+    pub maximum: usize,
+}
+
+/// One authored property on the holon being validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyValue {
+    pub name: String,
+    pub value: ConformanceValue,
+}
+
+/// One authored relationship collection on the holon being validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelationshipValue {
+    pub name: String,
+    pub target_count: usize,
+}
+
+/// Fully resolved, representation-neutral input to the conformance evaluator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HolonConformance {
+    pub properties: Vec<PropertyValue>,
+    pub relationships: Vec<RelationshipValue>,
+    pub property_declarations: Vec<PropertyDeclaration>,
+    pub relationship_declarations: Vec<RelationshipDeclaration>,
+    pub allows_additional_properties: bool,
+    pub allows_additional_relationships: bool,
+}
+
+/// Descriptor-conformance failure independent of runtime or authoring representations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConformanceViolation {
+    MissingRequiredProperty { property: String },
+    AdditionalProperty { property: String },
+    WrongValueKind { property: String, expected: &'static str },
+    UndeclaredEnumVariant { property: String, variant: String },
+    AdditionalRelationship { relationship: String },
+    RelationshipCardinality { relationship: String, actual: usize, minimum: usize, maximum: usize },
+}
+
+/// Evaluates one holon against already-resolved effective descriptor declarations.
+///
+/// Graph traversal and descriptor projection happen before this function. Keeping the evaluator
+/// over plain data makes the same policy usable by Canonical IR and bound runtime adapters.
+pub fn validate_holon_conformance(input: &HolonConformance) -> Vec<ConformanceViolation> {
+    let mut violations = Vec::new();
+    let property_names =
+        input.properties.iter().map(|property| property.name.as_str()).collect::<HashSet<_>>();
+
+    for declaration in &input.property_declarations {
+        if declaration.required && !property_names.contains(declaration.name.as_str()) {
+            violations.push(ConformanceViolation::MissingRequiredProperty {
+                property: declaration.name.clone(),
+            });
+        }
+    }
+
+    for property in &input.properties {
+        let Some(declaration) = input
+            .property_declarations
+            .iter()
+            .find(|declaration| declaration.name == property.name)
+        else {
+            if !input.allows_additional_properties {
+                violations.push(ConformanceViolation::AdditionalProperty {
+                    property: property.name.clone(),
+                });
+            }
+            continue;
+        };
+        validate_value(property, &declaration.value_policy, &mut violations);
+    }
+
+    let mut relationship_totals: Vec<(&str, usize)> = Vec::new();
+    for relationship in &input.relationships {
+        if let Some((_, total)) =
+            relationship_totals.iter_mut().find(|(name, _)| *name == relationship.name)
+        {
+            *total = total.saturating_add(relationship.target_count);
+        } else {
+            relationship_totals.push((&relationship.name, relationship.target_count));
+        }
+    }
+
+    for (relationship_name, target_count) in relationship_totals {
+        let Some(declaration) = input
+            .relationship_declarations
+            .iter()
+            .find(|declaration| declaration.name == relationship_name)
+        else {
+            if !input.allows_additional_relationships {
+                violations.push(ConformanceViolation::AdditionalRelationship {
+                    relationship: relationship_name.to_string(),
+                });
+            }
+            continue;
+        };
+        if let Err(error) =
+            validate_cardinality(target_count, declaration.minimum, declaration.maximum)
+        {
+            violations.push(ConformanceViolation::RelationshipCardinality {
+                relationship: relationship_name.to_string(),
+                actual: error.actual,
+                minimum: error.minimum,
+                maximum: error.maximum,
+            });
+        }
+    }
+
+    for declaration in &input.relationship_declarations {
+        if input.relationships.iter().any(|relationship| relationship.name == declaration.name) {
+            continue;
+        }
+        if declaration.minimum > 0 {
+            violations.push(ConformanceViolation::RelationshipCardinality {
+                relationship: declaration.name.clone(),
+                actual: 0,
+                minimum: declaration.minimum,
+                maximum: declaration.maximum,
+            });
+        }
+    }
+
+    violations
+}
+
+fn validate_value(
+    property: &PropertyValue,
+    policy: &ValuePolicy,
+    violations: &mut Vec<ConformanceViolation>,
+) {
+    let expected = match (policy, &property.value) {
+        (ValuePolicy::Any, _) => return,
+        (ValuePolicy::Boolean, ConformanceValue::Boolean(_)) => return,
+        (ValuePolicy::Integer, ConformanceValue::Integer(_)) => return,
+        (ValuePolicy::String, ConformanceValue::String(_)) => return,
+        (ValuePolicy::Enum { variants }, ConformanceValue::String(variant)) => {
+            if validate_enum_variant(variant, variants.iter().map(String::as_str)).is_err() {
+                violations.push(ConformanceViolation::UndeclaredEnumVariant {
+                    property: property.name.clone(),
+                    variant: variant.clone(),
+                });
+            }
+            return;
+        }
+        (ValuePolicy::Boolean, _) => "boolean",
+        (ValuePolicy::Integer, _) => "integer",
+        (ValuePolicy::String, _) => "string",
+        (ValuePolicy::Enum { .. }, _) => "enum variant string",
+    };
+    violations
+        .push(ConformanceViolation::WrongValueKind { property: property.name.clone(), expected });
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +238,8 @@ pub fn validate_cardinality(
         Err(CardinalityViolation { actual, minimum, maximum })
     }
 }
+
+use crate::validate_enum_variant;
 
 #[cfg(test)]
 mod tests {
@@ -55,6 +264,100 @@ mod tests {
         assert_eq!(
             validate_cardinality(3, 1, 2),
             Err(CardinalityViolation { actual: 3, minimum: 1, maximum: 2 })
+        );
+    }
+
+    #[test]
+    fn evaluates_descriptor_resolved_shape_without_property_specific_rules() {
+        let input = HolonConformance {
+            properties: vec![
+                PropertyValue {
+                    name: "status".to_string(),
+                    value: ConformanceValue::String("Status.Unknown".to_string()),
+                },
+                PropertyValue { name: "extra".to_string(), value: ConformanceValue::Boolean(true) },
+            ],
+            relationships: vec![RelationshipValue { name: "Owner".to_string(), target_count: 2 }],
+            property_declarations: vec![
+                PropertyDeclaration {
+                    name: "name".to_string(),
+                    required: true,
+                    value_policy: ValuePolicy::String,
+                },
+                PropertyDeclaration {
+                    name: "status".to_string(),
+                    required: false,
+                    value_policy: ValuePolicy::Enum {
+                        variants: vec!["Status.Open".to_string(), "Status.Closed".to_string()],
+                    },
+                },
+            ],
+            relationship_declarations: vec![RelationshipDeclaration {
+                name: "Owner".to_string(),
+                minimum: 1,
+                maximum: 1,
+            }],
+            allows_additional_properties: false,
+            allows_additional_relationships: false,
+        };
+
+        assert_eq!(
+            validate_holon_conformance(&input),
+            vec![
+                ConformanceViolation::MissingRequiredProperty { property: "name".to_string() },
+                ConformanceViolation::UndeclaredEnumVariant {
+                    property: "status".to_string(),
+                    variant: "Status.Unknown".to_string(),
+                },
+                ConformanceViolation::AdditionalProperty { property: "extra".to_string() },
+                ConformanceViolation::RelationshipCardinality {
+                    relationship: "Owner".to_string(),
+                    actual: 2,
+                    minimum: 1,
+                    maximum: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn value_policy_is_derived_from_descriptor_type_kind() {
+        assert_eq!(
+            value_policy_for_type_kind(
+                Some("TypeKind.Value.Enum"),
+                vec!["Status.Open".to_string()]
+            ),
+            ValuePolicy::Enum { variants: vec!["Status.Open".to_string()] }
+        );
+        assert_eq!(value_policy_for_type_kind(Some("Custom.ValueKind"), vec![]), ValuePolicy::Any);
+    }
+
+    #[test]
+    fn repeated_relationship_entries_share_one_cardinality_collection() {
+        let input = HolonConformance {
+            properties: vec![],
+            relationships: vec![
+                RelationshipValue { name: "Owner".to_string(), target_count: 1 },
+                RelationshipValue { name: "Owner".to_string(), target_count: 1 },
+            ],
+            property_declarations: vec![],
+            relationship_declarations: vec![RelationshipDeclaration {
+                name: "Owner".to_string(),
+                minimum: 0,
+                maximum: 1,
+            }],
+            allows_additional_properties: false,
+            allows_additional_relationships: false,
+        };
+
+        assert_eq!(
+            validate_holon_conformance(&input),
+            vec![ConformanceViolation::RelationshipCardinality {
+                relationship: "Owner".to_string(),
+                actual: 2,
+                minimum: 0,
+                maximum: 1,
+            }]
         );
     }
 }

--- a/shared_crates/descriptor_semantics/src/graph.rs
+++ b/shared_crates/descriptor_semantics/src/graph.rs
@@ -31,8 +31,11 @@ pub trait DescriptorGraph {
 pub enum DescriptorSemanticsError<E, N> {
     Access(E),
     MultipleExtends { descriptor: N, count: usize },
+    MissingDescribedBy { holon: N },
     MultipleDescribedBy { holon: N, count: usize },
     CyclicExtends { descriptor: N },
+    MultipleRelatedMembers { descriptor: N, kind: &'static str, count: usize },
+    DuplicateInheritedDeclaration { descriptor: N, kind: &'static str, name: String },
 }
 
 impl<E: fmt::Display, N: fmt::Debug> fmt::Display for DescriptorSemanticsError<E, N> {
@@ -43,13 +46,24 @@ impl<E: fmt::Display, N: fmt::Debug> fmt::Display for DescriptorSemanticsError<E
                 formatter,
                 "descriptor {descriptor:?} has {count} Extends targets; expected at most one"
             ),
+            Self::MissingDescribedBy { holon } => {
+                write!(formatter, "holon {holon:?} has no DescribedBy target; expected exactly one")
+            }
             Self::MultipleDescribedBy { holon, count } => write!(
                 formatter,
-                "holon {holon:?} has {count} DescribedBy targets; expected at most one"
+                "holon {holon:?} has {count} DescribedBy targets; expected exactly one"
             ),
             Self::CyclicExtends { descriptor } => {
                 write!(formatter, "cyclic Extends chain at {descriptor:?}")
             }
+            Self::MultipleRelatedMembers { descriptor, kind, count } => write!(
+                formatter,
+                "descriptor {descriptor:?} has {count} {kind} targets; expected at most one"
+            ),
+            Self::DuplicateInheritedDeclaration { descriptor, kind, name } => write!(
+                formatter,
+                "descriptor {descriptor:?} inherits more than one {kind} declaration named `{name}`"
+            ),
         }
     }
 }

--- a/shared_crates/descriptor_semantics/src/graph.rs
+++ b/shared_crates/descriptor_semantics/src/graph.rs
@@ -1,0 +1,55 @@
+use std::{fmt, hash::Hash};
+
+/// Read-only graph access required by representation-neutral descriptor algorithms.
+///
+/// Target collections remain uncollapsed so the semantic kernel, rather than an adapter, owns
+/// cardinality errors. `Identity` must represent node identity, not a display name.
+pub trait DescriptorGraph {
+    type Node: Clone;
+    type Identity: Clone + Eq + Hash;
+    type MemberKind;
+    type Error;
+
+    fn identity(&self, node: &Self::Node) -> Self::Identity;
+
+    fn extends_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error>;
+
+    fn described_by_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error>;
+
+    fn related_members(
+        &self,
+        node: &Self::Node,
+        member_kind: &Self::MemberKind,
+    ) -> Result<Vec<Self::Node>, Self::Error>;
+
+    /// Returns whether `node` is the descriptor that describes type-descriptor holons.
+    fn is_type_descriptor(&self, node: &Self::Node) -> Result<bool, Self::Error>;
+}
+
+/// Structural descriptor-graph failure independent of a concrete representation's error type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DescriptorSemanticsError<E, N> {
+    Access(E),
+    MultipleExtends { descriptor: N, count: usize },
+    MultipleDescribedBy { holon: N, count: usize },
+    CyclicExtends { descriptor: N },
+}
+
+impl<E: fmt::Display, N: fmt::Debug> fmt::Display for DescriptorSemanticsError<E, N> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Access(error) => write!(formatter, "{error}"),
+            Self::MultipleExtends { descriptor, count } => write!(
+                formatter,
+                "descriptor {descriptor:?} has {count} Extends targets; expected at most one"
+            ),
+            Self::MultipleDescribedBy { holon, count } => write!(
+                formatter,
+                "holon {holon:?} has {count} DescribedBy targets; expected at most one"
+            ),
+            Self::CyclicExtends { descriptor } => {
+                write!(formatter, "cyclic Extends chain at {descriptor:?}")
+            }
+        }
+    }
+}

--- a/shared_crates/descriptor_semantics/src/inheritance.rs
+++ b/shared_crates/descriptor_semantics/src/inheritance.rs
@@ -109,7 +109,104 @@ pub fn equals_or_extends<G: DescriptorGraph>(
     Ok(false)
 }
 
+/// Returns the exactly one concrete type that describes `holon`.
+pub fn describing_type<G: DescriptorGraph>(
+    graph: &G,
+    holon: &G::Node,
+) -> Result<G::Node, DescriptorSemanticsError<G::Error, G::Node>> {
+    let targets = graph.described_by_targets(holon).map_err(DescriptorSemanticsError::Access)?;
+    match targets.as_slice() {
+        [] => Err(DescriptorSemanticsError::MissingDescribedBy { holon: holon.clone() }),
+        [descriptor] => Ok(descriptor.clone()),
+        many => Err(DescriptorSemanticsError::MultipleDescribedBy {
+            holon: holon.clone(),
+            count: many.len(),
+        }),
+    }
+}
+
+/// Resolves the effective key rule governing instances described by `type_descriptor`.
+///
+/// `UsesKeyRule` is inherited self-first through the descriptor's `Extends` lineage. A lineage
+/// node may declare at most one rule.
+pub fn effective_instance_key_rule<G: DescriptorGraph>(
+    graph: &G,
+    type_descriptor: &G::Node,
+    uses_key_rule: &G::MemberKind,
+) -> Result<Option<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    first_single_member_from_lineage(
+        graph,
+        ancestors(graph, type_descriptor)?,
+        uses_key_rule,
+        "UsesKeyRule",
+    )
+}
+
+/// Resolves the key rule governing `holon` itself.
+///
+/// A descriptor holon's own direct `UsesKeyRule` governs its instances, so own-key resolution
+/// starts at its direct `Extends` parent. If that lineage supplies no rule, resolution falls back
+/// to the actual `DescribedBy` type and its effective instance rule.
+pub fn effective_holon_key_rule<G: DescriptorGraph>(
+    graph: &G,
+    holon: &G::Node,
+    uses_key_rule: &G::MemberKind,
+) -> Result<Option<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    let parents = graph.extends_targets(holon).map_err(DescriptorSemanticsError::Access)?;
+    match parents.as_slice() {
+        [parent] => {
+            if let Some(rule) = first_single_member_from_lineage(
+                graph,
+                ancestors(graph, parent)?,
+                uses_key_rule,
+                "UsesKeyRule",
+            )? {
+                return Ok(Some(rule));
+            }
+        }
+        [] => {}
+        many => {
+            return Err(DescriptorSemanticsError::MultipleExtends {
+                descriptor: holon.clone(),
+                count: many.len(),
+            })
+        }
+    }
+
+    effective_instance_key_rule(graph, &describing_type(graph, holon)?, uses_key_rule)
+}
+
+fn first_single_member_from_lineage<G: DescriptorGraph>(
+    graph: &G,
+    lineage: impl IntoIterator<Item = G::Node>,
+    member_kind: &G::MemberKind,
+    kind_label: &'static str,
+) -> Result<Option<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    for descriptor in lineage {
+        let members = graph
+            .related_members(&descriptor, member_kind)
+            .map_err(DescriptorSemanticsError::Access)?;
+        match members.as_slice() {
+            [] => {}
+            [member] => return Ok(Some(member.clone())),
+            many => {
+                return Err(DescriptorSemanticsError::MultipleRelatedMembers {
+                    descriptor,
+                    kind: kind_label,
+                    count: many.len(),
+                })
+            }
+        }
+    }
+    Ok(None)
+}
+
 /// Computes the effective descriptor lineage defined by MAP Type System v1.2.
+///
+/// A partially assembled descriptor may not yet have its required `DescribedBy` relationship. In
+/// that authoring state, its own `Extends` lineage is still available for effective-member lookup.
+/// Semantic conformance must call [`describing_type`] first to enforce the exact-one relationship
+/// invariant; this function does not weaken that validity rule.
 pub fn effective_descriptor_lineage<G: DescriptorGraph>(
     graph: &G,
     holon: &G::Node,
@@ -118,7 +215,7 @@ pub fn effective_descriptor_lineage<G: DescriptorGraph>(
         graph.described_by_targets(holon).map_err(DescriptorSemanticsError::Access)?;
     let described_by = match described_by_targets.as_slice() {
         [] => return ancestors(graph, holon),
-        [descriptor] => descriptor,
+        [descriptor] => descriptor.clone(),
         many => {
             return Err(DescriptorSemanticsError::MultipleDescribedBy {
                 holon: holon.clone(),
@@ -127,13 +224,13 @@ pub fn effective_descriptor_lineage<G: DescriptorGraph>(
         }
     };
 
-    if graph.is_type_descriptor(described_by).map_err(DescriptorSemanticsError::Access)? {
+    if graph.is_type_descriptor(&described_by).map_err(DescriptorSemanticsError::Access)? {
         let mut lineage = ancestors(graph, holon)?;
-        append_unique(graph, &mut lineage, ancestors(graph, described_by)?);
+        append_unique(graph, &mut lineage, ancestors(graph, &described_by)?);
         return Ok(lineage);
     }
 
-    ancestors(graph, described_by)
+    ancestors(graph, &described_by)
 }
 
 /// Collects related members in self-first lineage order, deduplicated by node identity.
@@ -158,6 +255,75 @@ pub fn flatten_related_members<G: DescriptorGraph>(
     }
 
     Ok(members)
+}
+
+/// Flattens inherited members and rejects distinct declarations with the same semantic name.
+///
+/// Repeated references are first deduplicated by node identity. A repeated name therefore only
+/// fails when it belongs to two distinct declaration nodes in the effective type lineage.
+pub fn flatten_named_members<G, F>(
+    graph: &G,
+    start: &G::Node,
+    member_kind: &G::MemberKind,
+    declaration_kind: &'static str,
+    semantic_name: F,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>>
+where
+    G: DescriptorGraph,
+    F: FnMut(&G::Node) -> Result<String, G::Error>,
+{
+    let lineage = ancestors(graph, start)?;
+    collect_named_members_from_lineage(graph, lineage, member_kind, declaration_kind, semantic_name)
+}
+
+/// Collects named declarations from a caller-selected self-first lineage.
+pub fn collect_named_members_from_lineage<G, F>(
+    graph: &G,
+    lineage: impl IntoIterator<Item = G::Node>,
+    member_kind: &G::MemberKind,
+    declaration_kind: &'static str,
+    mut semantic_name: F,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>>
+where
+    G: DescriptorGraph,
+    F: FnMut(&G::Node) -> Result<String, G::Error>,
+{
+    let mut members = Vec::new();
+    let mut seen_members = HashSet::new();
+    let mut names = Vec::new();
+    let mut subject = None;
+    for anchor in lineage {
+        if subject.is_none() {
+            subject = Some(anchor.clone());
+        }
+        for member in
+            graph.related_members(&anchor, member_kind).map_err(DescriptorSemanticsError::Access)?
+        {
+            if !seen_members.insert(graph.identity(&member)) {
+                continue;
+            }
+            let name = semantic_name(&member).map_err(DescriptorSemanticsError::Access)?;
+            names.push(name);
+            members.push(member);
+        }
+    }
+    if let Some(name) = duplicate_declaration_name(names) {
+        return Err(DescriptorSemanticsError::DuplicateInheritedDeclaration {
+            descriptor: subject.expect("a collected member always has a lineage anchor"),
+            kind: declaration_kind,
+            name,
+        });
+    }
+    Ok(members)
+}
+
+/// Returns the first repeated semantic declaration name, if any.
+///
+/// Callers must deduplicate repeated references by declaration identity before supplying names;
+/// only distinct declarations sharing a name are invalid.
+pub fn duplicate_declaration_name(names: impl IntoIterator<Item = String>) -> Option<String> {
+    let mut seen = HashSet::new();
+    names.into_iter().find(|name| !seen.insert(name.clone()))
 }
 
 fn append_unique<G: DescriptorGraph>(
@@ -317,5 +483,91 @@ mod tests {
             effective_descriptor_lineage(&graph, &"instance"),
             Err(DescriptorSemanticsError::MultipleDescribedBy { holon: "instance", count: 2 })
         );
+    }
+
+    #[test]
+    fn missing_described_by_is_rejected_by_the_validity_gate() {
+        let graph = TestGraph::default();
+        assert_eq!(
+            describing_type(&graph, &"instance"),
+            Err(DescriptorSemanticsError::MissingDescribedBy { holon: "instance" })
+        );
+    }
+
+    #[test]
+    fn partial_descriptor_lineage_is_available_before_described_by_is_attached() {
+        let graph =
+            TestGraph { extends: HashMap::from([("Child", vec!["Parent"])]), ..Default::default() };
+
+        assert_eq!(effective_descriptor_lineage(&graph, &"Child"), Ok(vec!["Child", "Parent"]));
+    }
+
+    #[test]
+    fn named_member_flattening_rejects_distinct_duplicate_declarations() {
+        let graph = TestGraph {
+            extends: HashMap::from([("Child", vec!["Parent"])]),
+            members: HashMap::from([
+                (("Child", "properties"), vec!["ChildName"]),
+                (("Parent", "properties"), vec!["ParentName"]),
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            flatten_named_members(&graph, &"Child", &"properties", "property", |_| {
+                Ok("name".to_string())
+            }),
+            Err(DescriptorSemanticsError::DuplicateInheritedDeclaration {
+                descriptor: "Child",
+                kind: "property",
+                name: "name".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn duplicate_name_policy_reports_the_first_repeated_name() {
+        assert_eq!(
+            duplicate_declaration_name([
+                "title".to_string(),
+                "author".to_string(),
+                "title".to_string(),
+            ]),
+            Some("title".to_string())
+        );
+    }
+
+    #[test]
+    fn instance_key_rule_is_self_first_but_descriptor_own_key_excludes_self() {
+        let graph = TestGraph {
+            extends: HashMap::from([("BookType", vec!["HolonType"])]),
+            described_by: HashMap::from([("BookType", vec!["TypeDescriptor"])]),
+            members: HashMap::from([
+                (("BookType", "key-rule"), vec!["BookRule"]),
+                (("HolonType", "key-rule"), vec!["ExtendedTypeRule"]),
+                (("TypeDescriptor", "key-rule"), vec!["TypeNameRule"]),
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_instance_key_rule(&graph, &"BookType", &"key-rule"),
+            Ok(Some("BookRule"))
+        );
+        assert_eq!(
+            effective_holon_key_rule(&graph, &"BookType", &"key-rule"),
+            Ok(Some("ExtendedTypeRule"))
+        );
+    }
+
+    #[test]
+    fn holon_key_rule_falls_back_through_described_by() {
+        let graph = TestGraph {
+            described_by: HashMap::from([("book-1", vec!["BookType"])]),
+            members: HashMap::from([(("BookType", "key-rule"), vec!["BookRule"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(effective_holon_key_rule(&graph, &"book-1", &"key-rule"), Ok(Some("BookRule")));
     }
 }

--- a/shared_crates/descriptor_semantics/src/inheritance.rs
+++ b/shared_crates/descriptor_semantics/src/inheritance.rs
@@ -152,28 +152,18 @@ pub fn effective_holon_key_rule<G: DescriptorGraph>(
     holon: &G::Node,
     uses_key_rule: &G::MemberKind,
 ) -> Result<Option<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
-    let parents = graph.extends_targets(holon).map_err(DescriptorSemanticsError::Access)?;
-    match parents.as_slice() {
-        [parent] => {
-            if let Some(rule) = first_single_member_from_lineage(
-                graph,
-                ancestors(graph, parent)?,
-                uses_key_rule,
-                "UsesKeyRule",
-            )? {
-                return Ok(Some(rule));
-            }
-        }
-        [] => {}
-        many => {
-            return Err(DescriptorSemanticsError::MultipleExtends {
-                descriptor: holon.clone(),
-                count: many.len(),
-            })
-        }
+    let described_by = describing_type(graph, holon)?;
+    let own_lineage = lineage_with_describing_type(graph, holon, &described_by)?;
+    if let Some(rule) = first_single_member_from_lineage(
+        graph,
+        own_lineage.into_iter().skip(1),
+        uses_key_rule,
+        "UsesKeyRule",
+    )? {
+        return Ok(Some(rule));
     }
 
-    effective_instance_key_rule(graph, &describing_type(graph, holon)?, uses_key_rule)
+    effective_instance_key_rule(graph, &described_by, uses_key_rule)
 }
 
 fn first_single_member_from_lineage<G: DescriptorGraph>(
@@ -201,36 +191,42 @@ fn first_single_member_from_lineage<G: DescriptorGraph>(
     Ok(None)
 }
 
-/// Computes the effective descriptor lineage defined by MAP Type System v1.2.
+/// Computes `L(H)`, the holon's own type lineage.
 ///
-/// A partially assembled descriptor may not yet have its required `DescribedBy` relationship. In
-/// that authoring state, its own `Extends` lineage is still available for effective-member lookup.
-/// Semantic conformance must call [`describing_type`] first to enforce the exact-one relationship
-/// invariant; this function does not weaken that validity rule.
+/// A holon is a type exactly when its unique `DescribedBy` target is `TypeDescriptor`. Type
+/// lineages are self-first; ordinary holons have an empty own lineage.
+pub fn lineage<G: DescriptorGraph>(
+    graph: &G,
+    holon: &G::Node,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    let described_by = describing_type(graph, holon)?;
+    lineage_with_describing_type(graph, holon, &described_by)
+}
+
+fn lineage_with_describing_type<G: DescriptorGraph>(
+    graph: &G,
+    holon: &G::Node,
+    described_by: &G::Node,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    if graph.is_type_descriptor(described_by).map_err(DescriptorSemanticsError::Access)? {
+        ancestors(graph, holon)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+/// Computes `E(H) = L(H) union-by-identity L(D(H))`.
+///
+/// The own lineage is retained first. Nodes from the describing type's lineage are appended only
+/// when their graph identity has not already appeared.
 pub fn effective_descriptor_lineage<G: DescriptorGraph>(
     graph: &G,
     holon: &G::Node,
 ) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
-    let described_by_targets =
-        graph.described_by_targets(holon).map_err(DescriptorSemanticsError::Access)?;
-    let described_by = match described_by_targets.as_slice() {
-        [] => return ancestors(graph, holon),
-        [descriptor] => descriptor.clone(),
-        many => {
-            return Err(DescriptorSemanticsError::MultipleDescribedBy {
-                holon: holon.clone(),
-                count: many.len(),
-            })
-        }
-    };
-
-    if graph.is_type_descriptor(&described_by).map_err(DescriptorSemanticsError::Access)? {
-        let mut lineage = ancestors(graph, holon)?;
-        append_unique(graph, &mut lineage, ancestors(graph, &described_by)?);
-        return Ok(lineage);
-    }
-
-    ancestors(graph, &described_by)
+    let described_by = describing_type(graph, holon)?;
+    let mut effective = lineage_with_describing_type(graph, holon, &described_by)?;
+    append_unique(graph, &mut effective, ancestors(graph, &described_by)?);
+    Ok(effective)
 }
 
 /// Collects related members in self-first lineage order, deduplicated by node identity.
@@ -332,9 +328,9 @@ fn append_unique<G: DescriptorGraph>(
     additional: Vec<G::Node>,
 ) {
     let mut seen = lineage.iter().map(|node| graph.identity(node)).collect::<HashSet<_>>();
-    for descriptor in additional {
-        if seen.insert(graph.identity(&descriptor)) {
-            lineage.push(descriptor);
+    for node in additional {
+        if seen.insert(graph.identity(&node)) {
+            lineage.push(node);
         }
     }
 }
@@ -427,7 +423,11 @@ mod tests {
     fn ordinary_holons_use_their_describing_descriptor_lineage() {
         let graph = TestGraph {
             extends: HashMap::from([("BookType", vec!["DocumentType"])]),
-            described_by: HashMap::from([("book-1", vec!["BookType"])]),
+            described_by: HashMap::from([
+                ("book-1", vec!["BookType"]),
+                ("BookType", vec!["TypeDescriptor"]),
+            ]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
             ..Default::default()
         };
 
@@ -438,13 +438,16 @@ mod tests {
     }
 
     #[test]
-    fn descriptor_holons_combine_own_and_describing_lineages_without_duplicates() {
+    fn type_holons_combine_own_and_describing_lineages_without_duplicates() {
         let graph = TestGraph {
             extends: HashMap::from([
                 ("BookType", vec!["HolonType"]),
                 ("TypeDescriptor", vec!["HolonType"]),
             ]),
-            described_by: HashMap::from([("BookType", vec!["TypeDescriptor"])]),
+            described_by: HashMap::from([
+                ("BookType", vec!["TypeDescriptor"]),
+                ("TypeDescriptor", vec!["TypeDescriptor"]),
+            ]),
             type_descriptors: HashSet::from(["TypeDescriptor"]),
             ..Default::default()
         };
@@ -452,6 +455,21 @@ mod tests {
         assert_eq!(
             effective_descriptor_lineage(&graph, &"BookType"),
             Ok(vec!["BookType", "HolonType", "TypeDescriptor"])
+        );
+    }
+
+    #[test]
+    fn self_describing_type_has_one_identity_deduplicated_lineage() {
+        let graph = TestGraph {
+            extends: HashMap::from([("TypeDescriptor", vec!["HolonType"])]),
+            described_by: HashMap::from([("TypeDescriptor", vec!["TypeDescriptor"])]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_descriptor_lineage(&graph, &"TypeDescriptor"),
+            Ok(vec!["TypeDescriptor", "HolonType"])
         );
     }
 
@@ -495,11 +513,14 @@ mod tests {
     }
 
     #[test]
-    fn partial_descriptor_lineage_is_available_before_described_by_is_attached() {
+    fn missing_described_by_is_not_reinterpreted_as_own_lineage() {
         let graph =
             TestGraph { extends: HashMap::from([("Child", vec!["Parent"])]), ..Default::default() };
 
-        assert_eq!(effective_descriptor_lineage(&graph, &"Child"), Ok(vec!["Child", "Parent"]));
+        assert_eq!(
+            effective_descriptor_lineage(&graph, &"Child"),
+            Err(DescriptorSemanticsError::MissingDescribedBy { holon: "Child" })
+        );
     }
 
     #[test]
@@ -547,6 +568,7 @@ mod tests {
                 (("HolonType", "key-rule"), vec!["ExtendedTypeRule"]),
                 (("TypeDescriptor", "key-rule"), vec!["TypeNameRule"]),
             ]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
             ..Default::default()
         };
 
@@ -563,11 +585,66 @@ mod tests {
     #[test]
     fn holon_key_rule_falls_back_through_described_by() {
         let graph = TestGraph {
-            described_by: HashMap::from([("book-1", vec!["BookType"])]),
+            described_by: HashMap::from([
+                ("book-1", vec!["BookType"]),
+                ("BookType", vec!["TypeDescriptor"]),
+            ]),
             members: HashMap::from([(("BookType", "key-rule"), vec!["BookRule"])]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
             ..Default::default()
         };
 
         assert_eq!(effective_holon_key_rule(&graph, &"book-1", &"key-rule"), Ok(Some("BookRule")));
+    }
+
+    #[test]
+    fn root_type_key_excludes_its_own_instance_rule_and_falls_back_to_described_by() {
+        let graph = TestGraph {
+            described_by: HashMap::from([("RootType", vec!["TypeDescriptor"])]),
+            members: HashMap::from([
+                (("RootType", "key-rule"), vec!["RootInstanceRule"]),
+                (("TypeDescriptor", "key-rule"), vec!["TypeNameRule"]),
+            ]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_holon_key_rule(&graph, &"RootType", &"key-rule"),
+            Ok(Some("TypeNameRule"))
+        );
+    }
+
+    #[test]
+    fn ordinary_holon_ignores_its_own_extends_edge_during_key_resolution() {
+        let graph = TestGraph {
+            extends: HashMap::from([("book-1", vec!["NotItsType"])]),
+            described_by: HashMap::from([
+                ("book-1", vec!["BookType"]),
+                ("BookType", vec!["TypeDescriptor"]),
+            ]),
+            members: HashMap::from([
+                (("NotItsType", "key-rule"), vec!["WrongRule"]),
+                (("BookType", "key-rule"), vec!["BookRule"]),
+            ]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
+            ..Default::default()
+        };
+
+        assert_eq!(effective_holon_key_rule(&graph, &"book-1", &"key-rule"), Ok(Some("BookRule")));
+    }
+
+    #[test]
+    fn holon_key_resolution_validates_described_by_before_using_own_ancestors() {
+        let graph = TestGraph {
+            extends: HashMap::from([("BookType", vec!["HolonType"])]),
+            members: HashMap::from([(("HolonType", "key-rule"), vec!["InheritedRule"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_holon_key_rule(&graph, &"BookType", &"key-rule"),
+            Err(DescriptorSemanticsError::MissingDescribedBy { holon: "BookType" })
+        );
     }
 }

--- a/shared_crates/descriptor_semantics/src/inheritance.rs
+++ b/shared_crates/descriptor_semantics/src/inheritance.rs
@@ -1,0 +1,321 @@
+use std::{collections::HashSet, hash::Hash};
+
+use crate::graph::{DescriptorGraph, DescriptorSemanticsError};
+
+/// Representation-neutral state machine for a self-first `Extends` traversal.
+///
+/// The state machine prepares the next edge after yielding the current node. Structural failures
+/// are therefore emitted on the following iteration, preserving the runtime API's ability to stop
+/// before an error farther up the chain.
+pub struct ExtendsTraversal<N, I, E> {
+    next: Option<N>,
+    pending_error: Option<DescriptorSemanticsError<E, N>>,
+    visited: HashSet<I>,
+    finished: bool,
+}
+
+impl<N, I, E> ExtendsTraversal<N, I, E>
+where
+    N: Clone,
+    I: Clone + Eq + Hash,
+{
+    pub fn new(start: N) -> Self {
+        Self { next: Some(start), pending_error: None, visited: HashSet::new(), finished: false }
+    }
+
+    pub fn next_with(
+        &mut self,
+        identity: impl Fn(&N) -> I,
+        extends_targets: impl FnOnce(&N) -> Result<Vec<N>, E>,
+    ) -> Option<Result<N, DescriptorSemanticsError<E, N>>> {
+        if self.finished {
+            return None;
+        }
+
+        if let Some(error) = self.pending_error.take() {
+            self.finished = true;
+            return Some(Err(error));
+        }
+
+        let current = self.next.take()?;
+        self.visited.insert(identity(&current));
+
+        match extends_targets(&current) {
+            Ok(targets) => match targets.as_slice() {
+                [] => self.finished = true,
+                [parent] => {
+                    if self.visited.contains(&identity(parent)) {
+                        self.pending_error = Some(DescriptorSemanticsError::CyclicExtends {
+                            descriptor: parent.clone(),
+                        });
+                    } else {
+                        self.next = Some(parent.clone());
+                    }
+                }
+                many => {
+                    self.pending_error = Some(DescriptorSemanticsError::MultipleExtends {
+                        descriptor: current.clone(),
+                        count: many.len(),
+                    });
+                }
+            },
+            Err(error) => self.pending_error = Some(DescriptorSemanticsError::Access(error)),
+        }
+
+        Some(Ok(current))
+    }
+}
+
+/// Lazy, self-first `Extends` iterator over a descriptor graph.
+pub struct ExtendsWalk<'a, G: DescriptorGraph> {
+    graph: &'a G,
+    traversal: ExtendsTraversal<G::Node, G::Identity, G::Error>,
+}
+
+impl<'a, G: DescriptorGraph> Iterator for ExtendsWalk<'a, G> {
+    type Item = Result<G::Node, DescriptorSemanticsError<G::Error, G::Node>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.traversal
+            .next_with(|node| self.graph.identity(node), |node| self.graph.extends_targets(node))
+    }
+}
+
+pub fn walk_extends_chain<'a, G: DescriptorGraph>(
+    graph: &'a G,
+    start: &G::Node,
+) -> ExtendsWalk<'a, G> {
+    ExtendsWalk { graph, traversal: ExtendsTraversal::new(start.clone()) }
+}
+
+pub fn ancestors<G: DescriptorGraph>(
+    graph: &G,
+    start: &G::Node,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    walk_extends_chain(graph, start).collect()
+}
+
+pub fn equals_or_extends<G: DescriptorGraph>(
+    graph: &G,
+    candidate: &G::Node,
+    anchor: &G::Node,
+) -> Result<bool, DescriptorSemanticsError<G::Error, G::Node>> {
+    let anchor_id = graph.identity(anchor);
+    for ancestor in walk_extends_chain(graph, candidate) {
+        if graph.identity(&ancestor?) == anchor_id {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Computes the effective descriptor lineage defined by MAP Type System v1.2.
+pub fn effective_descriptor_lineage<G: DescriptorGraph>(
+    graph: &G,
+    holon: &G::Node,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    let described_by_targets =
+        graph.described_by_targets(holon).map_err(DescriptorSemanticsError::Access)?;
+    let described_by = match described_by_targets.as_slice() {
+        [] => return ancestors(graph, holon),
+        [descriptor] => descriptor,
+        many => {
+            return Err(DescriptorSemanticsError::MultipleDescribedBy {
+                holon: holon.clone(),
+                count: many.len(),
+            })
+        }
+    };
+
+    if graph.is_type_descriptor(described_by).map_err(DescriptorSemanticsError::Access)? {
+        let mut lineage = ancestors(graph, holon)?;
+        append_unique(graph, &mut lineage, ancestors(graph, described_by)?);
+        return Ok(lineage);
+    }
+
+    ancestors(graph, described_by)
+}
+
+/// Collects related members in self-first lineage order, deduplicated by node identity.
+pub fn flatten_related_members<G: DescriptorGraph>(
+    graph: &G,
+    start: &G::Node,
+    member_kind: &G::MemberKind,
+) -> Result<Vec<G::Node>, DescriptorSemanticsError<G::Error, G::Node>> {
+    let mut members = Vec::new();
+    let mut seen = HashSet::new();
+
+    for ancestor in walk_extends_chain(graph, start) {
+        let ancestor = ancestor?;
+        for member in graph
+            .related_members(&ancestor, member_kind)
+            .map_err(DescriptorSemanticsError::Access)?
+        {
+            if seen.insert(graph.identity(&member)) {
+                members.push(member);
+            }
+        }
+    }
+
+    Ok(members)
+}
+
+fn append_unique<G: DescriptorGraph>(
+    graph: &G,
+    lineage: &mut Vec<G::Node>,
+    additional: Vec<G::Node>,
+) {
+    let mut seen = lineage.iter().map(|node| graph.identity(node)).collect::<HashSet<_>>();
+    for descriptor in additional {
+        if seen.insert(graph.identity(&descriptor)) {
+            lineage.push(descriptor);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestGraph {
+        extends: HashMap<&'static str, Vec<&'static str>>,
+        described_by: HashMap<&'static str, Vec<&'static str>>,
+        members: HashMap<(&'static str, &'static str), Vec<&'static str>>,
+        type_descriptors: HashSet<&'static str>,
+    }
+
+    impl DescriptorGraph for TestGraph {
+        type Node = &'static str;
+        type Identity = &'static str;
+        type MemberKind = &'static str;
+        type Error = &'static str;
+
+        fn identity(&self, node: &Self::Node) -> Self::Identity {
+            node
+        }
+
+        fn extends_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+            Ok(self.extends.get(node).cloned().unwrap_or_default())
+        }
+
+        fn described_by_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+            Ok(self.described_by.get(node).cloned().unwrap_or_default())
+        }
+
+        fn related_members(
+            &self,
+            node: &Self::Node,
+            member_kind: &Self::MemberKind,
+        ) -> Result<Vec<Self::Node>, Self::Error> {
+            Ok(self.members.get(&(*node, *member_kind)).cloned().unwrap_or_default())
+        }
+
+        fn is_type_descriptor(&self, node: &Self::Node) -> Result<bool, Self::Error> {
+            Ok(self.type_descriptors.contains(node))
+        }
+    }
+
+    #[test]
+    fn ancestors_are_self_first_and_identity_based() {
+        let graph = TestGraph {
+            extends: HashMap::from([("C", vec!["B"]), ("B", vec!["A"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(ancestors(&graph, &"C"), Ok(vec!["C", "B", "A"]));
+        assert_eq!(equals_or_extends(&graph, &"C", &"A"), Ok(true));
+        assert_eq!(equals_or_extends(&graph, &"C", &"Other"), Ok(false));
+    }
+
+    #[test]
+    fn traversal_defers_structural_errors_until_after_the_current_node() {
+        let graph =
+            TestGraph { extends: HashMap::from([("Child", vec!["A", "B"])]), ..Default::default() };
+        let mut walk = walk_extends_chain(&graph, &"Child");
+
+        assert_eq!(walk.next(), Some(Ok("Child")));
+        assert_eq!(
+            walk.next(),
+            Some(Err(DescriptorSemanticsError::MultipleExtends { descriptor: "Child", count: 2 }))
+        );
+        assert_eq!(walk.next(), None);
+    }
+
+    #[test]
+    fn cycles_are_reported_at_the_repeated_identity() {
+        let graph = TestGraph {
+            extends: HashMap::from([("A", vec!["B"]), ("B", vec!["A"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            ancestors(&graph, &"A"),
+            Err(DescriptorSemanticsError::CyclicExtends { descriptor: "A" })
+        );
+    }
+
+    #[test]
+    fn ordinary_holons_use_their_describing_descriptor_lineage() {
+        let graph = TestGraph {
+            extends: HashMap::from([("BookType", vec!["DocumentType"])]),
+            described_by: HashMap::from([("book-1", vec!["BookType"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_descriptor_lineage(&graph, &"book-1"),
+            Ok(vec!["BookType", "DocumentType"])
+        );
+    }
+
+    #[test]
+    fn descriptor_holons_combine_own_and_describing_lineages_without_duplicates() {
+        let graph = TestGraph {
+            extends: HashMap::from([
+                ("BookType", vec!["HolonType"]),
+                ("TypeDescriptor", vec!["HolonType"]),
+            ]),
+            described_by: HashMap::from([("BookType", vec!["TypeDescriptor"])]),
+            type_descriptors: HashSet::from(["TypeDescriptor"]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_descriptor_lineage(&graph, &"BookType"),
+            Ok(vec!["BookType", "HolonType", "TypeDescriptor"])
+        );
+    }
+
+    #[test]
+    fn flattening_preserves_lineage_order_and_deduplicates_by_identity() {
+        let graph = TestGraph {
+            extends: HashMap::from([("Child", vec!["Parent"])]),
+            members: HashMap::from([
+                (("Child", "properties"), vec!["Name", "Title"]),
+                (("Parent", "properties"), vec!["Name", "Description"]),
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            flatten_related_members(&graph, &"Child", &"properties"),
+            Ok(vec!["Name", "Title", "Description"])
+        );
+    }
+
+    #[test]
+    fn multiple_described_by_targets_are_rejected_by_the_kernel() {
+        let graph = TestGraph {
+            described_by: HashMap::from([("instance", vec!["TypeA", "TypeB"])]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_descriptor_lineage(&graph, &"instance"),
+            Err(DescriptorSemanticsError::MultipleDescribedBy { holon: "instance", count: 2 })
+        );
+    }
+}

--- a/shared_crates/descriptor_semantics/src/lib.rs
+++ b/shared_crates/descriptor_semantics/src/lib.rs
@@ -11,7 +11,10 @@ pub mod inheritance;
 pub mod value;
 
 pub use conformance::{
-    property_requirement, validate_cardinality, CardinalityViolation, PropertyRequirement,
+    property_requirement, validate_cardinality, validate_holon_conformance,
+    value_policy_for_type_kind, CardinalityViolation, ConformanceValue, ConformanceViolation,
+    HolonConformance, PropertyDeclaration, PropertyRequirement, PropertyValue,
+    RelationshipDeclaration, RelationshipValue, ValuePolicy,
 };
 pub use graph::{DescriptorGraph, DescriptorSemanticsError};
 pub use inheritance::{

--- a/shared_crates/descriptor_semantics/src/lib.rs
+++ b/shared_crates/descriptor_semantics/src/lib.rs
@@ -11,15 +11,17 @@ pub mod inheritance;
 pub mod value;
 
 pub use conformance::{
-    property_requirement, validate_cardinality, validate_holon_conformance,
+    compose_restrictive_boolean, validate_cardinality, validate_holon_conformance,
     value_policy_for_type_kind, CardinalityViolation, ConformanceValue, ConformanceViolation,
-    HolonConformance, PropertyDeclaration, PropertyRequirement, PropertyValue,
-    RelationshipDeclaration, RelationshipValue, ValuePolicy,
+    HolonConformance, PropertyDeclaration, PropertyValue, RelationshipDeclaration,
+    RelationshipValue, ValuePolicy,
 };
 pub use graph::{DescriptorGraph, DescriptorSemanticsError};
 pub use inheritance::{
-    ancestors, effective_descriptor_lineage, equals_or_extends, flatten_related_members,
-    walk_extends_chain, ExtendsTraversal, ExtendsWalk,
+    ancestors, collect_named_members_from_lineage, describing_type, duplicate_declaration_name,
+    effective_descriptor_lineage, effective_holon_key_rule, effective_instance_key_rule,
+    equals_or_extends, flatten_named_members, flatten_related_members, walk_extends_chain,
+    ExtendsTraversal, ExtendsWalk,
 };
 pub use value::{
     validate_enum_variant, validate_integer_maximum, validate_integer_minimum,

--- a/shared_crates/descriptor_semantics/src/lib.rs
+++ b/shared_crates/descriptor_semantics/src/lib.rs
@@ -1,0 +1,24 @@
+//! Representation-neutral MAP descriptor semantics.
+//!
+//! This crate owns graph and conformance rules that must behave identically for bound runtime
+//! holons and Canonical Holon IR. Representations provide graph access; this crate owns traversal,
+//! cardinality, ordering, deduplication, and value-policy decisions. It deliberately has no
+//! storage, transaction, runtime-reference, source-format, or host dependency.
+
+pub mod conformance;
+pub mod graph;
+pub mod inheritance;
+pub mod value;
+
+pub use conformance::{
+    property_requirement, validate_cardinality, CardinalityViolation, PropertyRequirement,
+};
+pub use graph::{DescriptorGraph, DescriptorSemanticsError};
+pub use inheritance::{
+    ancestors, effective_descriptor_lineage, equals_or_extends, flatten_related_members,
+    walk_extends_chain, ExtendsTraversal, ExtendsWalk,
+};
+pub use value::{
+    validate_enum_variant, validate_integer_maximum, validate_integer_minimum,
+    validate_string_maximum_length, validate_string_minimum_length, ValueViolation,
+};

--- a/shared_crates/descriptor_semantics/src/lib.rs
+++ b/shared_crates/descriptor_semantics/src/lib.rs
@@ -20,7 +20,7 @@ pub use graph::{DescriptorGraph, DescriptorSemanticsError};
 pub use inheritance::{
     ancestors, collect_named_members_from_lineage, describing_type, duplicate_declaration_name,
     effective_descriptor_lineage, effective_holon_key_rule, effective_instance_key_rule,
-    equals_or_extends, flatten_named_members, flatten_related_members, walk_extends_chain,
+    equals_or_extends, flatten_named_members, flatten_related_members, lineage, walk_extends_chain,
     ExtendsTraversal, ExtendsWalk,
 };
 pub use value::{

--- a/shared_crates/descriptor_semantics/src/value.rs
+++ b/shared_crates/descriptor_semantics/src/value.rs
@@ -1,0 +1,90 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueViolation {
+    EnumVariantNotDeclared,
+    IntegerBelowMinimum { minimum: i64, inclusive: bool },
+    IntegerAboveMaximum { maximum: i64, inclusive: bool },
+    StringBelowMinimumLength { minimum: i64, actual: usize },
+    StringAboveMaximumLength { maximum: i64, actual: usize },
+}
+
+pub fn validate_enum_variant<'a>(
+    variant: &str,
+    declared_variants: impl IntoIterator<Item = &'a str>,
+) -> Result<(), ValueViolation> {
+    if declared_variants.into_iter().any(|declared| declared == variant) {
+        Ok(())
+    } else {
+        Err(ValueViolation::EnumVariantNotDeclared)
+    }
+}
+
+pub fn validate_integer_minimum(
+    value: i64,
+    minimum: i64,
+    inclusive: bool,
+) -> Result<(), ValueViolation> {
+    if value > minimum || (inclusive && value == minimum) {
+        Ok(())
+    } else {
+        Err(ValueViolation::IntegerBelowMinimum { minimum, inclusive })
+    }
+}
+
+pub fn validate_integer_maximum(
+    value: i64,
+    maximum: i64,
+    inclusive: bool,
+) -> Result<(), ValueViolation> {
+    if value < maximum || (inclusive && value == maximum) {
+        Ok(())
+    } else {
+        Err(ValueViolation::IntegerAboveMaximum { maximum, inclusive })
+    }
+}
+
+pub fn validate_string_minimum_length(value: &str, minimum: i64) -> Result<(), ValueViolation> {
+    let actual = value.chars().count();
+    if (actual as i128) >= i128::from(minimum) {
+        Ok(())
+    } else {
+        Err(ValueViolation::StringBelowMinimumLength { minimum, actual })
+    }
+}
+
+pub fn validate_string_maximum_length(value: &str, maximum: i64) -> Result<(), ValueViolation> {
+    let actual = value.chars().count();
+    if (actual as i128) <= i128::from(maximum) {
+        Ok(())
+    } else {
+        Err(ValueViolation::StringAboveMaximumLength { maximum, actual })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enum_membership_uses_exact_declared_identity() {
+        assert!(validate_enum_variant("Color.Red", ["Color.Red", "Color.Blue"]).is_ok());
+        assert_eq!(
+            validate_enum_variant("Color.Reddish", ["Color.Red", "Color.Blue"]),
+            Err(ValueViolation::EnumVariantNotDeclared)
+        );
+    }
+
+    #[test]
+    fn integer_bounds_honor_inclusivity() {
+        assert!(validate_integer_minimum(2, 2, true).is_ok());
+        assert!(validate_integer_minimum(2, 2, false).is_err());
+        assert!(validate_integer_maximum(2, 2, true).is_ok());
+        assert!(validate_integer_maximum(2, 2, false).is_err());
+    }
+
+    #[test]
+    fn string_bounds_count_characters() {
+        assert!(validate_string_minimum_length("é", 1).is_ok());
+        assert!(validate_string_maximum_length("é", 1).is_ok());
+        assert!(validate_string_maximum_length("éé", 1).is_err());
+    }
+}

--- a/shared_crates/holons_core/Cargo.toml
+++ b/shared_crates/holons_core/Cargo.toml
@@ -11,6 +11,7 @@ name = "holons_core"
 # only used by holons_core
 quick_cache = { version = "0.6.14", default-features = false }
 serde_json = { workspace = true }
+descriptor_semantics = { path = "../descriptor_semantics" }
 
 
 # General dev-dependencies (platform-agnostic)

--- a/shared_crates/holons_core/src/descriptors/effective_relationships.rs
+++ b/shared_crates/holons_core/src/descriptors/effective_relationships.rs
@@ -195,10 +195,8 @@ pub(crate) fn effective_relationships(
 
 /// Finds a relationship declaration on a holon's effective relationship surface.
 ///
-/// Ordinary runtime holons draw this surface from `DescribedBy -> Extends*`.
-/// Descriptor holons also contribute their own `Extends*` lineage, which is
-/// where descriptor-populated relationships like `SourceType`, `TargetType`,
-/// `InverseOf`, and `ValueType` are licensed in MAP Type System v1.2.
+/// Ordinary runtime holons draw this surface from `DescribedBy -> Extends*`. Type holons also
+/// contribute their own `Extends*` lineage before the describing-type lineage.
 pub fn effective_relationship_declaration(
     source_holon: &HolonReference,
     name: impl ToRelationshipName,
@@ -975,8 +973,12 @@ mod tests {
     #[test]
     fn finds_descriptor_holon_declaration_through_own_extends_lineage() -> Result<(), HolonError> {
         let context = build_context();
-        let type_descriptor =
-            new_holon_type_descriptor(&context, "surface-type-descriptor", "TypeDescriptor")?;
+        let mut type_descriptor =
+            new_holon_type_descriptor(&context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+        type_descriptor.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&type_descriptor)],
+        )?;
         let mut meta_relationship_type = new_holon_type_descriptor(
             &context,
             "surface-meta-relationship-type",
@@ -1042,7 +1044,11 @@ mod tests {
         let mut holon_type =
             new_holon_type_descriptor(&context, "surface-tail-holon-type", "HolonType")?;
         let mut type_descriptor =
-            new_holon_type_descriptor(&context, "surface-tail-type-descriptor", "TypeDescriptor")?;
+            new_holon_type_descriptor(&context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+        type_descriptor.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&type_descriptor)],
+        )?;
         let properties = new_relationship_descriptor_holon(
             &context,
             "surface-properties",

--- a/shared_crates/holons_core/src/descriptors/effective_relationships.rs
+++ b/shared_crates/holons_core/src/descriptors/effective_relationships.rs
@@ -37,12 +37,13 @@
 use std::collections::HashSet;
 
 use crate::descriptors::{
-    accessor_helpers, effective_descriptor_lineage, inheritance::equals_or_extends,
-    inheritance::flatten_related_members, walk_extends_chain, DeclaredRelationshipDescriptor,
-    Descriptor, HolonDescriptor, InverseRelationshipDescriptor, RelationshipDescriptor,
-    RelationshipDirection,
+    accessor_helpers, effective_descriptor_lineage,
+    inheritance::collect_named_related_members_from_lineage, inheritance::equals_or_extends,
+    inheritance::flatten_named_related_members, inheritance::flatten_related_members,
+    DeclaredRelationshipDescriptor, Descriptor, HolonDescriptor, InverseRelationshipDescriptor,
+    RelationshipDescriptor, RelationshipDirection,
 };
-use crate::reference_layer::{HolonReference, ReadableHolon};
+use crate::reference_layer::HolonReference;
 use core_types::{HolonError, RelationshipName};
 use type_names::{CoreRelationshipTypeName, ToRelationshipName};
 
@@ -83,38 +84,19 @@ pub(crate) fn collect_relationships_from_anchors(
     anchors: impl IntoIterator<Item = Result<HolonReference, HolonError>>,
     subject_label: impl Fn() -> String,
 ) -> Result<Vec<RelationshipDescriptor>, HolonError> {
-    let mut relationship_descriptors = Vec::new();
-    let mut seen_declaration_refs = HashSet::new();
-    let mut seen_declaration_names = HashSet::new();
-
-    for anchor in anchors {
-        let anchor = anchor?;
-        let collection_arc =
-            anchor.related_holons(CoreRelationshipTypeName::InstanceRelationships)?;
-        let collection = collection_arc.read().map_err(accessor_helpers::lock_error)?;
-
-        for declaration_ref in collection.get_members() {
-            if !seen_declaration_refs.insert(declaration_ref.reference_id_string()) {
-                continue;
-            }
-
-            let relationship_descriptor =
-                RelationshipDescriptor::from_holon(declaration_ref.clone());
-            let declaration_name = relationship_descriptor.base_relationship_name()?;
-            let declaration_label = declaration_name.to_string();
-            if !seen_declaration_names.insert(declaration_label.clone()) {
-                return Err(HolonError::DuplicateInheritedDeclaration {
-                    kind: "relationship".to_string(),
-                    name: declaration_label,
-                    descriptor: subject_label(),
-                });
-            }
-
-            relationship_descriptors.push(relationship_descriptor);
-        }
-    }
-
-    Ok(relationship_descriptors)
+    let lineage = anchors.into_iter().collect::<Result<Vec<_>, _>>()?;
+    let members = collect_named_related_members_from_lineage(
+        lineage,
+        CoreRelationshipTypeName::InstanceRelationships,
+        "relationship",
+        |member| {
+            RelationshipDescriptor::from_holon(member.clone())
+                .base_relationship_name()
+                .map(|name| name.to_string())
+        },
+    )?;
+    let _ = subject_label;
+    Ok(members.into_iter().map(RelationshipDescriptor::from_holon).collect())
 }
 
 /// Collects declared relationship descriptors from an already-selected lineage.
@@ -138,9 +120,21 @@ pub(crate) fn collect_declared_from_anchors(
 pub(crate) fn effective_declared_relationships(
     endpoint: &HolonDescriptor,
 ) -> Result<Vec<DeclaredRelationshipDescriptor>, HolonError> {
-    collect_declared_from_anchors(walk_extends_chain(endpoint.holon()), || {
-        accessor_helpers::descriptor_label(endpoint.holon())
+    flatten_named_related_members(
+        endpoint.holon(),
+        CoreRelationshipTypeName::InstanceRelationships,
+        "relationship",
+        |member| {
+            RelationshipDescriptor::from_holon(member.clone())
+                .base_relationship_name()
+                .map(|name| name.to_string())
+        },
+    )?
+    .into_iter()
+    .map(|member| {
+        RelationshipDescriptor::from_holon(member).try_into_declared_relationship_descriptor()
     })
+    .collect()
 }
 
 /// Enumerates effective inverse relationships for `endpoint`.

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
-
 use crate::descriptors::{
-    accessor_helpers, effective_relationships, inheritance::flatten_related_members,
+    accessor_helpers, effective_relationships,
+    inheritance::{effective_instance_key_rule, flatten_named_related_members},
     walk_extends_chain, CommandDescriptor, DanceDescriptor, DeclaredRelationshipDescriptor,
     Descriptor, InverseRelationshipDescriptor, KeyRuleDescriptor, PropertyDescriptor,
     QualifiedRelationship, RelationshipDescriptor, TypeHeader,
@@ -34,18 +33,12 @@ impl HolonDescriptor {
 
     /// Returns whether instances may carry properties beyond the descriptor declaration.
     pub fn allows_additional_properties(&self) -> Result<bool, HolonError> {
-        accessor_helpers::require_bool(
-            &self.holon,
-            CorePropertyTypeName::AllowsAdditionalProperties,
-        )
+        self.compose_inherited_boolean(CorePropertyTypeName::AllowsAdditionalProperties)
     }
 
     /// Returns whether instances may carry relationships beyond the descriptor declaration.
     pub fn allows_additional_relationships(&self) -> Result<bool, HolonError> {
-        accessor_helpers::require_bool(
-            &self.holon,
-            CorePropertyTypeName::AllowsAdditionalRelationships,
-        )
+        self.compose_inherited_boolean(CorePropertyTypeName::AllowsAdditionalRelationships)
     }
 
     /// Returns effective instance property descriptors across this descriptor's inheritance chain.
@@ -55,20 +48,47 @@ impl HolonDescriptor {
 
     /// Returns effective instance relationship descriptors across this descriptor's inheritance chain.
     pub fn instance_relationships(&self) -> Result<Vec<RelationshipDescriptor>, HolonError> {
-        flatten_related_members(&self.holon, CoreRelationshipTypeName::InstanceRelationships)
-            .map(|members| members.into_iter().map(RelationshipDescriptor::from_holon).collect())
+        flatten_named_related_members(
+            &self.holon,
+            CoreRelationshipTypeName::InstanceRelationships,
+            "relationship",
+            |member| {
+                RelationshipDescriptor::from_holon(member.clone())
+                    .base_relationship_name()
+                    .map(|name| name.to_string())
+            },
+        )
+        .map(|members| members.into_iter().map(RelationshipDescriptor::from_holon).collect())
     }
 
     /// Returns effective command descriptors across this descriptor's inheritance chain.
     pub fn afforded_commands(&self) -> Result<Vec<CommandDescriptor>, HolonError> {
-        flatten_related_members(&self.holon, CoreRelationshipTypeName::AffordsCommand)
-            .map(|members| members.into_iter().map(CommandDescriptor::from_holon).collect())
+        flatten_named_related_members(
+            &self.holon,
+            CoreRelationshipTypeName::AffordsCommand,
+            "command",
+            |member| {
+                CommandDescriptor::from_holon(member.clone())
+                    .command_name()
+                    .map(|name| name.to_string())
+            },
+        )
+        .map(|members| members.into_iter().map(CommandDescriptor::from_holon).collect())
     }
 
     /// Returns effective dance descriptors across this descriptor's inheritance chain.
     pub fn afforded_dances(&self) -> Result<Vec<DanceDescriptor>, HolonError> {
-        flatten_related_members(&self.holon, CoreRelationshipTypeName::AffordsDance)
-            .map(|members| members.into_iter().map(DanceDescriptor::from_holon).collect())
+        flatten_named_related_members(
+            &self.holon,
+            CoreRelationshipTypeName::AffordsDance,
+            "dance",
+            |member| {
+                DanceDescriptor::from_holon(member.clone())
+                    .dance_name()
+                    .map(|name| name.to_string())
+            },
+        )
+        .map(|members| members.into_iter().map(DanceDescriptor::from_holon).collect())
     }
 
     /// Returns effective property type descriptors across this descriptor's inheritance chain.
@@ -91,25 +111,13 @@ impl HolonDescriptor {
     ) -> Result<PropertyDescriptor, HolonError> {
         let requested_name = name.to_property_name();
         let requested = requested_name.to_string();
-        let mut seen = HashSet::new();
-        let mut found = None;
-
         for descriptor in self.instance_properties()? {
             let declaration_name = PropertyName(descriptor.header().type_name()?);
-            let declaration_label = declaration_name.to_string();
-            if !seen.insert(declaration_label.clone()) {
-                return Err(HolonError::DuplicateInheritedDeclaration {
-                    kind: "property".to_string(),
-                    name: declaration_label,
-                    descriptor: accessor_helpers::descriptor_label(&self.holon),
-                });
-            }
             if declaration_name == requested_name {
-                found = Some(descriptor);
+                return Ok(descriptor);
             }
         }
-
-        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+        Err(HolonError::DescriptorDeclarationNotFound {
             kind: "property".to_string(),
             name: requested,
             descriptor: accessor_helpers::descriptor_label(&self.holon),
@@ -131,25 +139,13 @@ impl HolonDescriptor {
     ) -> Result<CommandDescriptor, HolonError> {
         let requested_name = name.to_command_name();
         let requested = requested_name.to_string();
-        let mut seen = HashSet::new();
-        let mut found = None;
-
         for descriptor in self.afforded_commands()? {
             let declaration_name = descriptor.command_name()?;
-            let declaration_label = declaration_name.to_string();
-            if !seen.insert(declaration_label.clone()) {
-                return Err(HolonError::DuplicateInheritedDeclaration {
-                    kind: "command".to_string(),
-                    name: declaration_label,
-                    descriptor: accessor_helpers::descriptor_label(&self.holon),
-                });
-            }
             if declaration_name == requested_name {
-                found = Some(descriptor);
+                return Ok(descriptor);
             }
         }
-
-        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+        Err(HolonError::DescriptorDeclarationNotFound {
             kind: "command".to_string(),
             name: requested,
             descriptor: accessor_helpers::descriptor_label(&self.holon),
@@ -165,25 +161,13 @@ impl HolonDescriptor {
     pub fn get_dance_by_name(&self, name: impl ToDanceName) -> Result<DanceDescriptor, HolonError> {
         let requested_name = name.to_dance_name();
         let requested = requested_name.to_string();
-        let mut seen = HashSet::new();
-        let mut found = None;
-
         for descriptor in self.afforded_dances()? {
             let declaration_name = descriptor.dance_name()?;
-            let declaration_label = declaration_name.to_string();
-            if !seen.insert(declaration_label.clone()) {
-                return Err(HolonError::DuplicateInheritedDeclaration {
-                    kind: "dance".to_string(),
-                    name: declaration_label,
-                    descriptor: accessor_helpers::descriptor_label(&self.holon),
-                });
-            }
             if declaration_name == requested_name {
-                found = Some(descriptor);
+                return Ok(descriptor);
             }
         }
-
-        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+        Err(HolonError::DescriptorDeclarationNotFound {
             kind: "dance".to_string(),
             name: requested,
             descriptor: accessor_helpers::descriptor_label(&self.holon),
@@ -197,25 +181,13 @@ impl HolonDescriptor {
     ) -> Result<RelationshipDescriptor, HolonError> {
         let requested_name = name.to_relationship_name();
         let requested = requested_name.to_string();
-        let mut seen = HashSet::new();
-        let mut found = None;
-
         for descriptor in self.instance_relationships()? {
             let declaration_name = descriptor.base_relationship_name()?;
-            let declaration_label = declaration_name.to_string();
-            if !seen.insert(declaration_label.clone()) {
-                return Err(HolonError::DuplicateInheritedDeclaration {
-                    kind: "relationship".to_string(),
-                    name: declaration_label,
-                    descriptor: accessor_helpers::descriptor_label(&self.holon),
-                });
-            }
             if declaration_name == requested_name {
-                found = Some(descriptor);
+                return Ok(descriptor);
             }
         }
-
-        found.ok_or_else(|| HolonError::DescriptorDeclarationNotFound {
+        Err(HolonError::DescriptorDeclarationNotFound {
             kind: "relationship".to_string(),
             name: requested,
             descriptor: accessor_helpers::descriptor_label(&self.holon),
@@ -281,41 +253,55 @@ impl HolonDescriptor {
 
     /// Resolves the effective key rule for instances of this descriptor.
     pub fn effective_key_rule(&self) -> Result<KeyRuleDescriptor, HolonError> {
-        for ancestor in walk_extends_chain(&self.holon) {
-            let ancestor = ancestor?;
-            if let Some(rule) = accessor_helpers::optional_single_related(
-                &ancestor,
-                CoreRelationshipTypeName::UsesKeyRule,
-            )? {
-                let rule_descriptor = KeyRuleDescriptor::from_holon(rule);
-                if !rule_descriptor.is_key_rule()? {
-                    return Err(HolonError::WrongDescriptorKind {
-                        expected: "KeyRuleType".to_string(),
-                        found: rule_descriptor
-                            .header()
-                            .type_name()
-                            .map(|type_name| type_name.to_string())
-                            .unwrap_or_else(|_| {
-                                accessor_helpers::descriptor_label(rule_descriptor.holon())
-                            }),
-                        descriptor: accessor_helpers::descriptor_label(rule_descriptor.holon()),
-                    });
-                }
-                return Ok(rule_descriptor);
+        let rule = effective_instance_key_rule(&self.holon)?.ok_or_else(|| {
+            HolonError::NoEffectiveKeyRule {
+                descriptor: accessor_helpers::descriptor_label(&self.holon),
             }
+        })?;
+        let rule_descriptor = KeyRuleDescriptor::from_holon(rule);
+        if !rule_descriptor.is_key_rule()? {
+            return Err(HolonError::WrongDescriptorKind {
+                expected: "KeyRuleType".to_string(),
+                found: rule_descriptor
+                    .header()
+                    .type_name()
+                    .map(|type_name| type_name.to_string())
+                    .unwrap_or_else(|_| {
+                        accessor_helpers::descriptor_label(rule_descriptor.holon())
+                    }),
+                descriptor: accessor_helpers::descriptor_label(rule_descriptor.holon()),
+            });
         }
-
-        Err(HolonError::NoEffectiveKeyRule {
-            descriptor: accessor_helpers::descriptor_label(&self.holon),
-        })
+        Ok(rule_descriptor)
     }
 
     fn flatten_property_descriptors(
         &self,
         relationship_name: CoreRelationshipTypeName,
     ) -> Result<Vec<PropertyDescriptor>, HolonError> {
-        flatten_related_members(&self.holon, relationship_name)
-            .map(|members| members.into_iter().map(PropertyDescriptor::from_holon).collect())
+        flatten_named_related_members(&self.holon, relationship_name, "property", |member| {
+            PropertyDescriptor::from_holon(member.clone())
+                .header()
+                .type_name()
+                .map(|name| name.to_string())
+        })
+        .map(|members| members.into_iter().map(PropertyDescriptor::from_holon).collect())
+    }
+
+    fn compose_inherited_boolean(
+        &self,
+        property_name: CorePropertyTypeName,
+    ) -> Result<bool, HolonError> {
+        let values = walk_extends_chain(&self.holon)
+            .map(|descriptor| {
+                descriptor.and_then(|descriptor| {
+                    accessor_helpers::require_bool(&descriptor, property_name.clone())
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        descriptor_semantics::compose_restrictive_boolean(values)
+            .ok_or_else(|| HolonError::InvalidState("empty descriptor lineage".to_string()))
     }
 }
 
@@ -473,6 +459,26 @@ mod tests {
         assert!(descriptor.allows_additional_properties()?);
         assert!(!descriptor.allows_additional_relationships()?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn structural_flags_compose_restrictively_across_extends() -> Result<(), HolonError> {
+        let context = build_context();
+        let mut parent = new_descriptor_holon(&context, "open-parent", "OpenParent")?;
+        parent
+            .with_property_value(CorePropertyTypeName::AllowsAdditionalProperties, true)?
+            .with_property_value(CorePropertyTypeName::AllowsAdditionalRelationships, true)?;
+        let mut child = new_descriptor_holon(&context, "closed-child", "ClosedChild")?;
+        child
+            .with_property_value(CorePropertyTypeName::AllowsAdditionalProperties, false)?
+            .with_property_value(CorePropertyTypeName::AllowsAdditionalRelationships, true)?
+            .add_related_holons(CoreRelationshipTypeName::Extends, vec![parent.into()])?;
+
+        let descriptor = HolonDescriptor::from_holon(child.into());
+
+        assert!(!descriptor.allows_additional_properties()?);
+        assert!(descriptor.allows_additional_relationships()?);
         Ok(())
     }
 

--- a/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/holon_descriptor.rs
@@ -404,10 +404,7 @@ mod tests {
         let staged_descriptor = context.mutation().stage_new_holon(descriptor)?;
         let source = new_test_holon(&context, "source-staged")?;
         let mut staged_source = context.mutation().stage_new_holon(source)?;
-        staged_source.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![staged_descriptor.into()],
-        )?;
+        staged_source.with_descriptor(staged_descriptor.into())?;
 
         let resolved = staged_source.holon_descriptor()?;
 

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -1,9 +1,10 @@
-use std::collections::HashSet;
-
 use crate::descriptors::accessor_helpers::{descriptor_label, lock_error, search_extends_chain};
 use crate::reference_layer::{HolonReference, ReadableHolon};
 use base_types::BaseValue;
 use core_types::HolonError;
+use descriptor_semantics::{
+    DescriptorGraph, DescriptorSemanticsError, ExtendsTraversal as SemanticExtendsTraversal,
+};
 use type_names::{CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName};
 
 /// Direction of a relationship type descriptor relative to its declared edge.
@@ -15,22 +16,61 @@ pub enum RelationshipDirection {
     Inverse,
 }
 
-/// Resolves the direct `Extends` parent for a descriptor holon.
-///
-/// Cardinality is enforced here so all iterator-based callers inherit the same
-/// multiple-parent error semantics.
-pub(crate) fn extends_parent(holon: &HolonReference) -> Result<Option<HolonReference>, HolonError> {
-    let collection_arc = holon.related_holons(CoreRelationshipTypeName::Extends)?;
-    let collection = collection_arc.read().map_err(lock_error)?;
-    let members = collection.get_members();
+struct HolonReferenceGraph;
 
-    match members.as_slice() {
-        [] => Ok(None),
-        [single] => Ok(Some(single.clone())),
-        many => Err(HolonError::MultipleExtends {
-            descriptor: descriptor_label(holon),
-            count: many.len(),
-        }),
+impl DescriptorGraph for HolonReferenceGraph {
+    type Node = HolonReference;
+    type Identity = String;
+    type MemberKind = CoreRelationshipTypeName;
+    type Error = HolonError;
+
+    fn identity(&self, node: &Self::Node) -> Self::Identity {
+        node.reference_id_string()
+    }
+
+    fn extends_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+        related_members(node, CoreRelationshipTypeName::Extends)
+    }
+
+    fn described_by_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+        related_members(node, CoreRelationshipTypeName::DescribedBy)
+    }
+
+    fn related_members(
+        &self,
+        node: &Self::Node,
+        member_kind: &Self::MemberKind,
+    ) -> Result<Vec<Self::Node>, Self::Error> {
+        related_members(node, member_kind.clone())
+    }
+
+    fn is_type_descriptor(&self, node: &Self::Node) -> Result<bool, Self::Error> {
+        is_type_descriptor_descriptor(node)
+    }
+}
+
+fn related_members(
+    holon: &HolonReference,
+    relationship_name: CoreRelationshipTypeName,
+) -> Result<Vec<HolonReference>, HolonError> {
+    let collection_arc = holon.related_holons(relationship_name)?;
+    let collection = collection_arc.read().map_err(lock_error)?;
+    Ok(collection.get_members().to_vec())
+}
+
+fn map_semantics_error(error: DescriptorSemanticsError<HolonError, HolonReference>) -> HolonError {
+    match error {
+        DescriptorSemanticsError::Access(error) => error,
+        DescriptorSemanticsError::MultipleExtends { descriptor, count } => {
+            HolonError::MultipleExtends { descriptor: descriptor_label(&descriptor), count }
+        }
+        DescriptorSemanticsError::MultipleDescribedBy { .. } => HolonError::DuplicateError(
+            "DescribedBy".into(),
+            "Expected exactly one descriptor target".into(),
+        ),
+        DescriptorSemanticsError::CyclicExtends { descriptor } => {
+            HolonError::CyclicExtends { descriptor: descriptor_label(&descriptor) }
+        }
     }
 }
 
@@ -58,15 +98,8 @@ pub(crate) fn equals_or_extends(
     candidate: &HolonReference,
     anchor: &HolonReference,
 ) -> Result<bool, HolonError> {
-    let anchor_id = anchor.reference_id_string();
-
-    for ancestor in walk_extends_chain(candidate) {
-        if ancestor?.reference_id_string() == anchor_id {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
+    descriptor_semantics::equals_or_extends(&HolonReferenceGraph, candidate, anchor)
+        .map_err(map_semantics_error)
 }
 
 /// Computes the effective descriptor lineage for a holon(per MAP Type System) v1.2.
@@ -77,29 +110,17 @@ pub(crate) fn equals_or_extends(
 pub fn effective_descriptor_lineage(
     holon: &HolonReference,
 ) -> Result<Vec<HolonReference>, HolonError> {
-    let Some(described_by_descriptor) = described_by_descriptor(holon)? else {
-        return ancestors(holon);
-    };
-
-    if is_type_descriptor_descriptor(&described_by_descriptor)? {
-        let mut lineage = ancestors(holon)?;
-        append_unique(&mut lineage, ancestors(&described_by_descriptor)?);
-        return Ok(lineage);
-    }
-
-    ancestors(&described_by_descriptor)
+    descriptor_semantics::effective_descriptor_lineage(&HolonReferenceGraph, holon)
+        .map_err(map_semantics_error)
 }
 
 pub(crate) fn described_by_descriptor(
     holon: &HolonReference,
 ) -> Result<Option<HolonReference>, HolonError> {
-    let collection_arc = holon.related_holons(CoreRelationshipTypeName::DescribedBy)?;
-    let collection = collection_arc.read().map_err(lock_error)?;
-    let members = collection.get_members();
-
-    match members.as_slice() {
+    let targets = HolonReferenceGraph.described_by_targets(holon)?;
+    match targets.as_slice() {
         [] => Ok(None),
-        [single] => Ok(Some(single.clone())),
+        [descriptor] => Ok(Some(descriptor.clone())),
         _ => Err(HolonError::DuplicateError(
             "DescribedBy".into(),
             "Expected exactly one descriptor target".into(),
@@ -113,16 +134,6 @@ fn is_type_descriptor_descriptor(descriptor: &HolonReference) -> Result<bool, Ho
         Some(BaseValue::StringValue(type_name)) => Ok(type_name == expected),
         Some(BaseValue::EnumValue(type_name)) => Ok(type_name.0 == expected),
         Some(_) | None => Ok(false),
-    }
-}
-
-fn append_unique(lineage: &mut Vec<HolonReference>, additional: Vec<HolonReference>) {
-    let mut seen = lineage.iter().map(HolonReference::reference_id_string).collect::<HashSet<_>>();
-
-    for descriptor in additional {
-        if seen.insert(descriptor.reference_id_string()) {
-            lineage.push(descriptor);
-        }
     }
 }
 
@@ -165,47 +176,21 @@ pub(crate) fn flatten_related_members(
     start: &HolonReference,
     relationship_name: CoreRelationshipTypeName,
 ) -> Result<Vec<HolonReference>, HolonError> {
-    let mut members = Vec::new();
-    let mut seen = HashSet::new();
-
-    for ancestor in walk_extends_chain(start) {
-        let ancestor = ancestor?;
-        let collection_arc = ancestor.related_holons(relationship_name.clone())?;
-        let collection = collection_arc.read().map_err(lock_error)?;
-
-        for member in collection.get_members() {
-            if seen.insert(member.reference_id_string()) {
-                members.push(member.clone());
-            }
-        }
-    }
-
-    Ok(members)
+    descriptor_semantics::flatten_related_members(&HolonReferenceGraph, start, &relationship_name)
+        .map_err(map_semantics_error)
 }
 
 /// Lazy iterator over a descriptor's `Extends` lineage.
 ///
-/// State model:
-/// - `next` is the next descriptor to yield
-/// - `pending_error` stores a structural error discovered while preparing the
-///   next step
-/// - `visited` tracks already-yielded descriptors for cycle detection
-/// - `finished` marks terminal exhaustion after either the root or an error
+/// Traversal state and structural policy are owned by `descriptor_semantics`;
+/// this wrapper preserves the established runtime iterator and `HolonError` API.
 pub struct ExtendsIter {
-    next: Option<HolonReference>,
-    pending_error: Option<HolonError>,
-    visited: HashSet<String>,
-    finished: bool,
+    traversal: SemanticExtendsTraversal<HolonReference, String, HolonError>,
 }
 
 impl ExtendsIter {
     fn new(start: &HolonReference) -> Self {
-        Self {
-            next: Some(start.clone()),
-            pending_error: None,
-            visited: HashSet::new(),
-            finished: false,
-        }
+        Self { traversal: SemanticExtendsTraversal::new(start.clone()) }
     }
 }
 
@@ -213,47 +198,11 @@ impl Iterator for ExtendsIter {
     type Item = Result<HolonReference, HolonError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Terminal state: once the chain is exhausted or an error has been
-        // emitted, iteration stays closed.
-        if self.finished {
-            return None;
-        }
-
-        // Deferred error emission preserves the current item for callers that
-        // intentionally stop early (for example, first-match inheritance lookups).
-        if let Some(error) = self.pending_error.take() {
-            self.finished = true;
-            return Some(Err(error));
-        }
-
-        let current = self.next.take()?;
-        // Cycle detection relies on reference_id_string() being a stable,
-        // collision-resistant identity for each concrete holon reference. Do
-        // not implement reference_id_string() with lossy display fallbacks such
-        // as "<invalid utf-8>" for binary saved IDs.
-        self.visited.insert(current.reference_id_string());
-
-        // Resolve the next step after capturing the current item. This keeps
-        // the iterator self-first while still surfacing cycles and
-        // multiple-parent structures on the following call.
-        match extends_parent(&current) {
-            Ok(Some(parent)) => {
-                if self.visited.contains(&parent.reference_id_string()) {
-                    self.pending_error =
-                        Some(HolonError::CyclicExtends { descriptor: descriptor_label(&parent) });
-                } else {
-                    self.next = Some(parent);
-                }
-            }
-            Ok(None) => {
-                self.finished = true;
-            }
-            Err(error) => {
-                self.pending_error = Some(error);
-            }
-        }
-
-        Some(Ok(current))
+        self.traversal
+            .next_with(HolonReference::reference_id_string, |current| {
+                HolonReferenceGraph.extends_targets(current)
+            })
+            .map(|result| result.map_err(map_semantics_error))
     }
 }
 

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -122,11 +122,10 @@ pub(crate) fn equals_or_extends(
         .map_err(map_semantics_error)
 }
 
-/// Computes the effective descriptor lineage for a holon(per MAP Type System) v1.2.
+/// Computes the effective lineage for a holon (MAP Type System v1.2).
 ///
-/// Ordinary instances use the `Extends` lineage of their `DescribedBy` descriptor.
-/// Descriptor holons additionally contribute their own `Extends` lineage before
-/// the effective lineage of their describing `TypeDescriptor` descriptor.
+/// The result is the ordered identity union of the holon's own type lineage and the lineage of its
+/// exactly one `DescribedBy` target. Ordinary holons have no own lineage.
 pub fn effective_descriptor_lineage(
     holon: &HolonReference,
 ) -> Result<Vec<HolonReference>, HolonError> {
@@ -149,10 +148,9 @@ pub(crate) fn described_by_descriptor(
 }
 
 fn is_type_descriptor_descriptor(descriptor: &HolonReference) -> Result<bool, HolonError> {
-    let expected = CoreHolonTypeName::TypeDescriptor.as_holon_name();
-    match descriptor.property_value(CorePropertyTypeName::TypeName)? {
-        Some(BaseValue::StringValue(type_name)) => Ok(type_name == expected),
-        Some(BaseValue::EnumValue(type_name)) => Ok(type_name.0 == expected),
+    const TYPE_DESCRIPTOR_KEY: &str = "TypeDescriptor.HolonType";
+    match descriptor.property_value(CorePropertyTypeName::Key)? {
+        Some(BaseValue::StringValue(key)) => Ok(key.0 == TYPE_DESCRIPTOR_KEY),
         Some(_) | None => Ok(false),
     }
 }
@@ -371,7 +369,7 @@ mod tests {
     }
 
     #[test]
-    fn effective_descriptor_lineage_for_descriptor_combines_own_and_describing_lineages(
+    fn effective_descriptor_lineage_for_type_combines_own_and_describing_lineages(
     ) -> Result<(), HolonError> {
         let context = build_context();
         let meta_type_descriptor =
@@ -386,6 +384,11 @@ mod tests {
             "MetaTypeDescriptor.Instance",
             "MetaTypeDescriptor",
             "Holon",
+        )?;
+
+        type_descriptor.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&type_descriptor)],
         )?;
 
         meta_holon_type.add_related_holons(

--- a/shared_crates/holons_core/src/descriptors/inheritance.rs
+++ b/shared_crates/holons_core/src/descriptors/inheritance.rs
@@ -68,8 +68,28 @@ fn map_semantics_error(error: DescriptorSemanticsError<HolonError, HolonReferenc
             "DescribedBy".into(),
             "Expected exactly one descriptor target".into(),
         ),
+        DescriptorSemanticsError::MissingDescribedBy { holon } => {
+            HolonError::MissingRequiredRelationship {
+                relationship: "DescribedBy".to_string(),
+                descriptor: descriptor_label(&holon),
+            }
+        }
         DescriptorSemanticsError::CyclicExtends { descriptor } => {
             HolonError::CyclicExtends { descriptor: descriptor_label(&descriptor) }
+        }
+        DescriptorSemanticsError::MultipleRelatedMembers { descriptor, kind, count } => {
+            HolonError::MultipleRelatedHolons {
+                relationship: kind.to_string(),
+                descriptor: descriptor_label(&descriptor),
+                count,
+            }
+        }
+        DescriptorSemanticsError::DuplicateInheritedDeclaration { descriptor, kind, name } => {
+            HolonError::DuplicateInheritedDeclaration {
+                kind: kind.to_string(),
+                name,
+                descriptor: descriptor_label(&descriptor),
+            }
         }
     }
 }
@@ -178,6 +198,50 @@ pub(crate) fn flatten_related_members(
 ) -> Result<Vec<HolonReference>, HolonError> {
     descriptor_semantics::flatten_related_members(&HolonReferenceGraph, start, &relationship_name)
         .map_err(map_semantics_error)
+}
+
+/// Collects inherited members and rejects distinct declarations with the same semantic name.
+pub(crate) fn flatten_named_related_members(
+    start: &HolonReference,
+    relationship_name: CoreRelationshipTypeName,
+    declaration_kind: &'static str,
+    semantic_name: impl FnMut(&HolonReference) -> Result<String, HolonError>,
+) -> Result<Vec<HolonReference>, HolonError> {
+    descriptor_semantics::flatten_named_members(
+        &HolonReferenceGraph,
+        start,
+        &relationship_name,
+        declaration_kind,
+        semantic_name,
+    )
+    .map_err(map_semantics_error)
+}
+
+pub(crate) fn collect_named_related_members_from_lineage(
+    lineage: impl IntoIterator<Item = HolonReference>,
+    relationship_name: CoreRelationshipTypeName,
+    declaration_kind: &'static str,
+    semantic_name: impl FnMut(&HolonReference) -> Result<String, HolonError>,
+) -> Result<Vec<HolonReference>, HolonError> {
+    descriptor_semantics::collect_named_members_from_lineage(
+        &HolonReferenceGraph,
+        lineage,
+        &relationship_name,
+        declaration_kind,
+        semantic_name,
+    )
+    .map_err(map_semantics_error)
+}
+
+pub(crate) fn effective_instance_key_rule(
+    descriptor: &HolonReference,
+) -> Result<Option<HolonReference>, HolonError> {
+    descriptor_semantics::effective_instance_key_rule(
+        &HolonReferenceGraph,
+        descriptor,
+        &CoreRelationshipTypeName::UsesKeyRule,
+    )
+    .map_err(map_semantics_error)
 }
 
 /// Lazy iterator over a descriptor's `Extends` lineage.

--- a/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
+++ b/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
@@ -23,8 +23,8 @@ mod tests {
     use super::*;
     use crate::core_shared_objects::transactions::TransactionContext;
     use crate::descriptors::test_support::{
-        build_context, core_holon_type_name, new_descriptor_holon, new_holon_type_descriptor,
-        new_relationship_descriptor_holon, new_test_holon,
+        build_context, core_holon_type_name, describe_as_type, new_descriptor_holon,
+        new_holon_type_descriptor, new_relationship_descriptor_holon, new_test_holon,
     };
     use crate::reference_layer::{StagedReference, TransientReference, WritableHolon};
     use base_types::MapString;
@@ -64,31 +64,32 @@ mod tests {
             &core_holon_type_name(CoreHolonTypeName::InverseRelationshipType),
             "Relationship",
         )?)?;
-        let source_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
-            &context,
-            "book-type",
-            "BookType",
-        )?)?;
+        let mut source_type_transient =
+            new_holon_type_descriptor(&context, "book-type", "BookType")?;
+        describe_as_type(&context, &mut source_type_transient)?;
+        let source_type = context.mutation().stage_new_holon(source_type_transient)?;
         let target_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
             &context,
             "person-type",
             "PersonType",
         )?)?;
 
-        let declared_transient = new_relationship_descriptor_holon(
+        let mut declared_transient = new_relationship_descriptor_holon(
             &context,
             "declared-relationship",
             relationship_name,
             (&source_type).into(),
             (&target_type).into(),
         )?;
-        let inverse_transient = new_relationship_descriptor_holon(
+        describe_as_type(&context, &mut declared_transient)?;
+        let mut inverse_transient = new_relationship_descriptor_holon(
             &context,
             "inverse-relationship",
             inverse_name,
             (&target_type).into(),
             (&source_type).into(),
         )?;
+        describe_as_type(&context, &mut inverse_transient)?;
 
         let mut declared = context.mutation().stage_new_holon(declared_transient)?;
         let mut inverse = context.mutation().stage_new_holon(inverse_transient)?;
@@ -153,8 +154,8 @@ mod tests {
 
         assert!(matches!(
             resolve_inverse_relationship_name(&(&source).into(), &authored_by()),
-            Err(HolonError::DescriptorDeclarationNotFound { kind, name, .. })
-                if kind == "relationship" && name == "AuthoredBy"
+            Err(HolonError::MissingRequiredRelationship { relationship, .. })
+                if relationship == "DescribedBy"
         ));
         Ok(())
     }
@@ -163,21 +164,34 @@ mod tests {
     fn resolves_descriptor_holon_relationship_through_own_extends_lineage() -> Result<(), HolonError>
     {
         let context = build_context();
-        let type_descriptor = context.mutation().stage_new_holon(new_holon_type_descriptor(
-            &context,
-            "type-descriptor",
-            "TypeDescriptor",
-        )?)?;
-        let meta_relationship_type = context.mutation().stage_new_holon(
-            new_holon_type_descriptor(&context, "meta-relationship-type", "MetaRelationshipType")?,
+        let mut type_descriptor_transient =
+            new_holon_type_descriptor(&context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+        type_descriptor_transient.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&type_descriptor_transient)],
         )?;
-        let mut declared_relationship_type =
-            context.mutation().stage_new_holon(new_descriptor_holon(
-                &context,
-                "declared-relationship-type-for-source-type",
-                &core_holon_type_name(CoreHolonTypeName::DeclaredRelationshipType),
-                "Relationship",
-            )?)?;
+        let type_descriptor = context.mutation().stage_new_holon(type_descriptor_transient)?;
+        let mut meta_relationship_type_transient =
+            new_holon_type_descriptor(&context, "meta-relationship-type", "MetaRelationshipType")?;
+        describe_as_type(&context, &mut meta_relationship_type_transient)?;
+        let meta_relationship_type =
+            context.mutation().stage_new_holon(meta_relationship_type_transient)?;
+        let mut declared_relationship_type_transient = new_descriptor_holon(
+            &context,
+            "declared-relationship-type-for-source-type",
+            &core_holon_type_name(CoreHolonTypeName::DeclaredRelationshipType),
+            "Relationship",
+        )?;
+        declared_relationship_type_transient.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![(&type_descriptor).into()],
+        )?;
+        declared_relationship_type_transient.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![(&meta_relationship_type).into()],
+        )?;
+        let declared_relationship_type =
+            context.mutation().stage_new_holon(declared_relationship_type_transient)?;
         let inverse_relationship_type =
             context.mutation().stage_new_holon(new_descriptor_holon(
                 &context,
@@ -186,27 +200,25 @@ mod tests {
                 "Relationship",
             )?)?;
 
-        let source_type_transient = new_relationship_descriptor_holon(
+        let mut source_type_transient = new_relationship_descriptor_holon(
             &context,
             "source-type",
             "SourceType",
             (&meta_relationship_type).into(),
             (&type_descriptor).into(),
         )?;
-        let source_for_transient = new_relationship_descriptor_holon(
+        describe_as_type(&context, &mut source_type_transient)?;
+        let mut source_for_transient = new_relationship_descriptor_holon(
             &context,
             "source-for",
             "SourceFor",
             (&type_descriptor).into(),
             (&meta_relationship_type).into(),
         )?;
+        describe_as_type(&context, &mut source_for_transient)?;
         let mut source_type = context.mutation().stage_new_holon(source_type_transient)?;
         let mut source_for = context.mutation().stage_new_holon(source_for_transient)?;
 
-        declared_relationship_type.add_related_holons(
-            CoreRelationshipTypeName::Extends,
-            vec![(&meta_relationship_type).into()],
-        )?;
         source_type.add_related_holons(
             CoreRelationshipTypeName::Extends,
             vec![declared_relationship_type.into()],
@@ -224,20 +236,18 @@ mod tests {
             vec![(&source_type).into()],
         )?;
 
+        let mut concrete_relationship_transient = new_relationship_descriptor_holon(
+            &context,
+            "affords-operator",
+            "AffordsOperator",
+            (&meta_relationship_type).into(),
+            (&type_descriptor).into(),
+        )?;
+        describe_as_type(&context, &mut concrete_relationship_transient)?;
         let mut concrete_relationship =
-            context.mutation().stage_new_holon(new_relationship_descriptor_holon(
-                &context,
-                "affords-operator",
-                "AffordsOperator",
-                (&meta_relationship_type).into(),
-                (&type_descriptor).into(),
-            )?)?;
+            context.mutation().stage_new_holon(concrete_relationship_transient)?;
         concrete_relationship
             .add_related_holons(CoreRelationshipTypeName::Extends, vec![(&source_type).into()])?;
-        concrete_relationship.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![type_descriptor.into()],
-        )?;
 
         let inverse_name = resolve_inverse_relationship_name(
             &(&concrete_relationship).into(),
@@ -269,13 +279,15 @@ mod tests {
             &core_holon_type_name(CoreHolonTypeName::InverseRelationshipType),
             "Relationship",
         )?)?;
+        let mut wrong_kind_relationship = new_descriptor_holon(
+            &fixture.context,
+            "wrong-kind-authored-by",
+            "AuthoredBy",
+            "Relationship",
+        )?;
+        describe_as_type(&fixture.context, &mut wrong_kind_relationship)?;
         let mut wrong_kind_relationship =
-            fixture.context.mutation().stage_new_holon(new_descriptor_holon(
-                &fixture.context,
-                "wrong-kind-authored-by",
-                "AuthoredBy",
-                "Relationship",
-            )?)?;
+            fixture.context.mutation().stage_new_holon(wrong_kind_relationship)?;
         wrong_kind_relationship
             .add_related_holons(CoreRelationshipTypeName::Extends, vec![inverse_type.into()])?;
         let mut source_type = fixture.source_type.clone();

--- a/shared_crates/holons_core/src/descriptors/test_support.rs
+++ b/shared_crates/holons_core/src/descriptors/test_support.rs
@@ -180,6 +180,69 @@ pub(crate) fn new_holon_type_descriptor(
     Ok(descriptor)
 }
 
+/// Attaches the canonical TypeDescriptor identity to a descriptor fixture.
+///
+/// Runtime authoring tests use this before staging or otherwise invoking descriptor semantics; the
+/// semantic kernel intentionally does not treat a missing `DescribedBy` as a partial own lineage.
+pub(crate) fn describe_as_type(
+    context: &Arc<TransactionContext>,
+    descriptor: &mut TransientReference,
+) -> Result<StagedReference, HolonError> {
+    let bootstrap_type_descriptor =
+        new_holon_type_descriptor(context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+    let mut bootstrap_type_descriptor =
+        context.mutation().stage_new_holon(bootstrap_type_descriptor)?;
+    bootstrap_type_descriptor.with_descriptor(HolonReference::from(&bootstrap_type_descriptor))?;
+
+    let mut declared_relationship_type = new_descriptor_holon(
+        context,
+        "test-declared-relationship-type",
+        &core_holon_type_name(CoreHolonTypeName::DeclaredRelationshipType),
+        TypeKind::Relationship,
+    )?;
+    declared_relationship_type.with_descriptor(HolonReference::from(&bootstrap_type_descriptor))?;
+    let declared_relationship_type =
+        context.mutation().stage_new_holon(declared_relationship_type)?;
+
+    let structural_relationships = [
+        CoreRelationshipTypeName::Extends,
+        CoreRelationshipTypeName::HasInverse,
+        CoreRelationshipTypeName::InstanceRelationships,
+        CoreRelationshipTypeName::InverseOf,
+        CoreRelationshipTypeName::TargetOf,
+    ];
+    let mut relationship_declarations = Vec::with_capacity(structural_relationships.len());
+    for relationship_name in structural_relationships {
+        let semantic_name = relationship_name.as_relationship_name().to_string();
+        let mut relationship_descriptor = new_relationship_descriptor_holon(
+            context,
+            &format!("test-{semantic_name}-relationship"),
+            &semantic_name,
+            HolonReference::from(&bootstrap_type_descriptor),
+            HolonReference::from(&bootstrap_type_descriptor),
+        )?;
+        relationship_descriptor
+            .with_descriptor(HolonReference::from(&bootstrap_type_descriptor))?;
+        relationship_descriptor.add_related_holons(
+            CoreRelationshipTypeName::Extends,
+            vec![HolonReference::from(&declared_relationship_type)],
+        )?;
+        relationship_declarations
+            .push(context.mutation().stage_new_holon(relationship_descriptor)?.into());
+    }
+
+    let mut type_descriptor =
+        new_holon_type_descriptor(context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+    type_descriptor.add_related_holons(
+        CoreRelationshipTypeName::InstanceRelationships,
+        relationship_declarations,
+    )?;
+    let mut type_descriptor = context.mutation().stage_new_holon(type_descriptor)?;
+    type_descriptor.with_descriptor(HolonReference::from(&type_descriptor))?;
+    descriptor.with_descriptor(HolonReference::from(&type_descriptor))?;
+    Ok(type_descriptor)
+}
+
 /// Creates a property descriptor with structural fields and its value type edge.
 pub(crate) fn new_property_descriptor_holon(
     context: &Arc<TransactionContext>,

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/constraints.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/constraints.rs
@@ -3,6 +3,10 @@ use crate::descriptors::inheritance::{flatten_related_members, walk_extends_chai
 use crate::descriptors::TypeHeader;
 use crate::reference_layer::HolonReference;
 use core_types::{HolonError, SchemaInvalidityKind};
+use descriptor_semantics::{
+    validate_integer_maximum, validate_integer_minimum, validate_string_maximum_length,
+    validate_string_minimum_length,
+};
 use type_names::{CoreHolonTypeName, CorePropertyTypeName, CoreRelationshipTypeName};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -73,7 +77,7 @@ struct ConstraintClassification {
 
 impl IntegerConstraintValidation for MinimumValueConstraint {
     fn is_valid(&self, value: i64, descriptor_label: &str) -> Result<(), HolonError> {
-        if value > self.value || (self.inclusive && value == self.value) {
+        if validate_integer_minimum(value, self.value, self.inclusive).is_ok() {
             return Ok(());
         }
 
@@ -90,7 +94,7 @@ impl IntegerConstraintValidation for MinimumValueConstraint {
 
 impl IntegerConstraintValidation for MaximumValueConstraint {
     fn is_valid(&self, value: i64, descriptor_label: &str) -> Result<(), HolonError> {
-        if value < self.value || (self.inclusive && value == self.value) {
+        if validate_integer_maximum(value, self.value, self.inclusive).is_ok() {
             return Ok(());
         }
 
@@ -108,7 +112,7 @@ impl IntegerConstraintValidation for MaximumValueConstraint {
 impl StringConstraintValidation for MinimumLengthConstraint {
     fn is_valid(&self, value: &str, descriptor_label: &str) -> Result<(), HolonError> {
         let length = value.chars().count();
-        if (length as i128) >= i128::from(self.length) {
+        if validate_string_minimum_length(value, self.length).is_ok() {
             return Ok(());
         }
 
@@ -124,7 +128,7 @@ impl StringConstraintValidation for MinimumLengthConstraint {
 impl StringConstraintValidation for MaximumLengthConstraint {
     fn is_valid(&self, value: &str, descriptor_label: &str) -> Result<(), HolonError> {
         let length = value.chars().count();
-        if (length as i128) <= i128::from(self.length) {
+        if validate_string_maximum_length(value, self.length).is_ok() {
             return Ok(());
         }
 

--- a/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/enum_value_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/value_descriptor_subtypes/enum_value_descriptor.rs
@@ -9,6 +9,7 @@ use crate::descriptors::{Descriptor, OperatorDescriptor, TypeHeader};
 use crate::reference_layer::HolonReference;
 use base_types::BaseValue;
 use core_types::HolonError;
+use descriptor_semantics::validate_enum_variant;
 use type_names::CoreRelationshipTypeName;
 
 /// Semantic wrapper for enum value descriptors.
@@ -34,7 +35,8 @@ impl EnumValueDescriptor {
             other => return Err(value_kind_mismatch(&self.holon, "Enum", other)),
         };
 
-        if self.declared_variants()?.contains(&variant) {
+        let declared_variants = self.declared_variants()?;
+        if validate_enum_variant(&variant, declared_variants.iter().map(String::as_str)).is_ok() {
             return Ok(());
         }
 

--- a/shared_crates/holons_core/src/reference_layer/available_relationships.rs
+++ b/shared_crates/holons_core/src/reference_layer/available_relationships.rs
@@ -10,10 +10,9 @@
 //! | uncommitted `StagedReference`   | yes      | no      |
 //! | `TransientReference`            | yes      | no      |
 //!
-//! The declared side is collected from `effective_descriptor_lineage`, so
-//! descriptor holon sources include declared relationships from their own
-//! `Extends` lineage. The inverse side remains anchored on the source holon's
-//! `DescribedBy` descriptor and is consulted only for committed sources.
+//! The declared side is collected from the source holon's effective lineage, so type holons include
+//! declarations from both their own and describing-type lineages. The inverse side remains anchored
+//! on the source holon's `DescribedBy` descriptor and is consulted only for committed sources.
 
 use crate::descriptors::{
     accessor_helpers, effective_descriptor_lineage,
@@ -60,8 +59,8 @@ mod tests {
     use super::*;
     use crate::core_shared_objects::Holon;
     use crate::descriptors::test_support::{
-        build_context, core_holon_type_name, new_descriptor_holon, new_holon_type_descriptor,
-        new_relationship_descriptor_holon, new_test_holon,
+        build_context, core_holon_type_name, describe_as_type, new_descriptor_holon,
+        new_holon_type_descriptor, new_relationship_descriptor_holon, new_test_holon,
     };
     use crate::descriptors::RelationshipDirection;
     use crate::reference_layer::{
@@ -105,43 +104,47 @@ mod tests {
             &core_holon_type_name(CoreHolonTypeName::InverseRelationshipType),
             "Relationship",
         )?)?;
-        let mut source_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
-            &context,
-            &format!("{key_prefix}-book-type"),
-            "BookType",
-        )?)?;
-        let mut target_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
+        let mut source_type_transient =
+            new_holon_type_descriptor(&context, &format!("{key_prefix}-book-type"), "BookType")?;
+        describe_as_type(&context, &mut source_type_transient)?;
+        let mut target_type_transient = new_holon_type_descriptor(
             &context,
             &format!("{key_prefix}-person-type"),
             "PersonType",
-        )?)?;
+        )?;
+        describe_as_type(&context, &mut target_type_transient)?;
+        let mut source_type = context.mutation().stage_new_holon(source_type_transient)?;
+        let mut target_type = context.mutation().stage_new_holon(target_type_transient)?;
         let club_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
             &context,
             &format!("{key_prefix}-club-type"),
             "ClubType",
         )?)?;
 
-        let authored_by_transient = new_relationship_descriptor_holon(
+        let mut authored_by_transient = new_relationship_descriptor_holon(
             &context,
             &format!("{key_prefix}-authored-by"),
             "AuthoredBy",
             HolonReference::from(&source_type),
             HolonReference::from(&target_type),
         )?;
-        let authors_transient = new_relationship_descriptor_holon(
+        describe_as_type(&context, &mut authored_by_transient)?;
+        let mut authors_transient = new_relationship_descriptor_holon(
             &context,
             &format!("{key_prefix}-authors"),
             "Authors",
             HolonReference::from(&target_type),
             HolonReference::from(&source_type),
         )?;
-        let member_of_transient = new_relationship_descriptor_holon(
+        describe_as_type(&context, &mut authors_transient)?;
+        let mut member_of_transient = new_relationship_descriptor_holon(
             &context,
             &format!("{key_prefix}-member-of"),
             "MemberOf",
             HolonReference::from(&target_type),
             HolonReference::from(&club_type),
         )?;
+        describe_as_type(&context, &mut member_of_transient)?;
         let mut authored_by = context.mutation().stage_new_holon(authored_by_transient)?;
         let mut authors = context.mutation().stage_new_holon(authors_transient)?;
         let mut member_of = context.mutation().stage_new_holon(member_of_transient)?;
@@ -213,10 +216,7 @@ mod tests {
         let fixture = build_availability_fixture("avail-uncommitted-ref")?;
         let source = new_test_holon(&fixture.context, "avail-uncommitted-person")?;
         let mut staged_source = fixture.context.mutation().stage_new_holon(source)?;
-        staged_source.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![HolonReference::from(&fixture.target_type)],
-        )?;
+        staged_source.with_descriptor(HolonReference::from(&fixture.target_type))?;
 
         let names = qualified_names(&staged_source.available_relationships()?)?;
 
@@ -229,10 +229,7 @@ mod tests {
         let fixture = build_availability_fixture("avail-committed-ref")?;
         let source = new_test_holon(&fixture.context, "avail-committed-person")?;
         let mut staged_source = fixture.context.mutation().stage_new_holon(source)?;
-        staged_source.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![HolonReference::from(&fixture.target_type)],
-        )?;
+        staged_source.with_descriptor(HolonReference::from(&fixture.target_type))?;
         mark_committed(&fixture.context, &staged_source)?;
 
         let names = qualified_names(&staged_source.available_relationships()?)?;
@@ -247,8 +244,12 @@ mod tests {
     fn descriptor_holon_source_includes_own_lineage_declared_relationships(
     ) -> Result<(), HolonError> {
         let context = build_context();
-        let type_descriptor =
-            new_holon_type_descriptor(&context, "avail-type-descriptor", "TypeDescriptor")?;
+        let mut type_descriptor =
+            new_holon_type_descriptor(&context, "TypeDescriptor.HolonType", "TypeDescriptor")?;
+        type_descriptor.add_related_holons(
+            CoreRelationshipTypeName::DescribedBy,
+            vec![HolonReference::from(&type_descriptor)],
+        )?;
         let mut meta_relationship_type = new_holon_type_descriptor(
             &context,
             "avail-meta-relationship-type",

--- a/shared_crates/holons_core/src/reference_layer/staged_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/staged_reference.rs
@@ -237,6 +237,14 @@ impl StagedReference {
             relationship_name.clone(),
         ) {
             Ok(descriptor) => descriptor,
+            Err(HolonError::MissingRequiredRelationship { relationship, .. })
+                if staged_state == StagedState::ForCreate && relationship == "DescribedBy" =>
+            {
+                return Ok(RelationshipMutationPolicy {
+                    note_definitional: None,
+                    duplicate_policy: DuplicatePolicy::Ungoverned,
+                });
+            }
             Err(
                 original_error @ HolonError::DescriptorDeclarationNotFound {
                     kind: _,
@@ -854,8 +862,8 @@ mod tests {
     use crate::{
         core_shared_objects::StagedHolon,
         descriptors::test_support::{
-            build_context, core_holon_type_name, new_descriptor_holon, new_holon_type_descriptor,
-            new_relationship_descriptor_holon, new_test_holon,
+            build_context, core_holon_type_name, describe_as_type, new_descriptor_holon,
+            new_holon_type_descriptor, new_relationship_descriptor_holon, new_test_holon,
         },
         reference_layer::WritableHolon,
     };
@@ -895,7 +903,8 @@ mod tests {
         relationship_name: &str,
         is_definitional: Option<bool>,
     ) -> Result<(StagedReference, StagedReference), HolonError> {
-        let source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        let mut source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        describe_as_type(context, &mut source_type)?;
         let target_type = new_holon_type_descriptor(context, "target-type", "TargetType")?;
         let staged_source_type = context.mutation().stage_new_holon(source_type)?;
         let staged_target_type = context.mutation().stage_new_holon(target_type)?;
@@ -935,7 +944,8 @@ mod tests {
         context: &Arc<TransactionContext>,
         relationship_name: &str,
     ) -> Result<(StagedReference, StagedReference), HolonError> {
-        let source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        let mut source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        describe_as_type(context, &mut source_type)?;
         let target_type = new_holon_type_descriptor(context, "target-type", "TargetType")?;
         let staged_source_type = context.mutation().stage_new_holon(source_type)?;
         let staged_target_type = context.mutation().stage_new_holon(target_type)?;
@@ -967,7 +977,8 @@ mod tests {
         is_definitional: Option<BaseValue>,
         allows_duplicates: Option<BaseValue>,
     ) -> Result<(StagedReference, StagedReference), HolonError> {
-        let source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        let mut source_type = new_holon_type_descriptor(context, "source-type", "SourceType")?;
+        describe_as_type(context, &mut source_type)?;
         let target_type = new_holon_type_descriptor(context, "target-type", "TargetType")?;
         let staged_source_type = context.mutation().stage_new_holon(source_type)?;
         let staged_target_type = context.mutation().stage_new_holon(target_type)?;
@@ -1021,31 +1032,32 @@ mod tests {
             &core_holon_type_name(CoreHolonTypeName::InverseRelationshipType),
             "Relationship",
         )?)?;
-        let mut source_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
+        let mut source_type_transient =
+            new_holon_type_descriptor(context, "book-type", "BookType")?;
+        describe_as_type(context, &mut source_type_transient)?;
+        let mut target_type_transient =
+            new_holon_type_descriptor(context, "person-type", "PersonType")?;
+        describe_as_type(context, &mut target_type_transient)?;
+        let mut source_type = context.mutation().stage_new_holon(source_type_transient)?;
+        let mut target_type = context.mutation().stage_new_holon(target_type_transient)?;
+        let mut declared_transient = new_relationship_descriptor_holon(
             context,
-            "book-type",
-            "BookType",
-        )?)?;
-        let mut target_type = context.mutation().stage_new_holon(new_holon_type_descriptor(
-            context,
-            "person-type",
-            "PersonType",
-        )?)?;
-        let mut declared =
-            context.mutation().stage_new_holon(new_relationship_descriptor_holon(
-                context,
-                "authored-by",
-                "AuthoredBy",
-                HolonReference::from(&source_type),
-                HolonReference::from(&target_type),
-            )?)?;
-        let mut inverse = context.mutation().stage_new_holon(new_relationship_descriptor_holon(
+            "authored-by",
+            "AuthoredBy",
+            HolonReference::from(&source_type),
+            HolonReference::from(&target_type),
+        )?;
+        describe_as_type(context, &mut declared_transient)?;
+        let mut inverse_transient = new_relationship_descriptor_holon(
             context,
             "authors",
             "Authors",
             HolonReference::from(&target_type),
             HolonReference::from(&source_type),
-        )?)?;
+        )?;
+        describe_as_type(context, &mut inverse_transient)?;
+        let mut declared = context.mutation().stage_new_holon(declared_transient)?;
+        let mut inverse = context.mutation().stage_new_holon(inverse_transient)?;
 
         declared
             .add_related_holons(CoreRelationshipTypeName::Extends, vec![declared_type.into()])?;
@@ -1070,10 +1082,7 @@ mod tests {
     ) -> Result<StagedReference, HolonError> {
         let source = new_test_holon(context, "source-instance")?;
         let mut staged_source = context.mutation().stage_new_holon(source)?;
-        staged_source.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![source_descriptor.into()],
-        )?;
+        staged_source.with_descriptor(source_descriptor.into())?;
         force_staged_reference_for_update(context, &staged_source)?;
         Ok(staged_source)
     }
@@ -1131,6 +1140,7 @@ mod tests {
 
         staged_source.add_related_holons("UndeclaredRelationship", vec![target.into()])?;
 
+        assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 1);
         assert!(staged_source.is_in_state(&context, StagedState::ForCreate)?);
         Ok(())
     }
@@ -1205,7 +1215,8 @@ mod tests {
         let mut staged_source = context.mutation().stage_new_holon(source)?;
         let target = staged_target(&context, "new-target")?;
 
-        staged_source.add_related_holons("UndeclaredRelationship", vec![target.clone().into()])?;
+        staged_source
+            .add_related_holons_ungoverned("UndeclaredRelationship", vec![target.clone().into()])?;
         staged_source.with_descriptor(source_descriptor.into())?;
         assert_eq!(relationship_member_count(&staged_source, "UndeclaredRelationship")?, 1);
 
@@ -1247,10 +1258,7 @@ mod tests {
             staged_relationship_descriptor(&context, "AuthoredBy", Some(false))?;
         let source = new_test_holon(&context, "source-instance")?;
         let mut staged_source = context.mutation().stage_new_holon(source)?;
-        staged_source.add_related_holons(
-            CoreRelationshipTypeName::DescribedBy,
-            vec![source_descriptor.into()],
-        )?;
+        staged_source.with_descriptor(source_descriptor.into())?;
         let target = staged_target(&context, "author")?;
 
         staged_source.add_related_holons("AuthoredBy", vec![target.clone().into()])?;
@@ -1267,7 +1275,8 @@ mod tests {
     #[test]
     fn duplicate_inherited_declaration_surfaces_through_mutation() -> Result<(), HolonError> {
         let context = build_context();
-        let source_type = new_holon_type_descriptor(&context, "source-type", "SourceType")?;
+        let mut source_type = new_holon_type_descriptor(&context, "source-type", "SourceType")?;
+        describe_as_type(&context, &mut source_type)?;
         let target_type = new_holon_type_descriptor(&context, "target-type", "TargetType")?;
         let staged_source_type = context.mutation().stage_new_holon(source_type)?;
         let staged_target_type = context.mutation().stage_new_holon(target_type)?;

--- a/shared_crates/map_schema_semantic/Cargo.toml
+++ b/shared_crates/map_schema_semantic/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-
+descriptor_semantics = { path = "../descriptor_semantics" }

--- a/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
@@ -1,0 +1,393 @@
+//! Descriptor-driven conformance over Canonical Holon IR.
+//!
+//! This module is the representation adapter: it resolves effective declarations from canonical
+//! holons, delegates policy evaluation to `descriptor_semantics`, and projects neutral violations
+//! into shared diagnostics. It intentionally contains no property-specific validation rules.
+
+use std::collections::HashSet;
+
+use descriptor_semantics::{
+    effective_descriptor_lineage, property_requirement, validate_holon_conformance,
+    value_policy_for_type_kind, ConformanceValue, ConformanceViolation, DescriptorGraph,
+    DescriptorSemanticsError, HolonConformance, PropertyDeclaration, PropertyValue,
+    RelationshipDeclaration, RelationshipValue, ValuePolicy,
+};
+
+use crate::{
+    CanonicalDescriptorGraph, CanonicalGraphError, CanonicalNodeId, Diagnostic, DiagnosticKind,
+    DiagnosticLayer, LiteralValue,
+};
+
+/// Runs descriptor-driven conformance for every holon exposed by the canonical graph.
+///
+/// Callers may retain legacy/model-wide passes alongside this result while migrating checks; this
+/// pass itself applies one descriptor-driven path to schema, descriptor, and ordinary holons.
+pub fn validate_canonical_model_conformance(graph: &CanonicalDescriptorGraph) -> Vec<Diagnostic> {
+    graph.nodes().flat_map(|node| validate_canonical_holon_conformance(graph, node)).collect()
+}
+
+/// Validates one canonical holon using declarations resolved from its effective descriptor graph.
+pub fn validate_canonical_holon_conformance(
+    graph: &CanonicalDescriptorGraph,
+    node: CanonicalNodeId,
+) -> Vec<Diagnostic> {
+    let input = match conformance_input(graph, node) {
+        Ok(input) => input,
+        Err(ConformanceBuildError::Graph(error)) => return vec![graph.diagnostic(error)],
+        Err(ConformanceBuildError::InvalidDescriptor { descriptor, message }) => {
+            return vec![Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::DescriptorGraphAccess {
+                    holon: graph.key(node).unwrap_or("<unknown>").to_string(),
+                    relationship: "descriptor conformance".to_string(),
+                    target: Some(descriptor),
+                    message,
+                },
+                graph.holon(node).map(|holon| holon.origin.clone()),
+            )]
+        }
+    };
+
+    let holon = graph.key(node).unwrap_or("<unknown>").to_string();
+    let origin = graph.holon(node).map(|holon| holon.origin.clone());
+    validate_holon_conformance(&input)
+        .into_iter()
+        .map(|violation| project_violation(&holon, origin.clone(), violation))
+        .collect()
+}
+
+#[derive(Debug)]
+enum ConformanceBuildError {
+    Graph(DescriptorSemanticsError<CanonicalGraphError, CanonicalNodeId>),
+    InvalidDescriptor { descriptor: String, message: String },
+}
+
+fn conformance_input(
+    graph: &CanonicalDescriptorGraph,
+    node: CanonicalNodeId,
+) -> Result<HolonConformance, ConformanceBuildError> {
+    let holon = graph.holon(node).ok_or_else(|| ConformanceBuildError::InvalidDescriptor {
+        descriptor: format!("{node:?}"),
+        message: "canonical holon is absent".to_string(),
+    })?;
+    let lineage =
+        effective_descriptor_lineage(graph, &node).map_err(ConformanceBuildError::Graph)?;
+    let property_nodes = effective_members(graph, &lineage, "InstanceProperties")?;
+    let relationship_nodes = effective_members(graph, &lineage, "InstanceRelationships")?;
+
+    let property_declarations = property_nodes
+        .into_iter()
+        .map(|descriptor| property_declaration(graph, descriptor))
+        .collect::<Result<Vec<_>, _>>()?;
+    let relationship_declarations = relationship_nodes
+        .into_iter()
+        .map(|descriptor| relationship_declaration(graph, descriptor))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(HolonConformance {
+        properties: holon
+            .properties
+            .iter()
+            .map(|(name, value)| PropertyValue {
+                name: name.clone(),
+                value: conformance_value(value),
+            })
+            .collect(),
+        relationships: holon
+            .relationships
+            .iter()
+            .map(|relationship| RelationshipValue {
+                name: relationship.name.clone(),
+                target_count: relationship.targets.len(),
+            })
+            .collect(),
+        property_declarations,
+        relationship_declarations,
+        allows_additional_properties: lineage_boolean(
+            graph,
+            &lineage,
+            "allows_additional_properties",
+        ),
+        allows_additional_relationships: lineage_boolean(
+            graph,
+            &lineage,
+            "allows_additional_relationships",
+        ),
+    })
+}
+
+fn effective_members(
+    graph: &CanonicalDescriptorGraph,
+    lineage: &[CanonicalNodeId],
+    relationship: &str,
+) -> Result<Vec<CanonicalNodeId>, ConformanceBuildError> {
+    let mut members = Vec::new();
+    let mut seen = HashSet::new();
+    for descriptor in lineage {
+        for member in
+            graph.related_members(descriptor, &relationship.to_string()).map_err(|error| {
+                ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error))
+            })?
+        {
+            if seen.insert(graph.identity(&member)) {
+                members.push(member);
+            }
+        }
+    }
+    Ok(members)
+}
+
+fn property_declaration(
+    graph: &CanonicalDescriptorGraph,
+    descriptor: CanonicalNodeId,
+) -> Result<PropertyDeclaration, ConformanceBuildError> {
+    let holon = graph
+        .holon(descriptor)
+        .ok_or_else(|| invalid_descriptor(graph, descriptor, "missing property descriptor"))?;
+    let declared_name = string_property(holon, "property_name")
+        .or_else(|| string_property(holon, "type_name"))
+        .ok_or_else(|| {
+            invalid_descriptor(
+                graph,
+                descriptor,
+                "property descriptor has no property_name or type_name",
+            )
+        })?;
+    let requirement = property_requirement(declared_name);
+    let value_types = graph
+        .related_members(&descriptor, &"ValueType".to_string())
+        .map_err(|error| ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error)))?;
+    let value_policy = match value_types.as_slice() {
+        [] => ValuePolicy::Any,
+        [value_type] => value_policy(graph, *value_type)?,
+        many => {
+            return Err(invalid_descriptor(
+                graph,
+                descriptor,
+                &format!("property descriptor has {} ValueType targets; expected one", many.len()),
+            ))
+        }
+    };
+
+    Ok(PropertyDeclaration {
+        name: requirement.name.to_string(),
+        required: requirement.required,
+        value_policy,
+    })
+}
+
+fn relationship_declaration(
+    graph: &CanonicalDescriptorGraph,
+    descriptor: CanonicalNodeId,
+) -> Result<RelationshipDeclaration, ConformanceBuildError> {
+    let holon = graph
+        .holon(descriptor)
+        .ok_or_else(|| invalid_descriptor(graph, descriptor, "missing relationship descriptor"))?;
+    let name = string_property(holon, "relationship_name")
+        .or_else(|| string_property(holon, "type_name"))
+        .ok_or_else(|| {
+            invalid_descriptor(
+                graph,
+                descriptor,
+                "relationship descriptor has no relationship_name or type_name",
+            )
+        })?;
+    let minimum = integer_property(holon, "min_cardinality").unwrap_or(0);
+    let maximum = integer_property(holon, "max_cardinality").unwrap_or(i64::MAX);
+    if minimum < 0 || maximum < minimum {
+        return Err(invalid_descriptor(
+            graph,
+            descriptor,
+            &format!("invalid relationship cardinality {minimum}..{maximum}"),
+        ));
+    }
+    Ok(RelationshipDeclaration {
+        name: name.to_string(),
+        minimum: usize::try_from(minimum).unwrap_or(usize::MAX),
+        maximum: usize::try_from(maximum).unwrap_or(usize::MAX),
+    })
+}
+
+fn value_policy(
+    graph: &CanonicalDescriptorGraph,
+    value_type: CanonicalNodeId,
+) -> Result<ValuePolicy, ConformanceBuildError> {
+    let holon = graph
+        .holon(value_type)
+        .ok_or_else(|| invalid_descriptor(graph, value_type, "missing value descriptor"))?;
+    let variants = graph
+        .related_members(&value_type, &"Variants".to_string())
+        .map_err(|error| ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error)))?
+        .into_iter()
+        .filter_map(|variant| graph.key(variant).map(ToString::to_string))
+        .collect();
+    Ok(value_policy_for_type_kind(string_property(holon, "instance_type_kind"), variants))
+}
+
+fn lineage_boolean(
+    graph: &CanonicalDescriptorGraph,
+    lineage: &[CanonicalNodeId],
+    property: &str,
+) -> bool {
+    lineage
+        .iter()
+        .find_map(|node| graph.holon(*node)?.properties.get(property)?.as_bool())
+        .unwrap_or(false)
+}
+
+fn string_property<'a>(holon: &'a crate::CanonicalHolon, name: &str) -> Option<&'a str> {
+    holon.properties.get(name).and_then(LiteralValue::as_str)
+}
+
+fn integer_property(holon: &crate::CanonicalHolon, name: &str) -> Option<i64> {
+    holon.properties.get(name).and_then(LiteralValue::as_i64)
+}
+
+fn conformance_value(value: &LiteralValue) -> ConformanceValue {
+    match value {
+        LiteralValue::Null => ConformanceValue::Null,
+        LiteralValue::Boolean(value) => ConformanceValue::Boolean(*value),
+        LiteralValue::Integer(value) => ConformanceValue::Integer(*value),
+        LiteralValue::Number(value) => ConformanceValue::Number(value.clone()),
+        LiteralValue::String(value) => ConformanceValue::String(value.clone()),
+        LiteralValue::Array(_) => ConformanceValue::Array,
+        LiteralValue::Object(_) => ConformanceValue::Object,
+    }
+}
+
+fn invalid_descriptor(
+    graph: &CanonicalDescriptorGraph,
+    descriptor: CanonicalNodeId,
+    message: &str,
+) -> ConformanceBuildError {
+    ConformanceBuildError::InvalidDescriptor {
+        descriptor: graph.key(descriptor).unwrap_or("<unknown>").to_string(),
+        message: message.to_string(),
+    }
+}
+
+fn project_violation(
+    holon: &str,
+    origin: Option<crate::Origin>,
+    violation: ConformanceViolation,
+) -> Diagnostic {
+    let kind = match violation {
+        ConformanceViolation::MissingRequiredProperty { property } => {
+            DiagnosticKind::MissingConformanceProperty { holon: holon.to_string(), property }
+        }
+        ConformanceViolation::AdditionalProperty { property } => {
+            DiagnosticKind::AdditionalConformanceProperty { holon: holon.to_string(), property }
+        }
+        ConformanceViolation::WrongValueKind { property, expected } => {
+            DiagnosticKind::InvalidConformanceValue {
+                holon: holon.to_string(),
+                property,
+                value: "wrong literal kind".to_string(),
+                expected: expected.to_string(),
+            }
+        }
+        ConformanceViolation::UndeclaredEnumVariant { property, variant } => {
+            DiagnosticKind::InvalidConformanceValue {
+                holon: holon.to_string(),
+                property,
+                value: variant,
+                expected: "a variant declared by the resolved enum ValueType".to_string(),
+            }
+        }
+        ConformanceViolation::AdditionalRelationship { relationship } => {
+            DiagnosticKind::AdditionalConformanceRelationship {
+                holon: holon.to_string(),
+                relationship,
+            }
+        }
+        ConformanceViolation::RelationshipCardinality {
+            relationship,
+            actual,
+            minimum,
+            maximum,
+        } => DiagnosticKind::ConformanceRelationshipCardinality {
+            holon: holon.to_string(),
+            relationship,
+            actual,
+            minimum,
+            maximum,
+        },
+    };
+    Diagnostic::error(DiagnosticLayer::SchemaAware, kind, origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DescriptorKind, LiteralRelationship, Origin, ReferenceRole, SemanticModel,
+        SemanticReference, SourceKind, SymbolIndex, TypeDescriptor,
+    };
+
+    fn descriptor_of_kind(key: &str, kind: DescriptorKind) -> TypeDescriptor {
+        TypeDescriptor::new(key, key, kind, "TestSchema", Origin::new(SourceKind::Generated))
+    }
+
+    fn descriptor(key: &str) -> TypeDescriptor {
+        descriptor_of_kind(key, DescriptorKind::HolonType)
+    }
+
+    fn string_property_value(descriptor: &mut TypeDescriptor, name: &str, value: &str) {
+        descriptor.literal_properties.insert(name, LiteralValue::String(value.to_string()));
+    }
+
+    #[test]
+    fn invalid_enum_value_is_rejected_through_descriptor_data() {
+        let mut model = SemanticModel::new();
+        model.push_descriptor(descriptor("TypeDescriptor.HolonType"));
+
+        let mut enum_type = descriptor_of_kind("KindEnum", DescriptorKind::Enum);
+        string_property_value(&mut enum_type, "instance_type_kind", "TypeKind.Value.Enum");
+        enum_type.literal_relationships.push(LiteralRelationship {
+            name: "Variants".to_string(),
+            targets: vec!["Kind.One".to_string(), "Kind.Two".to_string()],
+        });
+        model.push_descriptor(enum_type);
+        model.push_descriptor(descriptor_of_kind("Kind.One", DescriptorKind::EnumVariant));
+        model.push_descriptor(descriptor_of_kind("Kind.Two", DescriptorKind::EnumVariant));
+
+        let mut property = descriptor_of_kind("Kind.PropertyType", DescriptorKind::PropertyType);
+        string_property_value(&mut property, "property_name", "kind");
+        property.literal_relationships.push(LiteralRelationship {
+            name: "ValueType".to_string(),
+            targets: vec!["KindEnum".to_string()],
+        });
+        model.push_descriptor(property);
+
+        let mut thing_type = descriptor("Thing.HolonType");
+        thing_type.instance_properties.push(SemanticReference::unresolved(
+            ReferenceRole::InstanceProperty,
+            "Kind.PropertyType",
+        ));
+        thing_type.allows_additional_properties = false;
+        model.push_descriptor(thing_type);
+
+        let mut thing = descriptor("Thing.One");
+        thing
+            .described_by
+            .push(SemanticReference::unresolved(ReferenceRole::DescribedBy, "Thing.HolonType"));
+        string_property_value(&mut thing, "kind", "Kind.Unknown");
+        model.push_descriptor(thing);
+
+        let (symbols, index_diagnostics) = SymbolIndex::build(&mut model);
+        assert!(index_diagnostics.is_empty(), "{index_diagnostics:?}");
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let diagnostics = validate_canonical_holon_conformance(
+            &graph,
+            graph.node_by_key("Thing.One").expect("thing"),
+        );
+
+        assert!(matches!(
+            diagnostics.as_slice(),
+            [Diagnostic {
+                kind: DiagnosticKind::InvalidConformanceValue { property, value, .. },
+                ..
+            }] if property == "kind" && value == "Kind.Unknown"
+        ));
+    }
+}

--- a/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
@@ -7,10 +7,11 @@
 use std::collections::HashSet;
 
 use descriptor_semantics::{
-    effective_descriptor_lineage, property_requirement, validate_holon_conformance,
-    value_policy_for_type_kind, ConformanceValue, ConformanceViolation, DescriptorGraph,
-    DescriptorSemanticsError, HolonConformance, PropertyDeclaration, PropertyValue,
-    RelationshipDeclaration, RelationshipValue, ValuePolicy,
+    compose_restrictive_boolean, describing_type, duplicate_declaration_name,
+    effective_descriptor_lineage, validate_holon_conformance, value_policy_for_type_kind,
+    ConformanceValue, ConformanceViolation, DescriptorGraph, DescriptorSemanticsError,
+    HolonConformance, PropertyDeclaration, PropertyValue, RelationshipDeclaration,
+    RelationshipValue, ValuePolicy,
 };
 
 use crate::{
@@ -23,7 +24,26 @@ use crate::{
 /// Callers may retain legacy/model-wide passes alongside this result while migrating checks; this
 /// pass itself applies one descriptor-driven path to schema, descriptor, and ordinary holons.
 pub fn validate_canonical_model_conformance(graph: &CanonicalDescriptorGraph) -> Vec<Diagnostic> {
-    graph.nodes().flat_map(|node| validate_canonical_holon_conformance(graph, node)).collect()
+    graph
+        .nodes()
+        .filter(|node| !graph.is_schema(*node))
+        .flat_map(|node| validate_canonical_holon_conformance(graph, node))
+        .collect()
+}
+
+/// Runs the production-ready value-policy subset of descriptor conformance.
+///
+/// This staged entry point validates primitive shape and enum membership for every property whose
+/// effective descriptor supplies a value policy. Required/member/cardinality diagnostics remain
+/// available through [`validate_canonical_model_conformance`] while the Core Schema corpus is
+/// brought into strict conformance.
+pub fn validate_canonical_model_values(graph: &CanonicalDescriptorGraph) -> Vec<Diagnostic> {
+    validate_canonical_model_conformance(graph)
+        .into_iter()
+        .filter(|diagnostic| {
+            matches!(diagnostic.kind, DiagnosticKind::InvalidConformanceValue { .. })
+        })
+        .collect()
 }
 
 /// Validates one canonical holon using declarations resolved from its effective descriptor graph.
@@ -33,19 +53,7 @@ pub fn validate_canonical_holon_conformance(
 ) -> Vec<Diagnostic> {
     let input = match conformance_input(graph, node) {
         Ok(input) => input,
-        Err(ConformanceBuildError::Graph(error)) => return vec![graph.diagnostic(error)],
-        Err(ConformanceBuildError::InvalidDescriptor { descriptor, message }) => {
-            return vec![Diagnostic::error(
-                DiagnosticLayer::SchemaAware,
-                DiagnosticKind::DescriptorGraphAccess {
-                    holon: graph.key(node).unwrap_or("<unknown>").to_string(),
-                    relationship: "descriptor conformance".to_string(),
-                    target: Some(descriptor),
-                    message,
-                },
-                graph.holon(node).map(|holon| holon.origin.clone()),
-            )]
-        }
+        Err(error) => return vec![conformance_build_diagnostic(graph, node, error)],
     };
 
     let holon = graph.key(node).unwrap_or("<unknown>").to_string();
@@ -56,10 +64,49 @@ pub fn validate_canonical_holon_conformance(
         .collect()
 }
 
+/// Resolves Boolean property declarations effective for one canonical holon.
+///
+/// Source adapters use this view to lower source-level Boolean default conventions into explicit
+/// canonical values without copying inheritance or value-type classification rules.
+pub fn effective_boolean_property_names(
+    graph: &CanonicalDescriptorGraph,
+    node: CanonicalNodeId,
+) -> Result<Vec<String>, Diagnostic> {
+    effective_property_declarations(graph, node)
+        .map(|declarations| {
+            declarations
+                .into_iter()
+                .filter(|declaration| declaration.value_policy == ValuePolicy::Boolean)
+                .map(|declaration| declaration.name)
+                .collect()
+        })
+        .map_err(|error| conformance_build_diagnostic(graph, node, error))
+}
+
 #[derive(Debug)]
 enum ConformanceBuildError {
     Graph(DescriptorSemanticsError<CanonicalGraphError, CanonicalNodeId>),
     InvalidDescriptor { descriptor: String, message: String },
+}
+
+fn conformance_build_diagnostic(
+    graph: &CanonicalDescriptorGraph,
+    node: CanonicalNodeId,
+    error: ConformanceBuildError,
+) -> Diagnostic {
+    match error {
+        ConformanceBuildError::Graph(error) => graph.diagnostic(error),
+        ConformanceBuildError::InvalidDescriptor { descriptor, message } => Diagnostic::error(
+            DiagnosticLayer::SchemaAware,
+            DiagnosticKind::DescriptorGraphAccess {
+                holon: graph.key(node).unwrap_or("<unknown>").to_string(),
+                relationship: "descriptor conformance".to_string(),
+                target: Some(descriptor),
+                message,
+            },
+            graph.holon(node).map(|holon| holon.origin.clone()),
+        ),
+    }
 }
 
 fn conformance_input(
@@ -70,49 +117,90 @@ fn conformance_input(
         descriptor: format!("{node:?}"),
         message: "canonical holon is absent".to_string(),
     })?;
+    describing_type(graph, &node).map_err(ConformanceBuildError::Graph)?;
     let lineage =
         effective_descriptor_lineage(graph, &node).map_err(ConformanceBuildError::Graph)?;
-    let property_nodes = effective_members(graph, &lineage, "InstanceProperties")?;
     let relationship_nodes = effective_members(graph, &lineage, "InstanceRelationships")?;
 
-    let property_declarations = property_nodes
-        .into_iter()
-        .map(|descriptor| property_declaration(graph, descriptor))
-        .collect::<Result<Vec<_>, _>>()?;
+    let property_declarations = effective_property_declarations(graph, node)?;
     let relationship_declarations = relationship_nodes
         .into_iter()
         .map(|descriptor| relationship_declaration(graph, descriptor))
         .collect::<Result<Vec<_>, _>>()?;
+    reject_duplicate_declarations(
+        graph,
+        &lineage,
+        "relationship",
+        &relationship_declarations,
+        |item| &item.name,
+    )?;
+
+    let mut properties = holon
+        .properties
+        .iter()
+        .map(|(name, value)| PropertyValue { name: name.clone(), value: conformance_value(value) })
+        .collect::<Vec<_>>();
+    align_property_names(&mut properties, &property_declarations);
+    let relationships = holon
+        .relationships
+        .iter()
+        .map(|relationship| RelationshipValue {
+            name: relationship.name.clone(),
+            target_count: relationship.targets.len(),
+        })
+        .collect::<Vec<_>>();
 
     Ok(HolonConformance {
-        properties: holon
-            .properties
-            .iter()
-            .map(|(name, value)| PropertyValue {
-                name: name.clone(),
-                value: conformance_value(value),
-            })
-            .collect(),
-        relationships: holon
-            .relationships
-            .iter()
-            .map(|relationship| RelationshipValue {
-                name: relationship.name.clone(),
-                target_count: relationship.targets.len(),
-            })
-            .collect(),
+        properties,
+        relationships,
         property_declarations,
         relationship_declarations,
         allows_additional_properties: lineage_boolean(
             graph,
             &lineage,
             "allows_additional_properties",
-        ),
+        )?,
         allows_additional_relationships: lineage_boolean(
             graph,
             &lineage,
             "allows_additional_relationships",
-        ),
+        )?,
+    })
+}
+
+fn effective_property_declarations(
+    graph: &CanonicalDescriptorGraph,
+    node: CanonicalNodeId,
+) -> Result<Vec<PropertyDeclaration>, ConformanceBuildError> {
+    describing_type(graph, &node).map_err(ConformanceBuildError::Graph)?;
+    let lineage =
+        effective_descriptor_lineage(graph, &node).map_err(ConformanceBuildError::Graph)?;
+    let property_nodes = effective_members(graph, &lineage, "InstanceProperties")?;
+    let declarations = property_nodes
+        .into_iter()
+        .map(|descriptor| property_declaration(graph, descriptor))
+        .collect::<Result<Vec<_>, _>>()?;
+    reject_duplicate_declarations(graph, &lineage, "property", &declarations, |item| &item.name)?;
+    Ok(declarations)
+}
+
+fn reject_duplicate_declarations<T>(
+    graph: &CanonicalDescriptorGraph,
+    lineage: &[CanonicalNodeId],
+    kind: &str,
+    declarations: &[T],
+    name: impl Fn(&T) -> &str,
+) -> Result<(), ConformanceBuildError> {
+    let Some(duplicate) =
+        duplicate_declaration_name(declarations.iter().map(|item| name(item).to_string()))
+    else {
+        return Ok(());
+    };
+    let descriptor =
+        lineage.first().and_then(|node| graph.key(*node)).unwrap_or("<unknown>").to_string();
+    Err(ConformanceBuildError::InvalidDescriptor {
+        descriptor,
+        message: format!("distinct inherited {kind} declarations share the name `{duplicate}`"),
     })
 }
 
@@ -153,7 +241,9 @@ fn property_declaration(
                 "property descriptor has no property_name or type_name",
             )
         })?;
-    let requirement = property_requirement(declared_name);
+    let required = literal_property(holon, "is_required")
+        .and_then(LiteralValue::as_bool)
+        .ok_or_else(|| invalid_descriptor(graph, descriptor, "missing Boolean is_required"))?;
     let value_types = graph
         .related_members(&descriptor, &"ValueType".to_string())
         .map_err(|error| ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error)))?;
@@ -169,11 +259,28 @@ fn property_declaration(
         }
     };
 
-    Ok(PropertyDeclaration {
-        name: requirement.name.to_string(),
-        required: requirement.required,
-        value_policy,
-    })
+    Ok(PropertyDeclaration { name: declared_name.to_string(), required, value_policy })
+}
+
+fn align_property_names(properties: &mut [PropertyValue], declarations: &[PropertyDeclaration]) {
+    for property in properties {
+        let candidates = declarations
+            .iter()
+            .filter(|declaration| {
+                normalized_member_name(&declaration.name) == normalized_member_name(&property.name)
+            })
+            .collect::<Vec<_>>();
+        if let [declaration] = candidates.as_slice() {
+            property.name = declaration.name.clone();
+        }
+    }
+}
+
+fn normalized_member_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn relationship_declaration(
@@ -192,8 +299,10 @@ fn relationship_declaration(
                 "relationship descriptor has no relationship_name or type_name",
             )
         })?;
-    let minimum = integer_property(holon, "min_cardinality").unwrap_or(0);
-    let maximum = integer_property(holon, "max_cardinality").unwrap_or(i64::MAX);
+    let minimum = integer_property(holon, "min_cardinality")
+        .ok_or_else(|| invalid_descriptor(graph, descriptor, "missing integer min_cardinality"))?;
+    let maximum = integer_property(holon, "max_cardinality")
+        .ok_or_else(|| invalid_descriptor(graph, descriptor, "missing integer max_cardinality"))?;
     if minimum < 0 || maximum < minimum {
         return Err(invalid_descriptor(
             graph,
@@ -219,28 +328,60 @@ fn value_policy(
         .related_members(&value_type, &"Variants".to_string())
         .map_err(|error| ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error)))?
         .into_iter()
-        .filter_map(|variant| graph.key(variant).map(ToString::to_string))
+        .flat_map(|variant| {
+            let mut aliases = Vec::new();
+            if let Some(key) = graph.key(variant) {
+                aliases.push(key.to_string());
+            }
+            if let Some(type_name) =
+                graph.holon(variant).and_then(|holon| string_property(holon, "type_name"))
+            {
+                aliases.push(type_name.to_string());
+            }
+            aliases
+        })
         .collect();
-    Ok(value_policy_for_type_kind(string_property(holon, "instance_type_kind"), variants))
+    Ok(value_policy_for_type_kind(string_property(holon, "TypeKind"), variants))
 }
 
 fn lineage_boolean(
     graph: &CanonicalDescriptorGraph,
     lineage: &[CanonicalNodeId],
     property: &str,
-) -> bool {
-    lineage
-        .iter()
-        .find_map(|node| graph.holon(*node)?.properties.get(property)?.as_bool())
-        .unwrap_or(false)
+) -> Result<bool, ConformanceBuildError> {
+    let mut values = Vec::with_capacity(lineage.len());
+    for node in lineage {
+        let holon = graph.holon(*node).ok_or_else(|| ConformanceBuildError::InvalidDescriptor {
+            descriptor: format!("{node:?}"),
+            message: "canonical holon is absent".to_string(),
+        })?;
+        let value =
+            literal_property(holon, property).and_then(LiteralValue::as_bool).ok_or_else(|| {
+                invalid_descriptor(graph, *node, &format!("missing Boolean {property}"))
+            })?;
+        values.push(value);
+    }
+    compose_restrictive_boolean(values).ok_or_else(|| ConformanceBuildError::InvalidDescriptor {
+        descriptor: "<empty describing type lineage>".to_string(),
+        message: format!("cannot resolve {property}"),
+    })
 }
 
 fn string_property<'a>(holon: &'a crate::CanonicalHolon, name: &str) -> Option<&'a str> {
-    holon.properties.get(name).and_then(LiteralValue::as_str)
+    literal_property(holon, name).and_then(LiteralValue::as_str)
 }
 
 fn integer_property(holon: &crate::CanonicalHolon, name: &str) -> Option<i64> {
-    holon.properties.get(name).and_then(LiteralValue::as_i64)
+    literal_property(holon, name).and_then(LiteralValue::as_i64)
+}
+
+fn literal_property<'a>(holon: &'a crate::CanonicalHolon, name: &str) -> Option<&'a LiteralValue> {
+    let normalized = normalized_member_name(name);
+    holon
+        .properties
+        .iter()
+        .find(|(candidate, _)| normalized_member_name(candidate) == normalized)
+        .map(|(_, value)| value)
 }
 
 fn conformance_value(value: &LiteralValue) -> ConformanceValue {
@@ -342,7 +483,7 @@ mod tests {
         model.push_descriptor(descriptor("TypeDescriptor.HolonType"));
 
         let mut enum_type = descriptor_of_kind("KindEnum", DescriptorKind::Enum);
-        string_property_value(&mut enum_type, "instance_type_kind", "TypeKind.Value.Enum");
+        enum_type.instance_type_kind = Some("TypeKind.Value.Enum".to_string());
         enum_type.literal_relationships.push(LiteralRelationship {
             name: "Variants".to_string(),
             targets: vec!["Kind.One".to_string(), "Kind.Two".to_string()],
@@ -353,6 +494,7 @@ mod tests {
 
         let mut property = descriptor_of_kind("Kind.PropertyType", DescriptorKind::PropertyType);
         string_property_value(&mut property, "property_name", "kind");
+        property.property_required = Some(true);
         property.literal_relationships.push(LiteralRelationship {
             name: "ValueType".to_string(),
             targets: vec!["KindEnum".to_string()],
@@ -364,7 +506,12 @@ mod tests {
             ReferenceRole::InstanceProperty,
             "Kind.PropertyType",
         ));
-        thing_type.allows_additional_properties = false;
+        thing_type
+            .literal_properties
+            .insert("allows_additional_properties".to_string(), LiteralValue::Boolean(false));
+        thing_type
+            .literal_properties
+            .insert("allows_additional_relationships".to_string(), LiteralValue::Boolean(false));
         model.push_descriptor(thing_type);
 
         let mut thing = descriptor("Thing.One");
@@ -382,12 +529,13 @@ mod tests {
             graph.node_by_key("Thing.One").expect("thing"),
         );
 
-        assert!(matches!(
-            diagnostics.as_slice(),
-            [Diagnostic {
-                kind: DiagnosticKind::InvalidConformanceValue { property, value, .. },
-                ..
-            }] if property == "kind" && value == "Kind.Unknown"
-        ));
+        assert!(
+            diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                DiagnosticKind::InvalidConformanceValue { property, value, .. }
+                    if property == "kind" && value == "Kind.Unknown"
+            )),
+            "{diagnostics:#?}"
+        );
     }
 }

--- a/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_conformance.rs
@@ -4,10 +4,8 @@
 //! holons, delegates policy evaluation to `descriptor_semantics`, and projects neutral violations
 //! into shared diagnostics. It intentionally contains no property-specific validation rules.
 
-use std::collections::HashSet;
-
 use descriptor_semantics::{
-    compose_restrictive_boolean, describing_type, duplicate_declaration_name,
+    collect_named_members_from_lineage, compose_restrictive_boolean, describing_type,
     effective_descriptor_lineage, validate_holon_conformance, value_policy_for_type_kind,
     ConformanceValue, ConformanceViolation, DescriptorGraph, DescriptorSemanticsError,
     HolonConformance, PropertyDeclaration, PropertyValue, RelationshipDeclaration,
@@ -120,20 +118,19 @@ fn conformance_input(
     describing_type(graph, &node).map_err(ConformanceBuildError::Graph)?;
     let lineage =
         effective_descriptor_lineage(graph, &node).map_err(ConformanceBuildError::Graph)?;
-    let relationship_nodes = effective_members(graph, &lineage, "InstanceRelationships")?;
+    let relationship_nodes = effective_named_members(
+        graph,
+        &lineage,
+        "InstanceRelationships",
+        "relationship",
+        &["relationship_name", "type_name"],
+    )?;
 
     let property_declarations = effective_property_declarations(graph, node)?;
     let relationship_declarations = relationship_nodes
         .into_iter()
         .map(|descriptor| relationship_declaration(graph, descriptor))
         .collect::<Result<Vec<_>, _>>()?;
-    reject_duplicate_declarations(
-        graph,
-        &lineage,
-        "relationship",
-        &relationship_declarations,
-        |item| &item.name,
-    )?;
 
     let mut properties = holon
         .properties
@@ -175,54 +172,49 @@ fn effective_property_declarations(
     describing_type(graph, &node).map_err(ConformanceBuildError::Graph)?;
     let lineage =
         effective_descriptor_lineage(graph, &node).map_err(ConformanceBuildError::Graph)?;
-    let property_nodes = effective_members(graph, &lineage, "InstanceProperties")?;
+    let property_nodes = effective_named_members(
+        graph,
+        &lineage,
+        "InstanceProperties",
+        "property",
+        &["property_name", "type_name"],
+    )?;
     let declarations = property_nodes
         .into_iter()
         .map(|descriptor| property_declaration(graph, descriptor))
         .collect::<Result<Vec<_>, _>>()?;
-    reject_duplicate_declarations(graph, &lineage, "property", &declarations, |item| &item.name)?;
     Ok(declarations)
 }
 
-fn reject_duplicate_declarations<T>(
-    graph: &CanonicalDescriptorGraph,
-    lineage: &[CanonicalNodeId],
-    kind: &str,
-    declarations: &[T],
-    name: impl Fn(&T) -> &str,
-) -> Result<(), ConformanceBuildError> {
-    let Some(duplicate) =
-        duplicate_declaration_name(declarations.iter().map(|item| name(item).to_string()))
-    else {
-        return Ok(());
-    };
-    let descriptor =
-        lineage.first().and_then(|node| graph.key(*node)).unwrap_or("<unknown>").to_string();
-    Err(ConformanceBuildError::InvalidDescriptor {
-        descriptor,
-        message: format!("distinct inherited {kind} declarations share the name `{duplicate}`"),
-    })
-}
-
-fn effective_members(
+fn effective_named_members(
     graph: &CanonicalDescriptorGraph,
     lineage: &[CanonicalNodeId],
     relationship: &str,
+    declaration_kind: &'static str,
+    name_properties: &[&str],
 ) -> Result<Vec<CanonicalNodeId>, ConformanceBuildError> {
-    let mut members = Vec::new();
-    let mut seen = HashSet::new();
-    for descriptor in lineage {
-        for member in
-            graph.related_members(descriptor, &relationship.to_string()).map_err(|error| {
-                ConformanceBuildError::Graph(DescriptorSemanticsError::Access(error))
-            })?
-        {
-            if seen.insert(graph.identity(&member)) {
-                members.push(member);
-            }
-        }
-    }
-    Ok(members)
+    collect_named_members_from_lineage(
+        graph,
+        lineage.iter().copied(),
+        &relationship.to_string(),
+        declaration_kind,
+        |node| {
+            let holon =
+                graph.holon(*node).ok_or(CanonicalGraphError::UnknownNode { node: *node })?;
+            name_properties
+                .iter()
+                .find_map(|property| string_property(holon, property))
+                .map(ToString::to_string)
+                .ok_or_else(|| CanonicalGraphError::InvalidDescriptorData {
+                    node: *node,
+                    message: format!(
+                        "{declaration_kind} descriptor has no semantic name in {}",
+                        name_properties.join(" or ")
+                    ),
+                })
+        },
+    )
+    .map_err(ConformanceBuildError::Graph)
 }
 
 fn property_declaration(
@@ -480,7 +472,12 @@ mod tests {
     #[test]
     fn invalid_enum_value_is_rejected_through_descriptor_data() {
         let mut model = SemanticModel::new();
-        model.push_descriptor(descriptor("TypeDescriptor.HolonType"));
+        let mut type_descriptor = descriptor("TypeDescriptor.HolonType");
+        type_descriptor.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
+        model.push_descriptor(type_descriptor);
 
         let mut enum_type = descriptor_of_kind("KindEnum", DescriptorKind::Enum);
         enum_type.instance_type_kind = Some("TypeKind.Value.Enum".to_string());
@@ -502,6 +499,10 @@ mod tests {
         model.push_descriptor(property);
 
         let mut thing_type = descriptor("Thing.HolonType");
+        thing_type.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
         thing_type.instance_properties.push(SemanticReference::unresolved(
             ReferenceRole::InstanceProperty,
             "Kind.PropertyType",

--- a/shared_crates/map_schema_semantic/src/descriptor_graph.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_graph.rs
@@ -123,6 +123,11 @@ impl CanonicalDescriptorGraph {
         self.nodes_by_key.get(key).copied()
     }
 
+    /// Iterates all canonical graph nodes in deterministic model order.
+    pub fn nodes(&self) -> impl Iterator<Item = CanonicalNodeId> + '_ {
+        (0..self.holons.len()).map(CanonicalNodeId)
+    }
+
     /// Returns generic holon data for a graph node.
     pub fn holon(&self, node: CanonicalNodeId) -> Option<&CanonicalHolon> {
         self.holons.get(node.0)

--- a/shared_crates/map_schema_semantic/src/descriptor_graph.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_graph.rs
@@ -4,7 +4,10 @@
 //! relationship target collections to `descriptor_semantics`, then projects kernel failures into
 //! the shared diagnostic vocabulary at this representation boundary.
 
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use descriptor_semantics::{DescriptorGraph, DescriptorSemanticsError};
 
@@ -79,6 +82,7 @@ pub struct CanonicalDescriptorGraph {
     holons: Vec<CanonicalHolon>,
     nodes_by_key: HashMap<String, CanonicalNodeId>,
     type_descriptor_nodes: Vec<CanonicalNodeId>,
+    schema_nodes: HashSet<CanonicalNodeId>,
     symbols: SymbolIndex,
 }
 
@@ -115,7 +119,19 @@ impl CanonicalDescriptorGraph {
             .filter_map(|key| nodes_by_key.get(key).copied())
             .collect();
 
-        Ok(Self { holons, nodes_by_key, type_descriptor_nodes, symbols: symbols.clone() })
+        let schema_nodes = model
+            .schemas
+            .iter()
+            .filter_map(|schema| nodes_by_key.get(&schema.key).copied())
+            .collect();
+
+        Ok(Self {
+            holons,
+            nodes_by_key,
+            type_descriptor_nodes,
+            schema_nodes,
+            symbols: symbols.clone(),
+        })
     }
 
     /// Returns the node with the supplied canonical key.
@@ -126,6 +142,11 @@ impl CanonicalDescriptorGraph {
     /// Iterates all canonical graph nodes in deterministic model order.
     pub fn nodes(&self) -> impl Iterator<Item = CanonicalNodeId> + '_ {
         (0..self.holons.len()).map(CanonicalNodeId)
+    }
+
+    /// Returns whether the node is a schema container rather than a descriptor-governed holon.
+    pub fn is_schema(&self, node: CanonicalNodeId) -> bool {
+        self.schema_nodes.contains(&node)
     }
 
     /// Returns generic holon data for a graph node.
@@ -150,11 +171,37 @@ impl CanonicalDescriptorGraph {
             DescriptorSemanticsError::MultipleDescribedBy { holon, count } => {
                 self.cardinality_diagnostic(holon, "DescribedBy", count)
             }
+            DescriptorSemanticsError::MissingDescribedBy { holon } => Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::DescriptorGraphAccess {
+                    holon: self.node_label(holon),
+                    relationship: "DescribedBy".to_string(),
+                    target: None,
+                    message: "expected exactly one target; found 0".to_string(),
+                },
+                self.origin(holon),
+            ),
             DescriptorSemanticsError::CyclicExtends { descriptor } => {
                 let key = self.node_label(descriptor);
                 Diagnostic::error(
                     DiagnosticLayer::SchemaAware,
                     DiagnosticKind::InheritanceCycle { descriptor: key.clone(), target: key },
+                    self.origin(descriptor),
+                )
+            }
+            DescriptorSemanticsError::MultipleRelatedMembers { descriptor, kind, count } => {
+                self.cardinality_diagnostic(descriptor, kind, count)
+            }
+            DescriptorSemanticsError::DuplicateInheritedDeclaration { descriptor, kind, name } => {
+                Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    DiagnosticKind::DescriptorGraphAccess {
+                        holon: self.node_label(descriptor),
+                        relationship: format!("effective {kind} declarations"),
+                        target: Some(name),
+                        message: "distinct inherited declarations have the same semantic name"
+                            .to_string(),
+                    },
                     self.origin(descriptor),
                 )
             }

--- a/shared_crates/map_schema_semantic/src/descriptor_graph.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_graph.rs
@@ -1,0 +1,465 @@
+//! Canonical Holon IR adapter for representation-neutral descriptor semantics.
+//!
+//! The adapter owns no inheritance or conformance policy. It exposes stable holon identity and raw
+//! relationship target collections to `descriptor_semantics`, then projects kernel failures into
+//! the shared diagnostic vocabulary at this representation boundary.
+
+use std::{collections::HashMap, fmt};
+
+use descriptor_semantics::{DescriptorGraph, DescriptorSemanticsError};
+
+use crate::{
+    CanonicalHolon, CanonicalReference, Diagnostic, DiagnosticKind, DiagnosticLayer, Origin,
+    SemanticModel, SymbolIndex,
+};
+
+/// Canonical Core Schema identity used by the default descriptor graph bootstrap contract.
+pub const TYPE_DESCRIPTOR_BOOTSTRAP_KEY: &str = "TypeDescriptor.HolonType";
+
+/// Minimal explicit bootstrap identities needed before descriptor data can describe itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalGraphBootstrap {
+    pub type_descriptor_keys: Vec<String>,
+}
+
+impl Default for CanonicalGraphBootstrap {
+    fn default() -> Self {
+        Self { type_descriptor_keys: vec![TYPE_DESCRIPTOR_BOOTSTRAP_KEY.to_string()] }
+    }
+}
+
+/// Build-local handle for a holon in a [`CanonicalDescriptorGraph`].
+///
+/// The handle is deliberately opaque. [`DescriptorGraph::identity`] returns the canonical holon key
+/// used for cycle detection and deduplication, so vector position never becomes semantic identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CanonicalNodeId(usize);
+
+/// Failure while constructing the Canonical Holon IR graph adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalGraphBuildError {
+    DuplicateIdentity { key: String },
+}
+
+impl fmt::Display for CanonicalGraphBuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateIdentity { key } => {
+                write!(formatter, "canonical holon identity `{key}` occurs more than once")
+            }
+        }
+    }
+}
+
+/// Representation access failure encountered while the semantics kernel traverses Canonical IR.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalGraphError {
+    UnknownNode { node: CanonicalNodeId },
+    UnresolvedTarget { source: CanonicalNodeId, relationship: String, target: String },
+    ResolvedTargetOutsideModel { source: CanonicalNodeId, relationship: String, target: String },
+}
+
+impl fmt::Display for CanonicalGraphError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownNode { node } => write!(formatter, "unknown canonical node {node:?}"),
+            Self::UnresolvedTarget { relationship, target, .. } => {
+                write!(formatter, "unresolved `{relationship}` target `{target}`")
+            }
+            Self::ResolvedTargetOutsideModel { relationship, target, .. } => write!(
+                formatter,
+                "resolved `{relationship}` target `{target}` is outside the Canonical Holon IR model"
+            ),
+        }
+    }
+}
+
+/// Read-only Canonical Holon IR graph consumed by `descriptor_semantics`.
+pub struct CanonicalDescriptorGraph {
+    holons: Vec<CanonicalHolon>,
+    nodes_by_key: HashMap<String, CanonicalNodeId>,
+    type_descriptor_nodes: Vec<CanonicalNodeId>,
+    symbols: SymbolIndex,
+}
+
+impl CanonicalDescriptorGraph {
+    /// Builds an adapter over an indexed Canonical Holon IR model.
+    ///
+    /// The default bootstrap names only the canonical descriptor-of-descriptors identity needed to
+    /// enter the otherwise self-describing graph. No inheritance or effective-member behavior is
+    /// derived from projected descriptor kinds; those rules remain in the shared kernel.
+    pub fn new(
+        model: &SemanticModel,
+        symbols: &SymbolIndex,
+    ) -> Result<Self, CanonicalGraphBuildError> {
+        Self::with_bootstrap(model, symbols, &CanonicalGraphBootstrap::default())
+    }
+
+    /// Builds an adapter with an explicit bootstrap identity contract.
+    pub fn with_bootstrap(
+        model: &SemanticModel,
+        symbols: &SymbolIndex,
+        bootstrap: &CanonicalGraphBootstrap,
+    ) -> Result<Self, CanonicalGraphBuildError> {
+        let holons = model.canonical_holons();
+        let mut nodes_by_key = HashMap::new();
+        for (index, holon) in holons.iter().enumerate() {
+            if nodes_by_key.insert(holon.key.clone(), CanonicalNodeId(index)).is_some() {
+                return Err(CanonicalGraphBuildError::DuplicateIdentity { key: holon.key.clone() });
+            }
+        }
+
+        let type_descriptor_nodes = bootstrap
+            .type_descriptor_keys
+            .iter()
+            .filter_map(|key| nodes_by_key.get(key).copied())
+            .collect();
+
+        Ok(Self { holons, nodes_by_key, type_descriptor_nodes, symbols: symbols.clone() })
+    }
+
+    /// Returns the node with the supplied canonical key.
+    pub fn node_by_key(&self, key: &str) -> Option<CanonicalNodeId> {
+        self.nodes_by_key.get(key).copied()
+    }
+
+    /// Returns generic holon data for a graph node.
+    pub fn holon(&self, node: CanonicalNodeId) -> Option<&CanonicalHolon> {
+        self.holons.get(node.0)
+    }
+
+    /// Returns the canonical key for a graph node.
+    pub fn key(&self, node: CanonicalNodeId) -> Option<&str> {
+        self.holon(node).map(|holon| holon.key.as_str())
+    }
+
+    /// Projects a kernel graph failure into one schema-aware diagnostic.
+    pub fn diagnostic(
+        &self,
+        error: DescriptorSemanticsError<CanonicalGraphError, CanonicalNodeId>,
+    ) -> Diagnostic {
+        match error {
+            DescriptorSemanticsError::MultipleExtends { descriptor, count } => {
+                self.cardinality_diagnostic(descriptor, "Extends", count)
+            }
+            DescriptorSemanticsError::MultipleDescribedBy { holon, count } => {
+                self.cardinality_diagnostic(holon, "DescribedBy", count)
+            }
+            DescriptorSemanticsError::CyclicExtends { descriptor } => {
+                let key = self.node_label(descriptor);
+                Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    DiagnosticKind::InheritanceCycle { descriptor: key.clone(), target: key },
+                    self.origin(descriptor),
+                )
+            }
+            DescriptorSemanticsError::Access(error) => self.access_diagnostic(error),
+        }
+    }
+
+    fn relationship_targets(
+        &self,
+        node: CanonicalNodeId,
+        relationship_name: &str,
+    ) -> Result<Vec<CanonicalNodeId>, CanonicalGraphError> {
+        let holon = self.holon(node).ok_or(CanonicalGraphError::UnknownNode { node })?;
+        holon
+            .relationships
+            .iter()
+            .filter(|relationship| relationship.name == relationship_name)
+            .flat_map(|relationship| relationship.targets.iter())
+            .map(|reference| self.resolve_target(node, relationship_name, reference))
+            .collect()
+    }
+
+    fn resolve_target(
+        &self,
+        source: CanonicalNodeId,
+        relationship: &str,
+        reference: &CanonicalReference,
+    ) -> Result<CanonicalNodeId, CanonicalGraphError> {
+        let symbol = reference
+            .resolved
+            .and_then(|symbol_id| self.symbols.lookup_by_id(symbol_id))
+            .or_else(|| self.symbols.lookup_reference_target(&reference.target))
+            .ok_or_else(|| CanonicalGraphError::UnresolvedTarget {
+                source,
+                relationship: relationship.to_string(),
+                target: reference.target.clone(),
+            })?;
+
+        self.nodes_by_key.get(&symbol.key).copied().ok_or_else(|| {
+            CanonicalGraphError::ResolvedTargetOutsideModel {
+                source,
+                relationship: relationship.to_string(),
+                target: reference.target.clone(),
+            }
+        })
+    }
+
+    fn origin(&self, node: CanonicalNodeId) -> Option<Origin> {
+        self.holon(node).map(|holon| holon.origin.clone())
+    }
+
+    fn node_label(&self, node: CanonicalNodeId) -> String {
+        self.key(node).map(ToString::to_string).unwrap_or_else(|| format!("{node:?}"))
+    }
+
+    fn cardinality_diagnostic(
+        &self,
+        node: CanonicalNodeId,
+        relationship: &str,
+        actual: usize,
+    ) -> Diagnostic {
+        Diagnostic::error(
+            DiagnosticLayer::SchemaAware,
+            DiagnosticKind::DescriptorRelationshipCardinality {
+                holon: self.node_label(node),
+                relationship: relationship.to_string(),
+                actual,
+                maximum: 1,
+            },
+            self.origin(node),
+        )
+    }
+
+    fn access_diagnostic(&self, error: CanonicalGraphError) -> Diagnostic {
+        let (node, relationship, target) = match &error {
+            CanonicalGraphError::UnknownNode { node } => (*node, "graph node".to_string(), None),
+            CanonicalGraphError::UnresolvedTarget { source, relationship, target }
+            | CanonicalGraphError::ResolvedTargetOutsideModel { source, relationship, target } => {
+                (*source, relationship.clone(), Some(target.clone()))
+            }
+        };
+        Diagnostic::error(
+            DiagnosticLayer::SchemaAware,
+            DiagnosticKind::DescriptorGraphAccess {
+                holon: self.node_label(node),
+                relationship,
+                target,
+                message: error.to_string(),
+            },
+            self.origin(node),
+        )
+    }
+}
+
+impl DescriptorGraph for CanonicalDescriptorGraph {
+    type Node = CanonicalNodeId;
+    type Identity = String;
+    type MemberKind = String;
+    type Error = CanonicalGraphError;
+
+    fn identity(&self, node: &Self::Node) -> Self::Identity {
+        self.node_label(*node)
+    }
+
+    fn extends_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+        self.relationship_targets(*node, "Extends")
+    }
+
+    fn described_by_targets(&self, node: &Self::Node) -> Result<Vec<Self::Node>, Self::Error> {
+        let holon = self.holon(*node).ok_or(CanonicalGraphError::UnknownNode { node: *node })?;
+        holon
+            .described_by
+            .iter()
+            .map(|reference| self.resolve_target(*node, "DescribedBy", reference))
+            .collect()
+    }
+
+    fn related_members(
+        &self,
+        node: &Self::Node,
+        member_kind: &Self::MemberKind,
+    ) -> Result<Vec<Self::Node>, Self::Error> {
+        self.relationship_targets(*node, member_kind)
+    }
+
+    fn is_type_descriptor(&self, node: &Self::Node) -> Result<bool, Self::Error> {
+        if self.holon(*node).is_none() {
+            return Err(CanonicalGraphError::UnknownNode { node: *node });
+        }
+        Ok(self.type_descriptor_nodes.contains(node))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DescriptorKind, LiteralRelationship, ReferenceRole, SemanticReference, SourceKind,
+        TypeDescriptor,
+    };
+
+    fn descriptor(key: &str, kind: DescriptorKind) -> TypeDescriptor {
+        TypeDescriptor::new(key, key, kind, "TestSchema", Origin::new(SourceKind::Generated))
+    }
+
+    fn graph_model() -> (SemanticModel, SymbolIndex) {
+        let mut model = SemanticModel::new();
+        model.push_descriptor(descriptor(
+            "TypeDescriptor.HolonType",
+            DescriptorKind::TypeDescriptor,
+        ));
+        model.push_descriptor(descriptor("Name.PropertyType", DescriptorKind::PropertyType));
+        model.push_descriptor(descriptor("Title.PropertyType", DescriptorKind::PropertyType));
+
+        let mut parent = descriptor("Parent.HolonType", DescriptorKind::HolonType);
+        parent.instance_properties.push(SemanticReference::unresolved(
+            ReferenceRole::InstanceProperty,
+            "Name.PropertyType",
+        ));
+        model.push_descriptor(parent);
+
+        let mut child = descriptor("Child.HolonType", DescriptorKind::HolonType);
+        child.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
+        child.extends =
+            Some(SemanticReference::unresolved(ReferenceRole::Extends, "Parent.HolonType"));
+        child.instance_properties.push(SemanticReference::unresolved(
+            ReferenceRole::InstanceProperty,
+            "Title.PropertyType",
+        ));
+        model.push_descriptor(child);
+
+        let (symbols, diagnostics) = SymbolIndex::build(&mut model);
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        (model, symbols)
+    }
+
+    #[test]
+    fn delegates_lineage_and_member_flattening_to_the_shared_kernel() {
+        let (model, symbols) = graph_model();
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let child = graph.node_by_key("Child.HolonType").expect("child");
+
+        let lineage = descriptor_semantics::effective_descriptor_lineage(&graph, &child)
+            .expect("effective lineage")
+            .into_iter()
+            .map(|node| graph.key(node).unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            lineage,
+            vec!["Child.HolonType", "Parent.HolonType", "TypeDescriptor.HolonType"]
+        );
+
+        let properties = descriptor_semantics::flatten_related_members(
+            &graph,
+            &child,
+            &"InstanceProperties".to_string(),
+        )
+        .expect("flattened properties")
+        .into_iter()
+        .map(|node| graph.key(node).unwrap().to_string())
+        .collect::<Vec<_>>();
+        assert_eq!(properties, vec!["Title.PropertyType", "Name.PropertyType"]);
+    }
+
+    #[test]
+    fn preserves_raw_multiple_extends_targets_for_kernel_cardinality_enforcement() {
+        let (mut model, _) = graph_model();
+        let child = model
+            .descriptors
+            .iter_mut()
+            .find(|descriptor| descriptor.key == "Child.HolonType")
+            .expect("child");
+        child.literal_relationships = vec![LiteralRelationship {
+            name: "Extends".to_string(),
+            targets: vec!["Parent.HolonType".to_string(), "TypeDescriptor.HolonType".to_string()],
+        }];
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let child = graph.node_by_key("Child.HolonType").expect("child");
+
+        let error = descriptor_semantics::ancestors(&graph, &child).expect_err("multiple Extends");
+        assert!(matches!(
+            error,
+            DescriptorSemanticsError::MultipleExtends { descriptor, count: 2 }
+                if descriptor == child
+        ));
+        assert!(matches!(
+            graph.diagnostic(error).kind,
+            DiagnosticKind::DescriptorRelationshipCardinality {
+                relationship,
+                actual: 2,
+                maximum: 1,
+                ..
+            } if relationship == "Extends"
+        ));
+    }
+
+    #[test]
+    fn projects_described_by_cardinality_and_extends_cycles_from_kernel_errors() {
+        let (mut model, _) = graph_model();
+        let child = model
+            .descriptors
+            .iter_mut()
+            .find(|descriptor| descriptor.key == "Child.HolonType")
+            .expect("child");
+        child
+            .described_by
+            .push(SemanticReference::unresolved(ReferenceRole::DescribedBy, "Parent.HolonType"));
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let child = graph.node_by_key("Child.HolonType").expect("child");
+        let error = descriptor_semantics::effective_descriptor_lineage(&graph, &child)
+            .expect_err("multiple DescribedBy");
+        assert!(matches!(
+            graph.diagnostic(error).kind,
+            DiagnosticKind::DescriptorRelationshipCardinality {
+                relationship,
+                actual: 2,
+                maximum: 1,
+                ..
+            } if relationship == "DescribedBy"
+        ));
+
+        let (mut model, _) = graph_model();
+        let parent = model
+            .descriptors
+            .iter_mut()
+            .find(|descriptor| descriptor.key == "Parent.HolonType")
+            .expect("parent");
+        parent.extends =
+            Some(SemanticReference::unresolved(ReferenceRole::Extends, "Child.HolonType"));
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let child = graph.node_by_key("Child.HolonType").expect("child");
+        let error = descriptor_semantics::ancestors(&graph, &child).expect_err("Extends cycle");
+        assert!(matches!(
+            graph.diagnostic(error).kind,
+            DiagnosticKind::InheritanceCycle { descriptor, target }
+                if descriptor == "Child.HolonType" && target == "Child.HolonType"
+        ));
+    }
+
+    #[test]
+    fn projects_unresolved_raw_targets_as_graph_access_diagnostics() {
+        let (mut model, _) = graph_model();
+        let child = model
+            .descriptors
+            .iter_mut()
+            .find(|descriptor| descriptor.key == "Child.HolonType")
+            .expect("child");
+        child.literal_relationships = vec![LiteralRelationship {
+            name: "Extends".to_string(),
+            targets: vec!["Missing.HolonType".to_string()],
+        }];
+        child.extends = None;
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("graph");
+        let child = graph.node_by_key("Child.HolonType").expect("child");
+        let error = descriptor_semantics::ancestors(&graph, &child).expect_err("unresolved target");
+
+        assert!(matches!(
+            graph.diagnostic(error).kind,
+            DiagnosticKind::DescriptorGraphAccess {
+                relationship,
+                target: Some(target),
+                ..
+            } if relationship == "Extends" && target == "Missing.HolonType"
+        ));
+    }
+}

--- a/shared_crates/map_schema_semantic/src/descriptor_graph.rs
+++ b/shared_crates/map_schema_semantic/src/descriptor_graph.rs
@@ -60,6 +60,7 @@ pub enum CanonicalGraphError {
     UnknownNode { node: CanonicalNodeId },
     UnresolvedTarget { source: CanonicalNodeId, relationship: String, target: String },
     ResolvedTargetOutsideModel { source: CanonicalNodeId, relationship: String, target: String },
+    InvalidDescriptorData { node: CanonicalNodeId, message: String },
 }
 
 impl fmt::Display for CanonicalGraphError {
@@ -73,6 +74,7 @@ impl fmt::Display for CanonicalGraphError {
                 formatter,
                 "resolved `{relationship}` target `{target}` is outside the Canonical Holon IR model"
             ),
+            Self::InvalidDescriptorData { message, .. } => write!(formatter, "{message}"),
         }
     }
 }
@@ -282,6 +284,9 @@ impl CanonicalDescriptorGraph {
             | CanonicalGraphError::ResolvedTargetOutsideModel { source, relationship, target } => {
                 (*source, relationship.clone(), Some(target.clone()))
             }
+            CanonicalGraphError::InvalidDescriptorData { node, .. } => {
+                (*node, "descriptor data".to_string(), None)
+            }
         };
         Diagnostic::error(
             DiagnosticLayer::SchemaAware,
@@ -349,10 +354,13 @@ mod tests {
 
     fn graph_model() -> (SemanticModel, SymbolIndex) {
         let mut model = SemanticModel::new();
-        model.push_descriptor(descriptor(
+        let mut type_descriptor =
+            descriptor("TypeDescriptor.HolonType", DescriptorKind::TypeDescriptor);
+        type_descriptor.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
             "TypeDescriptor.HolonType",
-            DescriptorKind::TypeDescriptor,
         ));
+        model.push_descriptor(type_descriptor);
         model.push_descriptor(descriptor("Name.PropertyType", DescriptorKind::PropertyType));
         model.push_descriptor(descriptor("Title.PropertyType", DescriptorKind::PropertyType));
 

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -6,6 +6,19 @@
 use crate::schema_ir::{DescriptorKind, Origin, ReferenceRole};
 use std::fmt;
 
+/// Responsibility boundary that produced a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticLayer {
+    Syntax,
+    IrStructural,
+    DeclarationShape,
+    DescriptorKind,
+    ReferenceSymbol,
+    SchemaAware,
+    SemanticFidelity,
+    RuntimeLoaderBoundary,
+}
+
 /// Severity assigned to a semantic diagnostic.
 ///
 /// Diagnostics use compiler-style severity so source adapters and CLIs can present a single stream
@@ -38,20 +51,73 @@ pub enum DiagnosticKind {
     },
     /// A descriptor is missing a semantic field required by its descriptor kind.
     MissingRequiredField { descriptor: String, field: String },
+    /// Two attachments of the same role use the same local member name.
+    DuplicateLocalMember { descriptor: String, role: ReferenceRole, name: String },
+    /// An inheritance edge crosses projected TypeKind boundaries.
+    TypeKindMismatch { descriptor: String, target: String, actual: String, expected: String },
+    /// Authored/imported `instance_type_kind` contradicts the descriptor's projected TypeKind.
+    InvalidProjectedTypeKind { descriptor: String, actual: String, expected: String },
+    /// Relationship cardinality bounds are present but invalid.
+    InvalidCardinalityBounds { descriptor: String, min: i64, max: i64 },
+    /// A relationship descriptor is missing the required paired inverse metadata.
+    MissingInverseRelationship { descriptor: String },
+    /// Multiple relationship descriptors claim the same inverse pairing.
+    DuplicateInverseRelationship { descriptor: String, inverse: String },
+    /// Relationship pair metadata does not point back consistently.
+    InverseRelationshipMismatch { descriptor: String, inverse: String, expected: String },
+    /// A relationship pair resolved to the wrong declared/inverse flavor.
+    WrongRelationshipFlavor {
+        role: ReferenceRole,
+        descriptor: String,
+        target: String,
+        actual: String,
+        expected: String,
+    },
+    /// An `Extends` chain contains a cycle.
+    InheritanceCycle { descriptor: String, target: String },
+    /// No effective key rule could be derived for a descriptor key.
+    MissingEffectiveKeyRule { descriptor: String },
+    /// A resolved effective key rule is not one of the supported canonical rules.
+    UnsupportedKeyRule { descriptor: String, key_rule: String },
+    /// The selected key rule does not have the semantic inputs it requires.
+    MissingKeyRuleInput { descriptor: String, key_rule: String, field: String },
+    /// The generated key for a descriptor does not match the authored/imported key.
+    AuthoredKeyMismatch { descriptor: String, expected: String, actual: String },
 }
 
 /// A semantic diagnostic with optional source origin metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
     pub severity: DiagnosticSeverity,
+    pub layer: DiagnosticLayer,
     pub kind: DiagnosticKind,
     pub origin: Option<Origin>,
 }
 
 impl Diagnostic {
     /// Creates an error diagnostic with optional source origin metadata.
-    pub fn error(kind: DiagnosticKind, origin: Option<Origin>) -> Self {
-        Self { severity: DiagnosticSeverity::Error, kind, origin }
+    pub fn error(layer: DiagnosticLayer, kind: DiagnosticKind, origin: Option<Origin>) -> Self {
+        Self { severity: DiagnosticSeverity::Error, layer, kind, origin }
+    }
+
+    /// Creates a warning diagnostic with optional source origin metadata.
+    pub fn warning(layer: DiagnosticLayer, kind: DiagnosticKind, origin: Option<Origin>) -> Self {
+        Self { severity: DiagnosticSeverity::Warning, layer, kind, origin }
+    }
+}
+
+impl fmt::Display for DiagnosticLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Syntax => write!(f, "syntax"),
+            Self::IrStructural => write!(f, "ir_structural"),
+            Self::DeclarationShape => write!(f, "declaration_shape"),
+            Self::DescriptorKind => write!(f, "descriptor_kind"),
+            Self::ReferenceSymbol => write!(f, "reference_symbol"),
+            Self::SchemaAware => write!(f, "schema_aware"),
+            Self::SemanticFidelity => write!(f, "semantic_fidelity"),
+            Self::RuntimeLoaderBoundary => write!(f, "runtime_loader_boundary"),
+        }
     }
 }
 
@@ -83,13 +149,76 @@ impl fmt::Display for DiagnosticKind {
             Self::MissingRequiredField { descriptor, field } => {
                 write!(f, "descriptor `{descriptor}` is missing required field `{field}`")
             }
+            Self::DuplicateLocalMember { descriptor, role, name } => {
+                write!(f, "descriptor `{descriptor}` has duplicate {role} member `{name}`")
+            }
+            Self::TypeKindMismatch { descriptor, target, actual, expected } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` cannot extend `{target}` because projected TypeKind `{actual}` does not match `{expected}`"
+                )
+            }
+            Self::InvalidProjectedTypeKind { descriptor, actual, expected } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` has authored/imported instance_type_kind `{actual}` but projected TypeKind is `{expected}`"
+                )
+            }
+            Self::InvalidCardinalityBounds { descriptor, min, max } => {
+                write!(f, "descriptor `{descriptor}` has invalid cardinality bounds `{min}..{max}`")
+            }
+            Self::MissingInverseRelationship { descriptor } => {
+                write!(f, "descriptor `{descriptor}` is missing its required inverse relationship")
+            }
+            Self::DuplicateInverseRelationship { descriptor, inverse } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` conflicts with another relationship over inverse `{inverse}`"
+                )
+            }
+            Self::InverseRelationshipMismatch { descriptor, inverse, expected } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` points to inverse `{inverse}` but expected a back-reference to `{expected}`"
+                )
+            }
+            Self::WrongRelationshipFlavor { role, descriptor, target, actual, expected } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` has {role} target `{target}` with flavor `{actual}`, expected `{expected}`"
+                )
+            }
+            Self::InheritanceCycle { descriptor, target } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` participates in an Extends cycle through `{target}`"
+                )
+            }
+            Self::MissingEffectiveKeyRule { descriptor } => {
+                write!(f, "descriptor `{descriptor}` has no effective key rule")
+            }
+            Self::UnsupportedKeyRule { descriptor, key_rule } => {
+                write!(f, "descriptor `{descriptor}` resolved unsupported key rule `{key_rule}`")
+            }
+            Self::MissingKeyRuleInput { descriptor, key_rule, field } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` uses key rule `{key_rule}` but is missing required input `{field}`"
+                )
+            }
+            Self::AuthoredKeyMismatch { descriptor, expected, actual } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` has key `{actual}` but effective key rule generates `{expected}`"
+                )
+            }
         }
     }
 }
 
 impl fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.severity, self.kind)?;
+        write!(f, "{}[{}]: {}", self.severity, self.layer, self.kind)?;
         if let Some(origin) = &self.origin {
             write!(f, " ({})", format_origin(origin))?;
         }
@@ -124,6 +253,7 @@ mod tests {
     #[test]
     fn formats_unresolved_reference_with_origin() {
         let diagnostic = Diagnostic::error(
+            DiagnosticLayer::ReferenceSymbol,
             DiagnosticKind::UnresolvedReference {
                 role: ReferenceRole::InstanceRelationship,
                 target: "DeclaredRelationshipType".to_string(),
@@ -133,7 +263,7 @@ mod tests {
 
         assert_eq!(
             diagnostic.to_string(),
-            "error: unresolved InstanceRelationships reference `DeclaredRelationshipType` (schema-src/example.tdl:12:3)"
+            "error[reference_symbol]: unresolved InstanceRelationships reference `DeclaredRelationshipType` (schema-src/example.tdl:12:3)"
         );
     }
 
@@ -141,10 +271,12 @@ mod tests {
     fn formats_multiple_diagnostics_as_newline_separated_list() {
         let diagnostics = vec![
             Diagnostic::error(
+                DiagnosticLayer::ReferenceSymbol,
                 DiagnosticKind::DuplicateSymbol { key: "Name.PropertyType".to_string() },
                 Some(Origin::json_file("fixture.json")),
             ),
             Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
                 DiagnosticKind::MissingRequiredField {
                     descriptor: "Owns.RelationshipType".to_string(),
                     field: "SourceType".to_string(),
@@ -160,7 +292,7 @@ mod tests {
 
         assert_eq!(
             format_diagnostics(&diagnostics),
-            "error: duplicate symbol key `Name.PropertyType` (fixture.json)\nerror: descriptor `Owns.RelationshipType` is missing required field `SourceType` (generated.tdl)"
+            "error[reference_symbol]: duplicate symbol key `Name.PropertyType` (fixture.json)\nerror[schema_aware]: descriptor `Owns.RelationshipType` is missing required field `SourceType` (generated.tdl)"
         );
     }
 }

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -38,6 +38,10 @@ pub enum DiagnosticSeverity {
 /// semantic model exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiagnosticKind {
+    /// Source syntax was malformed while parsing authored content.
+    InvalidSyntax { context: String, message: String },
+    /// A required syntax element was missing from authored content.
+    MissingSyntaxElement { context: String, expected: String },
     /// Two schemas/descriptors produced the same canonical symbol key.
     DuplicateSymbol { key: String },
     /// A reference target could not be resolved against the derived symbol index.
@@ -133,6 +137,12 @@ impl fmt::Display for DiagnosticSeverity {
 impl fmt::Display for DiagnosticKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidSyntax { context, message } => {
+                write!(f, "invalid syntax in `{context}`: {message}")
+            }
+            Self::MissingSyntaxElement { context, expected } => {
+                write!(f, "missing syntax element `{expected}` in `{context}`")
+            }
             Self::DuplicateSymbol { key } => {
                 write!(f, "duplicate symbol key `{key}`")
             }
@@ -271,6 +281,14 @@ mod tests {
     fn formats_multiple_diagnostics_as_newline_separated_list() {
         let diagnostics = vec![
             Diagnostic::error(
+                DiagnosticLayer::Syntax,
+                DiagnosticKind::InvalidSyntax {
+                    context: "schema".to_string(),
+                    message: "unexpected token".to_string(),
+                },
+                Some(Origin::tdl_file("broken.tdl", Some(1), Some(1))),
+            ),
+            Diagnostic::error(
                 DiagnosticLayer::ReferenceSymbol,
                 DiagnosticKind::DuplicateSymbol { key: "Name.PropertyType".to_string() },
                 Some(Origin::json_file("fixture.json")),
@@ -292,7 +310,7 @@ mod tests {
 
         assert_eq!(
             format_diagnostics(&diagnostics),
-            "error[reference_symbol]: duplicate symbol key `Name.PropertyType` (fixture.json)\nerror[schema_aware]: descriptor `Owns.RelationshipType` is missing required field `SourceType` (generated.tdl)"
+            "error[syntax]: invalid syntax in `schema`: unexpected token (broken.tdl:1:1)\nerror[reference_symbol]: duplicate symbol key `Name.PropertyType` (fixture.json)\nerror[schema_aware]: descriptor `Owns.RelationshipType` is missing required field `SourceType` (generated.tdl)"
         );
     }
 }

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -93,6 +93,22 @@ pub enum DiagnosticKind {
         target: Option<String>,
         message: String,
     },
+    /// A holon omits a property required by its effective descriptor.
+    MissingConformanceProperty { holon: String, property: String },
+    /// A closed descriptor does not declare an authored property.
+    AdditionalConformanceProperty { holon: String, property: String },
+    /// A property value does not satisfy its resolved value descriptor.
+    InvalidConformanceValue { holon: String, property: String, value: String, expected: String },
+    /// A closed descriptor does not declare an authored relationship.
+    AdditionalConformanceRelationship { holon: String, relationship: String },
+    /// A relationship target collection violates its descriptor-provided bounds.
+    ConformanceRelationshipCardinality {
+        holon: String,
+        relationship: String,
+        actual: usize,
+        minimum: usize,
+        maximum: usize,
+    },
     /// No effective key rule could be derived for a descriptor key.
     MissingEffectiveKeyRule { descriptor: String },
     /// A resolved effective key rule is not one of the supported canonical rules.
@@ -231,6 +247,29 @@ impl fmt::Display for DiagnosticKind {
                 }
                 write!(f, ": {message}")
             }
+            Self::MissingConformanceProperty { holon, property } => {
+                write!(f, "holon `{holon}` is missing required property `{property}`")
+            }
+            Self::AdditionalConformanceProperty { holon, property } => {
+                write!(f, "holon `{holon}` has undeclared property `{property}`")
+            }
+            Self::InvalidConformanceValue { holon, property, value, expected } => write!(
+                f,
+                "holon `{holon}` property `{property}` has invalid value `{value}`; expected {expected}"
+            ),
+            Self::AdditionalConformanceRelationship { holon, relationship } => {
+                write!(f, "holon `{holon}` has undeclared relationship `{relationship}`")
+            }
+            Self::ConformanceRelationshipCardinality {
+                holon,
+                relationship,
+                actual,
+                minimum,
+                maximum,
+            } => write!(
+                f,
+                "holon `{holon}` has {actual} `{relationship}` targets; expected {minimum}..{maximum}"
+            ),
             Self::MissingEffectiveKeyRule { descriptor } => {
                 write!(f, "descriptor `{descriptor}` has no effective key rule")
             }

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -59,8 +59,6 @@ pub enum DiagnosticKind {
     DuplicateLocalMember { descriptor: String, role: ReferenceRole, name: String },
     /// An inheritance edge crosses projected TypeKind boundaries.
     TypeKindMismatch { descriptor: String, target: String, actual: String, expected: String },
-    /// Authored/imported `instance_type_kind` contradicts the descriptor's projected TypeKind.
-    InvalidProjectedTypeKind { descriptor: String, actual: String, expected: String },
     /// Relationship cardinality bounds are present but invalid.
     InvalidCardinalityBounds { descriptor: String, min: i64, max: i64 },
     /// A relationship descriptor is missing the required paired inverse metadata.
@@ -196,12 +194,6 @@ impl fmt::Display for DiagnosticKind {
                 write!(
                     f,
                     "descriptor `{descriptor}` cannot extend `{target}` because projected TypeKind `{actual}` does not match `{expected}`"
-                )
-            }
-            Self::InvalidProjectedTypeKind { descriptor, actual, expected } => {
-                write!(
-                    f,
-                    "descriptor `{descriptor}` has authored/imported instance_type_kind `{actual}` but projected TypeKind is `{expected}`"
                 )
             }
             Self::InvalidCardinalityBounds { descriptor, min, max } => {

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -79,6 +79,20 @@ pub enum DiagnosticKind {
     },
     /// An `Extends` chain contains a cycle.
     InheritanceCycle { descriptor: String, target: String },
+    /// A descriptor graph relationship violates kernel-owned structural cardinality.
+    DescriptorRelationshipCardinality {
+        holon: String,
+        relationship: String,
+        actual: usize,
+        maximum: usize,
+    },
+    /// The Canonical Holon IR graph could not provide a target required by descriptor semantics.
+    DescriptorGraphAccess {
+        holon: String,
+        relationship: String,
+        target: Option<String>,
+        message: String,
+    },
     /// No effective key rule could be derived for a descriptor key.
     MissingEffectiveKeyRule { descriptor: String },
     /// A resolved effective key rule is not one of the supported canonical rules.
@@ -203,6 +217,19 @@ impl fmt::Display for DiagnosticKind {
                     f,
                     "descriptor `{descriptor}` participates in an Extends cycle through `{target}`"
                 )
+            }
+            Self::DescriptorRelationshipCardinality { holon, relationship, actual, maximum } => {
+                write!(
+                    f,
+                    "holon `{holon}` has {actual} `{relationship}` targets; expected at most {maximum}"
+                )
+            }
+            Self::DescriptorGraphAccess { holon, relationship, target, message } => {
+                write!(f, "cannot traverse `{relationship}` for holon `{holon}`")?;
+                if let Some(target) = target {
+                    write!(f, " through target `{target}`")?;
+                }
+                write!(f, ": {message}")
             }
             Self::MissingEffectiveKeyRule { descriptor } => {
                 write!(f, "descriptor `{descriptor}` has no effective key rule")

--- a/shared_crates/map_schema_semantic/src/diagnostics.rs
+++ b/shared_crates/map_schema_semantic/src/diagnostics.rs
@@ -59,6 +59,8 @@ pub enum DiagnosticKind {
     DuplicateLocalMember { descriptor: String, role: ReferenceRole, name: String },
     /// An inheritance edge crosses projected TypeKind boundaries.
     TypeKindMismatch { descriptor: String, target: String, actual: String, expected: String },
+    /// An `Extends` edge has a source or target that is not described by `TypeDescriptor`.
+    ExtendsEndpointNotType { descriptor: String, endpoint: String },
     /// Relationship cardinality bounds are present but invalid.
     InvalidCardinalityBounds { descriptor: String, min: i64, max: i64 },
     /// A relationship descriptor is missing the required paired inverse metadata.
@@ -194,6 +196,12 @@ impl fmt::Display for DiagnosticKind {
                 write!(
                     f,
                     "descriptor `{descriptor}` cannot extend `{target}` because projected TypeKind `{actual}` does not match `{expected}`"
+                )
+            }
+            Self::ExtendsEndpointNotType { descriptor, endpoint } => {
+                write!(
+                    f,
+                    "descriptor `{descriptor}` cannot extend through non-type endpoint `{endpoint}`"
                 )
             }
             Self::InvalidCardinalityBounds { descriptor, min, max } => {

--- a/shared_crates/map_schema_semantic/src/lib.rs
+++ b/shared_crates/map_schema_semantic/src/lib.rs
@@ -7,6 +7,7 @@
 //! descriptor vocabulary without depending on a host-only parser or a particular serialization
 //! format.
 
+pub mod descriptor_conformance;
 pub mod descriptor_graph;
 pub mod diagnostics;
 pub mod literal_value;
@@ -14,6 +15,7 @@ pub mod schema_index;
 pub mod schema_ir;
 pub mod validator;
 
+pub use descriptor_conformance::*;
 pub use descriptor_graph::*;
 pub use diagnostics::*;
 pub use literal_value::*;

--- a/shared_crates/map_schema_semantic/src/lib.rs
+++ b/shared_crates/map_schema_semantic/src/lib.rs
@@ -7,12 +7,14 @@
 //! descriptor vocabulary without depending on a host-only parser or a particular serialization
 //! format.
 
+pub mod descriptor_graph;
 pub mod diagnostics;
 pub mod literal_value;
 pub mod schema_index;
 pub mod schema_ir;
 pub mod validator;
 
+pub use descriptor_graph::*;
 pub use diagnostics::*;
 pub use literal_value::*;
 pub use schema_index::*;

--- a/shared_crates/map_schema_semantic/src/lib.rs
+++ b/shared_crates/map_schema_semantic/src/lib.rs
@@ -11,8 +11,10 @@ pub mod diagnostics;
 pub mod literal_value;
 pub mod schema_index;
 pub mod schema_ir;
+pub mod validator;
 
 pub use diagnostics::*;
 pub use literal_value::*;
 pub use schema_index::*;
 pub use schema_ir::*;
+pub use validator::*;

--- a/shared_crates/map_schema_semantic/src/schema_index.rs
+++ b/shared_crates/map_schema_semantic/src/schema_index.rs
@@ -5,7 +5,7 @@
 //! source of truth.
 
 use crate::{
-    diagnostics::{Diagnostic, DiagnosticKind},
+    diagnostics::{Diagnostic, DiagnosticKind, DiagnosticLayer},
     schema_ir::{
         DescriptorKind, Origin, ReferenceRole, Schema, SemanticModel, SemanticReference,
         TypeDescriptor,
@@ -120,6 +120,7 @@ impl SymbolIndex {
         if self.by_key.contains_key(&symbol.key) {
             self.duplicate_keys.insert(symbol.key.clone());
             return Err(Diagnostic::error(
+                DiagnosticLayer::ReferenceSymbol,
                 DiagnosticKind::DuplicateSymbol { key: symbol.key.clone() },
                 Some(symbol.origin),
             ));
@@ -219,7 +220,7 @@ impl SymbolIndex {
         unresolved
     }
 
-    /// Validates references and required relationship fields after resolution.
+    /// Validates reference resolution and role/kind compatibility after resolution.
     ///
     /// This check is intentionally semantic-role based: a `ValueType` reference must target a value
     /// type or enum regardless of whether it came from JSON import data, TDL syntax, or generated
@@ -246,27 +247,6 @@ impl SymbolIndex {
                     reference,
                     Some(descriptor.origin.clone()),
                 );
-            }
-
-            if descriptor.kind == DescriptorKind::RelationshipType {
-                if descriptor.source_type.is_none() {
-                    diagnostics.push(Diagnostic::error(
-                        DiagnosticKind::MissingRequiredField {
-                            descriptor: descriptor.key.clone(),
-                            field: "SourceType".to_string(),
-                        },
-                        Some(descriptor.origin.clone()),
-                    ));
-                }
-                if descriptor.target_type.is_none() {
-                    diagnostics.push(Diagnostic::error(
-                        DiagnosticKind::MissingRequiredField {
-                            descriptor: descriptor.key.clone(),
-                            field: "TargetType".to_string(),
-                        },
-                        Some(descriptor.origin.clone()),
-                    ));
-                }
             }
         }
 
@@ -299,6 +279,7 @@ fn push_reference_diagnostic(
 ) {
     let Some(symbol_id) = reference.resolved else {
         diagnostics.push(Diagnostic::error(
+            DiagnosticLayer::ReferenceSymbol,
             DiagnosticKind::UnresolvedReference {
                 role: reference.role,
                 target: reference.target.clone(),
@@ -315,6 +296,7 @@ fn push_reference_diagnostic(
     let expected = expected_kinds(reference.role);
     if !expected.is_empty() && !expected.contains(&symbol.kind) {
         diagnostics.push(Diagnostic::error(
+            DiagnosticLayer::ReferenceSymbol,
             DiagnosticKind::WrongDescriptorKind {
                 role: reference.role,
                 target: reference.target.clone(),
@@ -343,10 +325,10 @@ fn expected_kinds(role: ReferenceRole) -> Vec<DescriptorKind> {
         ReferenceRole::VariantOf => vec![DescriptorKind::Enum],
         ReferenceRole::InstanceProperty => vec![DescriptorKind::PropertyType],
         ReferenceRole::InstanceRelationship => vec![DescriptorKind::RelationshipType],
-        ReferenceRole::Extends
-        | ReferenceRole::KeyRule
-        | ReferenceRole::InverseOf
-        | ReferenceRole::HasInverse => Vec::new(),
+        ReferenceRole::InverseOf | ReferenceRole::HasInverse => {
+            vec![DescriptorKind::RelationshipType]
+        }
+        ReferenceRole::Extends | ReferenceRole::KeyRule => Vec::new(),
     }
 }
 
@@ -582,7 +564,7 @@ mod tests {
     }
 
     #[test]
-    fn detects_missing_required_relationship_fields() {
+    fn leaves_required_relationship_fields_to_the_validator_layer() {
         let mut model = SemanticModel::new();
         model.push_schema(schema(json_origin()));
         model.push_descriptor(descriptor(
@@ -594,20 +576,7 @@ mod tests {
 
         let (_, diagnostics) = SymbolIndex::build(&mut model);
 
-        assert!(diagnostics.iter().any(|diagnostic| {
-            matches!(
-                &diagnostic.kind,
-                DiagnosticKind::MissingRequiredField { descriptor, field }
-                    if descriptor == "Owns.RelationshipType" && field == "SourceType"
-            )
-        }));
-        assert!(diagnostics.iter().any(|diagnostic| {
-            matches!(
-                &diagnostic.kind,
-                DiagnosticKind::MissingRequiredField { descriptor, field }
-                    if descriptor == "Owns.RelationshipType" && field == "TargetType"
-            )
-        }));
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/shared_crates/map_schema_semantic/src/schema_index.rs
+++ b/shared_crates/map_schema_semantic/src/schema_index.rs
@@ -202,8 +202,9 @@ impl SymbolIndex {
         for schema in &model.schemas {
             unresolved.extend(
                 schema
-                    .dependencies
+                    .described_by
                     .iter()
+                    .chain(schema.dependencies.iter())
                     .filter(|reference| reference.resolved.is_none())
                     .cloned(),
             );
@@ -229,7 +230,7 @@ impl SymbolIndex {
         let mut diagnostics = Vec::new();
 
         for schema in &model.schemas {
-            for reference in &schema.dependencies {
+            for reference in schema.described_by.iter().chain(schema.dependencies.iter()) {
                 push_reference_diagnostic(
                     &mut diagnostics,
                     self,
@@ -310,6 +311,7 @@ fn push_reference_diagnostic(
 
 fn expected_kinds(role: ReferenceRole) -> Vec<DescriptorKind> {
     match role {
+        ReferenceRole::DescribedBy => Vec::new(),
         ReferenceRole::ComponentOf | ReferenceRole::DependsOn => vec![DescriptorKind::Schema],
         ReferenceRole::SourceType | ReferenceRole::TargetType => vec![
             DescriptorKind::TypeDescriptor,
@@ -358,6 +360,7 @@ mod tests {
             name: "Test Schema".to_string(),
             key: "Test Schema".to_string(),
             origin,
+            described_by: Vec::new(),
             dependencies: Vec::new(),
             literal_properties: LiteralObject::new(),
             literal_relationships: Vec::new(),

--- a/shared_crates/map_schema_semantic/src/schema_ir.rs
+++ b/shared_crates/map_schema_semantic/src/schema_ir.rs
@@ -280,6 +280,10 @@ pub struct TypeDescriptor {
     /// Raw descriptor identity retained independently of projected [`DescriptorKind`].
     pub described_by: Vec<SemanticReference>,
     pub header: Option<DescriptorHeader>,
+    /// Authored or adapter-lowered TypeKind enum identity for this descriptor holon.
+    pub instance_type_kind: Option<String>,
+    /// Requiredness declared by a PropertyType; absent for non-property descriptors.
+    pub property_required: Option<bool>,
     pub is_abstract: bool,
     pub extends: Option<SemanticReference>,
     pub component_of: Option<SemanticReference>,
@@ -296,6 +300,12 @@ pub struct TypeDescriptor {
     /// Variant-owned link to its enum when preserved from a source shape.
     pub variant_of: Option<SemanticReference>,
     pub literal_properties: LiteralObject,
+    /// Source conveniences lowered into explicit canonical property values.
+    ///
+    /// Entries use descriptor member names rather than source-format field spellings. Once
+    /// materialized they are ordinary semantic values; downstream validation and projection must
+    /// not reinterpret the source convention that produced them.
+    pub materialized_properties: LiteralObject,
     pub instance_properties: Vec<SemanticReference>,
     pub instance_relationships: Vec<SemanticReference>,
     pub literal_relationships: Vec<LiteralRelationship>,
@@ -327,6 +337,8 @@ impl TypeDescriptor {
             origin,
             described_by: Vec::new(),
             header: None,
+            instance_type_kind: None,
+            property_required: None,
             is_abstract: false,
             extends: None,
             component_of: None,
@@ -339,6 +351,7 @@ impl TypeDescriptor {
             variants: Vec::new(),
             variant_of: None,
             literal_properties: LiteralObject::new(),
+            materialized_properties: LiteralObject::new(),
             instance_properties: Vec::new(),
             instance_relationships: Vec::new(),
             literal_relationships: Vec::new(),
@@ -453,7 +466,7 @@ impl SemanticModel {
             .map(|schema| CanonicalHolon {
                 key: schema.key.clone(),
                 described_by: canonical_refs(&schema.described_by),
-                properties: schema.literal_properties.clone(),
+                properties: canonical_schema_properties(schema),
                 relationships: canonical_relationships(
                     &schema.literal_relationships,
                     [(&ReferenceRole::DependsOn, schema.dependencies.as_slice())],
@@ -465,7 +478,7 @@ impl SemanticModel {
         holons.extend(self.descriptors.iter().map(|descriptor| CanonicalHolon {
             key: descriptor.key.clone(),
             described_by: canonical_refs(&descriptor.described_by),
-            properties: descriptor.literal_properties.clone(),
+            properties: canonical_descriptor_properties(descriptor),
             relationships: canonical_relationships(
                 &descriptor.literal_relationships,
                 descriptor_reference_groups(descriptor),
@@ -499,6 +512,9 @@ impl SemanticModel {
                 name: descriptor.name.clone(),
                 kind: descriptor.kind,
                 owning_schema: descriptor.owning_schema.clone(),
+                instance_type_kind: descriptor.instance_type_kind.clone(),
+                property_required: (descriptor.kind == DescriptorKind::PropertyType)
+                    .then_some(descriptor.property_required.unwrap_or(true)),
                 is_abstract: descriptor.is_abstract,
                 references: comparable_descriptor_refs(descriptor),
                 relationship_flavor: descriptor.relationship_flavor,
@@ -549,6 +565,8 @@ pub struct ComparableDescriptor {
     pub name: String,
     pub kind: DescriptorKind,
     pub owning_schema: String,
+    pub instance_type_kind: Option<String>,
+    pub property_required: Option<bool>,
     pub is_abstract: bool,
     pub references: Vec<(ReferenceRole, String)>,
     pub relationship_flavor: Option<RelationshipFlavor>,
@@ -560,6 +578,197 @@ pub struct ComparableDescriptor {
     pub allows_duplicates: bool,
     pub allows_additional_properties: bool,
     pub allows_additional_relationships: bool,
+}
+
+fn canonical_descriptor_properties(descriptor: &TypeDescriptor) -> LiteralObject {
+    let mut properties = LiteralObject::new();
+    for (name, value) in descriptor.literal_properties.iter() {
+        if !is_projected_descriptor_property(name) {
+            properties.insert(name.clone(), value.clone());
+        }
+    }
+    for (name, value) in descriptor.materialized_properties.iter() {
+        insert_literal_if_absent(&mut properties, name, value.clone());
+    }
+    insert_literal_if_absent(
+        &mut properties,
+        "TypeName",
+        crate::LiteralValue::String(descriptor.name.clone()),
+    );
+    insert_literal_if_absent(
+        &mut properties,
+        "SchemaName",
+        crate::LiteralValue::String(descriptor.owning_schema.clone()),
+    );
+    if let Some(header) = &descriptor.header {
+        for (name, value) in [
+            ("Description", header.description.as_ref()),
+            ("DisplayName", header.display_name.as_ref()),
+            ("DisplayNamePlural", header.display_name_plural.as_ref()),
+            ("TypeNamePlural", header.type_name_plural.as_ref()),
+        ] {
+            if let Some(value) = value {
+                insert_literal_if_absent(
+                    &mut properties,
+                    name,
+                    crate::LiteralValue::String(value.clone()),
+                );
+            }
+        }
+    }
+    if let Some(instance_type_kind) = &descriptor.instance_type_kind {
+        insert_literal_if_absent(
+            &mut properties,
+            "TypeKind",
+            crate::LiteralValue::String(instance_type_kind.clone()),
+        );
+    }
+    insert_literal_if_absent(
+        &mut properties,
+        "IsAbstractType",
+        crate::LiteralValue::Boolean(descriptor.is_abstract),
+    );
+
+    match descriptor.kind {
+        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => {
+            for (canonical_name, authored_name, shorthand_value) in [
+                (
+                    "AllowsAdditionalProperties",
+                    "allows_additional_properties",
+                    descriptor.allows_additional_properties,
+                ),
+                (
+                    "AllowsAdditionalRelationships",
+                    "allows_additional_relationships",
+                    descriptor.allows_additional_relationships,
+                ),
+            ] {
+                let value = descriptor
+                    .literal_properties
+                    .get(authored_name)
+                    .and_then(crate::LiteralValue::as_bool)
+                    .or_else(|| shorthand_value.then_some(true));
+                if let Some(value) = value {
+                    insert_literal_if_absent(
+                        &mut properties,
+                        canonical_name,
+                        crate::LiteralValue::Boolean(value),
+                    );
+                }
+            }
+        }
+        DescriptorKind::PropertyType => {
+            if let Some(required) = descriptor.property_required {
+                insert_literal_if_absent(
+                    &mut properties,
+                    "IsRequired",
+                    crate::LiteralValue::Boolean(required),
+                );
+            }
+        }
+        DescriptorKind::RelationshipType => {
+            insert_literal_if_absent(
+                &mut properties,
+                "IsDefinitional",
+                crate::LiteralValue::Boolean(descriptor.is_definitional),
+            );
+            insert_literal_if_absent(
+                &mut properties,
+                "IsOrdered",
+                crate::LiteralValue::Boolean(descriptor.is_ordered),
+            );
+            insert_literal_if_absent(
+                &mut properties,
+                "AllowsDuplicates",
+                crate::LiteralValue::Boolean(descriptor.allows_duplicates),
+            );
+            if let Some(minimum) = descriptor.min_cardinality {
+                insert_literal_if_absent(
+                    &mut properties,
+                    "MinCardinality",
+                    crate::LiteralValue::Integer(minimum),
+                );
+            }
+            if let Some(maximum) = descriptor.max_cardinality {
+                insert_literal_if_absent(
+                    &mut properties,
+                    "MaxCardinality",
+                    crate::LiteralValue::Integer(maximum),
+                );
+            }
+            if let Some(deletion_semantic) = &descriptor.deletion_semantic {
+                insert_literal_if_absent(
+                    &mut properties,
+                    "DeletionSemantic",
+                    crate::LiteralValue::String(deletion_semantic.clone()),
+                );
+            }
+        }
+        DescriptorKind::Schema
+        | DescriptorKind::ValueType
+        | DescriptorKind::Enum
+        | DescriptorKind::EnumVariant => {}
+    }
+    properties
+}
+
+fn is_projected_descriptor_property(name: &str) -> bool {
+    matches!(
+        name,
+        "type_name"
+            | "schema_name"
+            | "description"
+            | "display_name"
+            | "display_name_plural"
+            | "type_name_plural"
+            | "instance_type_kind"
+            | "is_abstract_type"
+            | "allows_additional_properties"
+            | "allows_additional_relationships"
+            | "is_required"
+            | "is_definitional"
+            | "is_ordered"
+            | "allows_duplicates"
+            | "min_cardinality"
+            | "max_cardinality"
+            | "deletion_semantic"
+    )
+}
+
+fn canonical_schema_properties(schema: &Schema) -> LiteralObject {
+    let mut properties = schema.literal_properties.clone();
+    insert_literal_if_absent(
+        &mut properties,
+        "schema_name",
+        crate::LiteralValue::String(schema.name.clone()),
+    );
+    if let Some(header) = &schema.header {
+        for (name, value) in [
+            ("description", header.description.as_ref()),
+            ("display_name", header.display_name.as_ref()),
+            ("display_name_plural", header.display_name_plural.as_ref()),
+            ("type_name_plural", header.type_name_plural.as_ref()),
+        ] {
+            if let Some(value) = value {
+                insert_literal_if_absent(
+                    &mut properties,
+                    name,
+                    crate::LiteralValue::String(value.clone()),
+                );
+            }
+        }
+    }
+    properties
+}
+
+fn insert_literal_if_absent(
+    properties: &mut LiteralObject,
+    name: &str,
+    value: crate::LiteralValue,
+) {
+    if properties.get(name).is_none() {
+        properties.insert(name, value);
+    }
 }
 
 fn comparable_descriptor_refs(descriptor: &TypeDescriptor) -> Vec<(ReferenceRole, String)> {

--- a/shared_crates/map_schema_semantic/src/schema_ir.rs
+++ b/shared_crates/map_schema_semantic/src/schema_ir.rs
@@ -107,6 +107,8 @@ impl Origin {
 /// than any one source syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ReferenceRole {
+    /// Descriptor identity (`type` in loader JSON, `DescribedBy` in the MAP graph).
+    DescribedBy,
     /// Schema membership relationship.
     ComponentOf,
     /// Type inheritance relationship.
@@ -138,6 +140,7 @@ pub enum ReferenceRole {
 impl fmt::Display for ReferenceRole {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::DescribedBy => write!(f, "DescribedBy"),
             Self::ComponentOf => write!(f, "ComponentOf"),
             Self::Extends => write!(f, "Extends"),
             Self::KeyRule => write!(f, "UsesKeyRule"),
@@ -202,6 +205,46 @@ pub struct LiteralRelationship {
     pub targets: Vec<String>,
 }
 
+/// A representation-neutral target in the generic Canonical Holon IR view.
+///
+/// `resolved` is build-local derived state. `target` remains the stable source-neutral identity
+/// used by projections, diagnostics, and semantic comparisons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalReference {
+    pub target: String,
+    pub resolved: Option<SymbolId>,
+}
+
+impl From<&SemanticReference> for CanonicalReference {
+    fn from(reference: &SemanticReference) -> Self {
+        Self { target: reference.target.clone(), resolved: reference.resolved }
+    }
+}
+
+/// A named relationship and its uncollapsed target collection.
+///
+/// Target multiplicity is preserved so descriptor semantics, rather than source adapters or
+/// descriptor-specific compatibility slots, can enforce relationship cardinality.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalRelationship {
+    pub name: String,
+    pub targets: Vec<CanonicalReference>,
+}
+
+/// Generic holon data retained by the Canonical Holon IR.
+///
+/// This is an owned, derived view over the current schema and descriptor records. It gives the
+/// descriptor-semantics adapter a uniform graph surface without introducing runtime references or
+/// creating a second mutable representation that could diverge from the compiler/decompiler view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalHolon {
+    pub key: String,
+    pub described_by: Vec<CanonicalReference>,
+    pub properties: LiteralObject,
+    pub relationships: Vec<CanonicalRelationship>,
+    pub origin: Origin,
+}
+
 /// Semantic representation of a schema declaration.
 ///
 /// A schema is a descriptor container plus source-preserved metadata. Canonical references such as
@@ -212,6 +255,8 @@ pub struct Schema {
     pub name: String,
     pub key: String,
     pub origin: Origin,
+    /// Raw descriptor identity retained independently of projected schema classification.
+    pub described_by: Vec<SemanticReference>,
     pub dependencies: Vec<SemanticReference>,
     pub literal_properties: LiteralObject,
     pub literal_relationships: Vec<LiteralRelationship>,
@@ -232,6 +277,8 @@ pub struct TypeDescriptor {
     pub kind: DescriptorKind,
     pub owning_schema: String,
     pub origin: Origin,
+    /// Raw descriptor identity retained independently of projected [`DescriptorKind`].
+    pub described_by: Vec<SemanticReference>,
     pub header: Option<DescriptorHeader>,
     pub is_abstract: bool,
     pub extends: Option<SemanticReference>,
@@ -278,6 +325,7 @@ impl TypeDescriptor {
             kind,
             owning_schema: owning_schema.into(),
             origin,
+            described_by: Vec::new(),
             header: None,
             is_abstract: false,
             extends: None,
@@ -312,6 +360,7 @@ impl TypeDescriptor {
     /// canonical semantic roles.
     pub fn references(&self) -> Vec<&SemanticReference> {
         let mut refs = Vec::new();
+        refs.extend(self.described_by.iter());
         refs.extend(self.extends.iter());
         refs.extend(self.component_of.iter());
         refs.extend(self.key_rule.iter());
@@ -330,6 +379,7 @@ impl TypeDescriptor {
     /// Returns all semantic references carried by this descriptor for resolution.
     pub fn references_mut(&mut self) -> Vec<&mut SemanticReference> {
         let mut refs = Vec::new();
+        refs.extend(self.described_by.iter_mut());
         refs.extend(self.extends.iter_mut());
         refs.extend(self.component_of.iter_mut());
         refs.extend(self.key_rule.iter_mut());
@@ -375,7 +425,7 @@ impl SemanticModel {
     /// Resolves known references in-place against an already-derived symbol table.
     pub fn resolve_references(&mut self, symbols: &SymbolIndex) {
         for schema in &mut self.schemas {
-            for reference in &mut schema.dependencies {
+            for reference in schema.described_by.iter_mut().chain(schema.dependencies.iter_mut()) {
                 if let Some(symbol) = symbols.lookup_reference_target(&reference.target) {
                     reference.resolve(symbol.id);
                 }
@@ -391,6 +441,40 @@ impl SemanticModel {
         }
     }
 
+    /// Derives a uniform holon graph from the compatibility schema/descriptor records.
+    ///
+    /// Literal relationship collections are retained verbatim. First-class semantic references are
+    /// then added when an equivalent target is not already present, ensuring adapter-authored
+    /// duplicate targets remain visible while projected references are never lost.
+    pub fn canonical_holons(&self) -> Vec<CanonicalHolon> {
+        let mut holons = self
+            .schemas
+            .iter()
+            .map(|schema| CanonicalHolon {
+                key: schema.key.clone(),
+                described_by: canonical_refs(&schema.described_by),
+                properties: schema.literal_properties.clone(),
+                relationships: canonical_relationships(
+                    &schema.literal_relationships,
+                    [(&ReferenceRole::DependsOn, schema.dependencies.as_slice())],
+                ),
+                origin: schema.origin.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        holons.extend(self.descriptors.iter().map(|descriptor| CanonicalHolon {
+            key: descriptor.key.clone(),
+            described_by: canonical_refs(&descriptor.described_by),
+            properties: descriptor.literal_properties.clone(),
+            relationships: canonical_relationships(
+                &descriptor.literal_relationships,
+                descriptor_reference_groups(descriptor),
+            ),
+            origin: descriptor.origin.clone(),
+        }));
+        holons
+    }
+
     /// Produces a stable, origin-insensitive signature for round-trip comparisons.
     pub fn comparable_signature(&self) -> ComparableSemanticModel {
         let mut schemas = self
@@ -399,6 +483,7 @@ impl SemanticModel {
             .map(|schema| ComparableSchema {
                 name: schema.name.clone(),
                 key: schema.key.clone(),
+                described_by: comparable_refs(&schema.described_by),
                 dependencies: comparable_refs(&schema.dependencies),
                 allows_additional_properties: schema.allows_additional_properties,
                 allows_additional_relationships: schema.allows_additional_relationships,
@@ -451,6 +536,7 @@ pub struct ComparableSemanticModel {
 pub struct ComparableSchema {
     pub name: String,
     pub key: String,
+    pub described_by: Vec<(ReferenceRole, String)>,
     pub dependencies: Vec<(ReferenceRole, String)>,
     pub allows_additional_properties: bool,
     pub allows_additional_relationships: bool,
@@ -525,10 +611,12 @@ impl TdlDescriptorInput {
 
 /// Adds a reference to the matching semantic slot on a descriptor.
 ///
-/// Single-valued roles overwrite the previous value; multi-valued roles append. `DependsOn` is a
-/// schema-level role and is ignored for descriptors.
+/// Single-valued compatibility roles overwrite the previous value. `DescribedBy` and other
+/// multi-valued roles append so raw cardinality remains available to semantic validation.
+/// `DependsOn` is a schema-level role and is ignored for descriptors.
 pub fn push_reference(descriptor: &mut TypeDescriptor, reference: SemanticReference) {
     match reference.role {
+        ReferenceRole::DescribedBy => descriptor.described_by.push(reference),
         ReferenceRole::ComponentOf => descriptor.component_of = Some(reference),
         ReferenceRole::Extends => descriptor.extends = Some(reference),
         ReferenceRole::KeyRule => descriptor.key_rule = Some(reference),
@@ -542,5 +630,138 @@ pub fn push_reference(descriptor: &mut TypeDescriptor, reference: SemanticRefere
         ReferenceRole::InstanceProperty => descriptor.instance_properties.push(reference),
         ReferenceRole::InstanceRelationship => descriptor.instance_relationships.push(reference),
         ReferenceRole::DependsOn => {}
+    }
+}
+
+fn canonical_refs(references: &[SemanticReference]) -> Vec<CanonicalReference> {
+    references.iter().map(CanonicalReference::from).collect()
+}
+
+fn descriptor_reference_groups(
+    descriptor: &TypeDescriptor,
+) -> Vec<(&ReferenceRole, &[SemanticReference])> {
+    vec![
+        (&ReferenceRole::ComponentOf, descriptor.component_of.as_slice()),
+        (&ReferenceRole::Extends, descriptor.extends.as_slice()),
+        (&ReferenceRole::KeyRule, descriptor.key_rule.as_slice()),
+        (&ReferenceRole::ValueType, descriptor.value_type.as_slice()),
+        (&ReferenceRole::SourceType, descriptor.source_type.as_slice()),
+        (&ReferenceRole::TargetType, descriptor.target_type.as_slice()),
+        (&ReferenceRole::InverseOf, descriptor.inverse_of.as_slice()),
+        (&ReferenceRole::HasInverse, descriptor.has_inverse.as_slice()),
+        (&ReferenceRole::Variants, descriptor.variants.as_slice()),
+        (&ReferenceRole::VariantOf, descriptor.variant_of.as_slice()),
+        (&ReferenceRole::InstanceProperty, descriptor.instance_properties.as_slice()),
+        (&ReferenceRole::InstanceRelationship, descriptor.instance_relationships.as_slice()),
+    ]
+}
+
+fn canonical_relationships<'a>(
+    literal_relationships: &[LiteralRelationship],
+    reference_groups: impl IntoIterator<Item = (&'a ReferenceRole, &'a [SemanticReference])>,
+) -> Vec<CanonicalRelationship> {
+    let mut relationships = literal_relationships
+        .iter()
+        .map(|relationship| CanonicalRelationship {
+            name: relationship.name.clone(),
+            targets: relationship
+                .targets
+                .iter()
+                .map(|target| CanonicalReference { target: target.clone(), resolved: None })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+
+    for (role, references) in reference_groups {
+        if references.is_empty() {
+            continue;
+        }
+        let relationship_name = role.to_string();
+        let relationship =
+            relationships.iter_mut().find(|relationship| relationship.name == relationship_name);
+        if let Some(relationship) = relationship {
+            for reference in references {
+                let mut matched = false;
+                for target in relationship
+                    .targets
+                    .iter_mut()
+                    .filter(|target| target.target == reference.target)
+                {
+                    target.resolved = reference.resolved;
+                    matched = true;
+                }
+                if !matched {
+                    relationship.targets.push(CanonicalReference::from(reference));
+                }
+            }
+        } else {
+            relationships.push(CanonicalRelationship {
+                name: relationship_name,
+                targets: canonical_refs(references),
+            });
+        }
+    }
+    relationships
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origin() -> Origin {
+        Origin::new(SourceKind::Generated)
+    }
+
+    #[test]
+    fn canonical_holon_view_preserves_descriptor_identity_and_raw_target_multiplicity() {
+        let mut descriptor = TypeDescriptor::new(
+            "Book.HolonType",
+            "Book",
+            DescriptorKind::HolonType,
+            "Books",
+            origin(),
+        );
+        descriptor.described_by.push(SemanticReference {
+            role: ReferenceRole::DescribedBy,
+            target: "TypeDescriptor.HolonType".to_string(),
+            resolved: Some(SymbolId(7)),
+        });
+        descriptor.extends = Some(SemanticReference {
+            role: ReferenceRole::Extends,
+            target: "Document.HolonType".to_string(),
+            resolved: Some(SymbolId(11)),
+        });
+        descriptor.literal_relationships.push(LiteralRelationship {
+            name: "Extends".to_string(),
+            targets: vec!["Document.HolonType".to_string(), "Document.HolonType".to_string()],
+        });
+
+        let mut model = SemanticModel::new();
+        model.push_descriptor(descriptor);
+        let holon = model.canonical_holons().pop().expect("canonical holon");
+
+        assert_eq!(holon.key, "Book.HolonType");
+        assert_eq!(
+            holon.described_by,
+            vec![CanonicalReference {
+                target: "TypeDescriptor.HolonType".to_string(),
+                resolved: Some(SymbolId(7)),
+            }]
+        );
+        assert_eq!(
+            holon
+                .relationships
+                .iter()
+                .find(|relationship| relationship.name == "Extends")
+                .expect("Extends relationship")
+                .targets
+                .iter()
+                .map(|target| (target.target.as_str(), target.resolved))
+                .collect::<Vec<_>>(),
+            vec![
+                ("Document.HolonType", Some(SymbolId(11))),
+                ("Document.HolonType", Some(SymbolId(11))),
+            ]
+        );
     }
 }

--- a/shared_crates/map_schema_semantic/src/validator.rs
+++ b/shared_crates/map_schema_semantic/src/validator.rs
@@ -3,7 +3,11 @@
 //! This module owns source-neutral semantic checks that apply after lowering and reference
 //! resolution. Source adapters remain responsible for syntax and source-format conveniences.
 
+use descriptor_semantics::{ancestors, effective_holon_key_rule};
+
 use crate::{
+    descriptor_conformance::validate_canonical_model_values,
+    descriptor_graph::CanonicalDescriptorGraph,
     diagnostics::{Diagnostic, DiagnosticKind, DiagnosticLayer},
     schema_index::{Symbol, SymbolIndex},
     schema_ir::{
@@ -31,33 +35,15 @@ pub fn validate_model(model: &SemanticModel, symbols: &SymbolIndex) -> Vec<Diagn
     let mut diagnostics = Vec::new();
 
     diagnostics.extend(validate_required_slots(model));
-    diagnostics.extend(validate_projected_type_kinds(model));
-    diagnostics.extend(validate_extends_graph(model, symbols, &descriptor_by_key));
+    if let Ok(graph) = CanonicalDescriptorGraph::new(model, symbols) {
+        diagnostics.extend(validate_canonical_model_values(&graph));
+        diagnostics.extend(validate_inheritance_graph(model, &graph));
+        diagnostics.extend(validate_effective_keys(model, symbols, &descriptor_by_key, &graph));
+    }
     diagnostics.extend(validate_relationship_pairs(model, symbols, &descriptor_by_key));
     diagnostics.extend(validate_local_duplicates(model, symbols));
-    diagnostics.extend(validate_effective_keys(model, symbols, &descriptor_by_key));
 
     diagnostics
-}
-
-/// Applies validation-only normalization that should not mutate emitted source artifacts.
-pub fn normalize_validation_model(model: &mut SemanticModel) {
-    for descriptor in &mut model.descriptors {
-        if descriptor.kind != DescriptorKind::RelationshipType {
-            continue;
-        }
-        if descriptor.min_cardinality.is_none() {
-            descriptor.min_cardinality = Some(0);
-        }
-        if descriptor.max_cardinality.is_none() {
-            descriptor.max_cardinality = Some(32_767);
-        }
-        if descriptor.relationship_flavor != Some(RelationshipFlavor::Inverse)
-            && descriptor.deletion_semantic.is_none()
-        {
-            descriptor.deletion_semantic = Some("Allow".to_string());
-        }
-    }
 }
 
 /// Synthesizes missing inverse-pair references from the side that was authored explicitly.
@@ -203,87 +189,17 @@ fn validate_required_slots(model: &SemanticModel) -> Vec<Diagnostic> {
     diagnostics
 }
 
-fn validate_projected_type_kinds(model: &SemanticModel) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-    for descriptor in &model.descriptors {
-        if is_bootstrap_descriptor(descriptor) {
-            continue;
-        }
-        let Some(projected) = projected_type_kind(descriptor) else {
-            continue;
-        };
-        let Some(authored) = descriptor
-            .literal_properties
-            .get("instance_type_kind")
-            .and_then(|value| value.as_str())
-        else {
-            continue;
-        };
-        if type_kind_family_for_text(authored) != type_kind_family_for_descriptor(descriptor) {
-            diagnostics.push(Diagnostic::error(
-                DiagnosticLayer::DescriptorKind,
-                DiagnosticKind::InvalidProjectedTypeKind {
-                    descriptor: descriptor.key.clone(),
-                    actual: authored.to_string(),
-                    expected: projected.to_string(),
-                },
-                Some(descriptor.origin.clone()),
-            ));
-        }
-    }
-    diagnostics
-}
-
-fn validate_extends_graph(
+fn validate_inheritance_graph(
     model: &SemanticModel,
-    symbols: &SymbolIndex,
-    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+    graph: &CanonicalDescriptorGraph,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     for descriptor in &model.descriptors {
-        let Some(extends) = &descriptor.extends else {
+        let Some(node) = graph.node_by_key(&descriptor.key) else {
             continue;
         };
-        let Some(target_symbol) = resolved_symbol(extends, symbols) else {
-            continue;
-        };
-        let Some(parent) = descriptor_by_key.get(target_symbol.key.as_str()).copied() else {
-            continue;
-        };
-
-        if descriptor.name.starts_with("Meta") || parent.name.starts_with("Meta") {
-            continue;
-        }
-        if let (Some(actual), Some(expected)) =
-            (type_kind_family_for_descriptor(descriptor), type_kind_family_for_descriptor(parent))
-        {
-            if !type_kind_families_compatible(actual, expected) {
-                diagnostics.push(Diagnostic::error(
-                    DiagnosticLayer::SchemaAware,
-                    DiagnosticKind::TypeKindMismatch {
-                        descriptor: descriptor.key.clone(),
-                        target: parent.key.clone(),
-                        actual: projected_type_kind(descriptor)
-                            .unwrap_or(actual.as_str())
-                            .to_string(),
-                        expected: projected_type_kind(parent)
-                            .unwrap_or(expected.as_str())
-                            .to_string(),
-                    },
-                    Some(descriptor.origin.clone()),
-                ));
-            }
-        }
-
-        if has_extends_cycle(descriptor, symbols, descriptor_by_key) {
-            diagnostics.push(Diagnostic::error(
-                DiagnosticLayer::SchemaAware,
-                DiagnosticKind::InheritanceCycle {
-                    descriptor: descriptor.key.clone(),
-                    target: parent.key.clone(),
-                },
-                Some(descriptor.origin.clone()),
-            ));
+        if let Err(error) = ancestors(graph, &node) {
+            diagnostics.push(graph.diagnostic(error));
         }
     }
     diagnostics
@@ -459,11 +375,22 @@ fn validate_effective_keys(
     model: &SemanticModel,
     symbols: &SymbolIndex,
     descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+    graph: &CanonicalDescriptorGraph,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     for descriptor in &model.descriptors {
-        let Some(resolution) = resolve_effective_key_rule(descriptor, symbols, descriptor_by_key)
-        else {
+        let Some(node) = graph.node_by_key(&descriptor.key) else {
+            continue;
+        };
+        let resolution = match effective_holon_key_rule(graph, &node, &"UsesKeyRule".to_string()) {
+            Ok(Some(rule)) => graph.key(rule).map(canonical_key_rule),
+            Ok(None) => None,
+            Err(error) => {
+                diagnostics.push(graph.diagnostic(error));
+                continue;
+            }
+        };
+        let Some(resolution) = resolution else {
             diagnostics.push(Diagnostic::error(
                 DiagnosticLayer::SchemaAware,
                 DiagnosticKind::MissingEffectiveKeyRule { descriptor: descriptor.key.clone() },
@@ -505,28 +432,6 @@ fn requires_extends(descriptor: &TypeDescriptor) -> bool {
             && descriptor.name == "MetaTypeDescriptor"))
 }
 
-fn has_extends_cycle(
-    descriptor: &TypeDescriptor,
-    symbols: &SymbolIndex,
-    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
-) -> bool {
-    let mut seen = HashSet::new();
-    let mut current = descriptor.extends.as_ref();
-    while let Some(reference) = current {
-        let Some(symbol) = resolved_symbol(reference, symbols) else {
-            return false;
-        };
-        if !seen.insert(symbol.key.clone()) {
-            return true;
-        }
-        if symbol.key == descriptor.key {
-            return true;
-        }
-        current = descriptor_by_key.get(symbol.key.as_str()).and_then(|next| next.extends.as_ref());
-    }
-    false
-}
-
 fn find_duplicate_members(
     descriptor: &TypeDescriptor,
     references: &[SemanticReference],
@@ -554,55 +459,6 @@ fn find_duplicate_members(
     diagnostics
 }
 
-fn resolve_effective_key_rule<'a>(
-    descriptor: &'a TypeDescriptor,
-    symbols: &'a SymbolIndex,
-    descriptor_by_key: &'a HashMap<&str, &TypeDescriptor>,
-) -> Option<String> {
-    if descriptor.extends.is_some() {
-        let mut current = descriptor.extends.as_ref();
-        let mut visited = HashSet::new();
-        while let Some(reference) = current {
-            let symbol = resolved_symbol(reference, symbols)?;
-            if !visited.insert(symbol.key.clone()) {
-                break;
-            }
-            let parent = descriptor_by_key.get(symbol.key.as_str())?;
-            if let Some(rule) =
-                parent.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
-            {
-                return Some(rule);
-            }
-            current = parent.extends.as_ref();
-        }
-    } else if let Some(rule) =
-        descriptor.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
-    {
-        return Some(rule);
-    }
-
-    let described_by = describing_type_target(descriptor)?;
-    let describing_symbol = symbols.lookup_reference_target(described_by)?;
-    let mut current = descriptor_by_key.get(describing_symbol.key.as_str()).copied();
-    let mut visited = HashSet::new();
-    while let Some(next) = current {
-        if !visited.insert(next.key.clone()) {
-            break;
-        }
-        if let Some(rule) =
-            next.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
-        {
-            return Some(rule);
-        }
-        current = next
-            .extends
-            .as_ref()
-            .and_then(|reference| resolved_symbol(reference, symbols))
-            .and_then(|symbol| descriptor_by_key.get(symbol.key.as_str()).copied());
-    }
-    None
-}
-
 fn generate_key(
     descriptor: &TypeDescriptor,
     key_rule: &str,
@@ -612,7 +468,9 @@ fn generate_key(
     match key_rule {
         TYPE_NAME_RULE => Ok(descriptor.name.clone()),
         SCHEMA_NAME_RULE => Ok(descriptor.owning_schema.clone()),
-        TYPE_KIND_RULE => projected_type_kind(descriptor)
+        TYPE_KIND_RULE => descriptor
+            .instance_type_kind
+            .as_deref()
             .map(|kind| format!("{}.{}", descriptor.name, kind))
             .ok_or_else(|| DiagnosticKind::MissingKeyRuleInput {
                 descriptor: descriptor.key.clone(),
@@ -692,22 +550,6 @@ fn canonical_key_rule(target: &str) -> String {
     }
 }
 
-fn describing_type_target(descriptor: &TypeDescriptor) -> Option<&'static str> {
-    match descriptor.kind {
-        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => Some("MetaHolonType"),
-        DescriptorKind::PropertyType => Some("MetaPropertyType"),
-        DescriptorKind::RelationshipType => {
-            Some(if descriptor.relationship_flavor == Some(RelationshipFlavor::Inverse) {
-                "MetaInverseRelationshipType"
-            } else {
-                "MetaDeclaredRelationshipType"
-            })
-        }
-        DescriptorKind::ValueType | DescriptorKind::Enum => Some("MetaValueType"),
-        DescriptorKind::EnumVariant | DescriptorKind::Schema => None,
-    }
-}
-
 fn relationship_flavor_label(flavor: Option<RelationshipFlavor>) -> String {
     match flavor {
         Some(RelationshipFlavor::Declared) => "declared".to_string(),
@@ -721,148 +563,6 @@ fn resolved_symbol<'a>(
     symbols: &'a SymbolIndex,
 ) -> Option<&'a Symbol> {
     reference.resolved.and_then(|id| symbols.lookup_by_id(id))
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TypeKindFamily {
-    Holon,
-    Property,
-    Relationship,
-    Value,
-    EnumVariant,
-}
-
-impl TypeKindFamily {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Holon => "TypeKind.Holon",
-            Self::Property => "TypeKind.Property",
-            Self::Relationship => "TypeKind.Relationship",
-            Self::Value => "TypeKind.Value",
-            Self::EnumVariant => "TypeKind.EnumVariant",
-        }
-    }
-}
-
-fn type_kind_family_for_descriptor(descriptor: &TypeDescriptor) -> Option<TypeKindFamily> {
-    match descriptor.kind {
-        DescriptorKind::Schema => None,
-        DescriptorKind::PropertyType => Some(TypeKindFamily::Property),
-        DescriptorKind::RelationshipType => Some(TypeKindFamily::Relationship),
-        DescriptorKind::ValueType | DescriptorKind::Enum => Some(TypeKindFamily::Value),
-        DescriptorKind::EnumVariant => Some(TypeKindFamily::EnumVariant),
-        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => {
-            if descriptor.name == "PropertyType" || descriptor.name.ends_with("PropertyType") {
-                Some(TypeKindFamily::Property)
-            } else if descriptor.name == "ValueType" || descriptor.name.ends_with("ValueType") {
-                Some(TypeKindFamily::Value)
-            } else if descriptor.name == "DeclaredRelationshipType"
-                || descriptor.name == "InverseRelationshipType"
-                || descriptor.name == "MetaRelationshipType"
-                || descriptor.name.ends_with("RelationshipType")
-            {
-                Some(TypeKindFamily::Relationship)
-            } else {
-                Some(TypeKindFamily::Holon)
-            }
-        }
-    }
-}
-
-fn type_kind_family_for_text(text: &str) -> Option<TypeKindFamily> {
-    if text.starts_with("TypeKind.Property") {
-        Some(TypeKindFamily::Property)
-    } else if text.starts_with("TypeKind.Relationship") {
-        Some(TypeKindFamily::Relationship)
-    } else if text.starts_with("TypeKind.Value") {
-        Some(TypeKindFamily::Value)
-    } else if text.starts_with("TypeKind.EnumVariant") {
-        Some(TypeKindFamily::EnumVariant)
-    } else if text.starts_with("TypeKind.Holon") {
-        Some(TypeKindFamily::Holon)
-    } else {
-        None
-    }
-}
-
-fn type_kind_families_compatible(actual: TypeKindFamily, expected: TypeKindFamily) -> bool {
-    actual == expected
-        || matches!(
-            (actual, expected),
-            (TypeKindFamily::EnumVariant, TypeKindFamily::Value)
-                | (TypeKindFamily::Value, TypeKindFamily::EnumVariant)
-        )
-}
-
-fn is_bootstrap_descriptor(descriptor: &TypeDescriptor) -> bool {
-    descriptor.name.starts_with("Meta")
-        || matches!(
-            descriptor.name.as_str(),
-            "TypeDescriptor"
-                | "HolonType"
-                | "ValueType"
-                | "PropertyType"
-                | "RelationshipType"
-                | "DeclaredRelationshipType"
-                | "InverseRelationshipType"
-        )
-}
-
-fn projected_type_kind(descriptor: &TypeDescriptor) -> Option<&'static str> {
-    match descriptor.kind {
-        DescriptorKind::Schema => None,
-        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => Some("TypeKind.Holon"),
-        DescriptorKind::PropertyType => Some("TypeKind.Property"),
-        DescriptorKind::RelationshipType => Some("TypeKind.Relationship"),
-        DescriptorKind::Enum => Some("TypeKind.Value.Enum"),
-        DescriptorKind::EnumVariant => Some("TypeKind.EnumVariant"),
-        DescriptorKind::ValueType => Some(infer_value_kind(descriptor)),
-    }
-}
-
-fn infer_value_kind(descriptor: &TypeDescriptor) -> &'static str {
-    if descriptor.name == "MetaValueType" {
-        return "TypeKind.Holon";
-    }
-    if descriptor.name == "ValueType" {
-        return "TypeKind.Value";
-    }
-    if matches!(descriptor.name.as_str(), "EnumVariantValueType" | "MapEnumVariantValueType") {
-        return "TypeKind.EnumVariant";
-    }
-    if descriptor.name.ends_with("StringValueType") {
-        return "TypeKind.Value.String";
-    }
-    if descriptor.name.ends_with("IntegerValueType") {
-        return "TypeKind.Value.Integer";
-    }
-    if descriptor.name.ends_with("BooleanValueType") {
-        return "TypeKind.Value.Boolean";
-    }
-    if descriptor.name.ends_with("BytesValueType") || descriptor.name == "HolonIdValueType" {
-        return "TypeKind.Value.Bytes";
-    }
-    if descriptor.name.ends_with("ValueArrayType")
-        || descriptor.name.ends_with("ValueArrayValueType")
-    {
-        return "TypeKind.Value.Array";
-    }
-    if descriptor.name.ends_with("EnumValueType") {
-        return "TypeKind.Value.Enum";
-    }
-    match descriptor.extends.as_ref().map(|reference| reference.target.as_str()) {
-        Some("MetaTypeDescriptor") | Some("MetaValueType") => "TypeKind.Holon",
-        Some("StringValueType") | Some("MapStringValueType") => "TypeKind.Value.String",
-        Some("IntegerValueType") | Some("MapIntegerValueType") => "TypeKind.Value.Integer",
-        Some("BooleanValueType") | Some("MapBooleanValueType") => "TypeKind.Value.Boolean",
-        Some("BytesValueType") | Some("MapBytesValueType") | Some("HolonIdValueType") => {
-            "TypeKind.Value.Bytes"
-        }
-        Some("ValueArrayValueType") | Some("MapValueArrayType") => "TypeKind.Value.Array",
-        Some("EnumValueType") | Some("MapEnumValueType") => "TypeKind.Value.Enum",
-        Some("EnumVariantValueType") | Some("MapEnumVariantValueType") => "TypeKind.EnumVariant",
-        _ => "TypeKind.Value.String",
-    }
 }
 
 #[cfg(test)]

--- a/shared_crates/map_schema_semantic/src/validator.rs
+++ b/shared_crates/map_schema_semantic/src/validator.rs
@@ -1,0 +1,968 @@
+//! Schema-authoring validation over the Canonical Holon IR.
+//!
+//! This module owns source-neutral semantic checks that apply after lowering and reference
+//! resolution. Source adapters remain responsible for syntax and source-format conveniences.
+
+use crate::{
+    diagnostics::{Diagnostic, DiagnosticKind, DiagnosticLayer},
+    schema_index::{Symbol, SymbolIndex},
+    schema_ir::{
+        DescriptorKind, ReferenceRole, RelationshipFlavor, SemanticModel, SemanticReference,
+        TypeDescriptor,
+    },
+};
+use std::collections::{HashMap, HashSet};
+
+const TYPE_NAME_RULE: &str = "TypeNameRule.KeyRuleType";
+const SCHEMA_NAME_RULE: &str = "SchemaNameRule.KeyRuleType";
+const TYPE_KIND_RULE: &str = "TypeKindRule.KeyRuleType";
+const ENUM_VARIANT_RULE: &str = "EnumVariantRule.KeyRuleType";
+const RELATIONSHIP_RULE: &str = "RelationshipRule.KeyRuleType";
+const EXTENDED_TYPE_RULE: &str = "ExtendedTypeRule.KeyRuleType";
+const NONE_RULE: &str = "NoneRule.KeyRuleType";
+
+/// Validates one semantic model after reference resolution.
+pub fn validate_model(model: &SemanticModel, symbols: &SymbolIndex) -> Vec<Diagnostic> {
+    let descriptor_by_key = model
+        .descriptors
+        .iter()
+        .map(|descriptor| (descriptor.key.as_str(), descriptor))
+        .collect::<HashMap<_, _>>();
+    let mut diagnostics = Vec::new();
+
+    diagnostics.extend(validate_required_slots(model));
+    diagnostics.extend(validate_projected_type_kinds(model));
+    diagnostics.extend(validate_extends_graph(model, symbols, &descriptor_by_key));
+    diagnostics.extend(validate_relationship_pairs(model, symbols, &descriptor_by_key));
+    diagnostics.extend(validate_local_duplicates(model, symbols));
+    diagnostics.extend(validate_effective_keys(model, symbols, &descriptor_by_key));
+
+    diagnostics
+}
+
+/// Applies validation-only normalization that should not mutate emitted source artifacts.
+pub fn normalize_validation_model(model: &mut SemanticModel) {
+    for descriptor in &mut model.descriptors {
+        if descriptor.kind != DescriptorKind::RelationshipType {
+            continue;
+        }
+        if descriptor.min_cardinality.is_none() {
+            descriptor.min_cardinality = Some(0);
+        }
+        if descriptor.max_cardinality.is_none() {
+            descriptor.max_cardinality = Some(32_767);
+        }
+        if descriptor.relationship_flavor != Some(RelationshipFlavor::Inverse)
+            && descriptor.deletion_semantic.is_none()
+        {
+            descriptor.deletion_semantic = Some("Allow".to_string());
+        }
+    }
+}
+
+/// Synthesizes missing inverse-pair references from the side that was authored explicitly.
+pub fn normalize_relationship_pairs(model: &mut SemanticModel, symbols: &SymbolIndex) {
+    let descriptor_indexes = model
+        .descriptors
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| (descriptor.key.clone(), index))
+        .collect::<HashMap<_, _>>();
+
+    for index in 0..model.descriptors.len() {
+        if model.descriptors[index].kind != DescriptorKind::RelationshipType {
+            continue;
+        }
+
+        let current_key = model.descriptors[index].key.clone();
+        let current_symbol_id = symbols.lookup_by_key(&current_key).map(|symbol| symbol.id);
+
+        if let Some(has_inverse) = model.descriptors[index].has_inverse.clone() {
+            if let Some(target_symbol) = resolved_symbol(&has_inverse, symbols) {
+                if let Some(target_index) = descriptor_indexes.get(&target_symbol.key).copied() {
+                    if model.descriptors[target_index].inverse_of.is_none() {
+                        model.descriptors[target_index].inverse_of = Some(SemanticReference {
+                            role: ReferenceRole::InverseOf,
+                            target: current_key.clone(),
+                            resolved: current_symbol_id,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(inverse_of) = model.descriptors[index].inverse_of.clone() {
+            if let Some(target_symbol) = resolved_symbol(&inverse_of, symbols) {
+                if let Some(target_index) = descriptor_indexes.get(&target_symbol.key).copied() {
+                    if model.descriptors[target_index].has_inverse.is_none() {
+                        model.descriptors[target_index].has_inverse = Some(SemanticReference {
+                            role: ReferenceRole::HasInverse,
+                            target: current_key.clone(),
+                            resolved: current_symbol_id,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn validate_required_slots(model: &SemanticModel) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for descriptor in &model.descriptors {
+        let mut required_fields = Vec::new();
+
+        required_fields.push("ComponentOf");
+
+        if requires_extends(descriptor) {
+            required_fields.push("Extends");
+        }
+
+        match descriptor.kind {
+            DescriptorKind::PropertyType => required_fields.push("ValueType"),
+            DescriptorKind::RelationshipType => {
+                required_fields.push("SourceType");
+                required_fields.push("TargetType");
+                required_fields.push("min_cardinality");
+                required_fields.push("max_cardinality");
+                if descriptor.relationship_flavor != Some(RelationshipFlavor::Inverse) {
+                    required_fields.push("deletion_semantic");
+                    required_fields.push("HasInverse");
+                } else {
+                    required_fields.push("InverseOf");
+                }
+            }
+            DescriptorKind::Enum => {
+                if descriptor.variants.is_empty()
+                    && !descriptor.is_abstract
+                    && !descriptor.name.ends_with("ValueType")
+                {
+                    diagnostics.push(Diagnostic::error(
+                        DiagnosticLayer::SchemaAware,
+                        DiagnosticKind::MissingRequiredField {
+                            descriptor: descriptor.key.clone(),
+                            field: "Variants".to_string(),
+                        },
+                        Some(descriptor.origin.clone()),
+                    ));
+                }
+            }
+            DescriptorKind::EnumVariant => {
+                if !descriptor.is_abstract && !descriptor.name.ends_with("ValueType") {
+                    required_fields.push("VariantOf");
+                }
+            }
+            DescriptorKind::Schema
+            | DescriptorKind::TypeDescriptor
+            | DescriptorKind::HolonType
+            | DescriptorKind::ValueType => {}
+        }
+
+        for field in required_fields {
+            let present = match field {
+                "ComponentOf" => descriptor.component_of.is_some(),
+                "Extends" => descriptor.extends.is_some(),
+                "ValueType" => descriptor.value_type.is_some(),
+                "SourceType" => descriptor.source_type.is_some(),
+                "TargetType" => descriptor.target_type.is_some(),
+                "HasInverse" => descriptor.has_inverse.is_some(),
+                "InverseOf" => descriptor.inverse_of.is_some(),
+                "VariantOf" => descriptor.variant_of.is_some(),
+                "min_cardinality" => descriptor.min_cardinality.is_some(),
+                "max_cardinality" => descriptor.max_cardinality.is_some(),
+                "deletion_semantic" => descriptor.deletion_semantic.is_some(),
+                _ => true,
+            };
+
+            if !present {
+                diagnostics.push(Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    DiagnosticKind::MissingRequiredField {
+                        descriptor: descriptor.key.clone(),
+                        field: field.to_string(),
+                    },
+                    Some(descriptor.origin.clone()),
+                ));
+            }
+        }
+
+        if let (Some(min), Some(max)) = (descriptor.min_cardinality, descriptor.max_cardinality) {
+            if min > max {
+                diagnostics.push(Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    DiagnosticKind::InvalidCardinalityBounds {
+                        descriptor: descriptor.key.clone(),
+                        min,
+                        max,
+                    },
+                    Some(descriptor.origin.clone()),
+                ));
+            }
+        }
+    }
+    diagnostics
+}
+
+fn validate_projected_type_kinds(model: &SemanticModel) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for descriptor in &model.descriptors {
+        if is_bootstrap_descriptor(descriptor) {
+            continue;
+        }
+        let Some(projected) = projected_type_kind(descriptor) else {
+            continue;
+        };
+        let Some(authored) = descriptor
+            .literal_properties
+            .get("instance_type_kind")
+            .and_then(|value| value.as_str())
+        else {
+            continue;
+        };
+        if type_kind_family_for_text(authored) != type_kind_family_for_descriptor(descriptor) {
+            diagnostics.push(Diagnostic::error(
+                DiagnosticLayer::DescriptorKind,
+                DiagnosticKind::InvalidProjectedTypeKind {
+                    descriptor: descriptor.key.clone(),
+                    actual: authored.to_string(),
+                    expected: projected.to_string(),
+                },
+                Some(descriptor.origin.clone()),
+            ));
+        }
+    }
+    diagnostics
+}
+
+fn validate_extends_graph(
+    model: &SemanticModel,
+    symbols: &SymbolIndex,
+    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for descriptor in &model.descriptors {
+        let Some(extends) = &descriptor.extends else {
+            continue;
+        };
+        let Some(target_symbol) = resolved_symbol(extends, symbols) else {
+            continue;
+        };
+        let Some(parent) = descriptor_by_key.get(target_symbol.key.as_str()).copied() else {
+            continue;
+        };
+
+        if descriptor.name.starts_with("Meta") || parent.name.starts_with("Meta") {
+            continue;
+        }
+        if let (Some(actual), Some(expected)) =
+            (type_kind_family_for_descriptor(descriptor), type_kind_family_for_descriptor(parent))
+        {
+            if !type_kind_families_compatible(actual, expected) {
+                diagnostics.push(Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    DiagnosticKind::TypeKindMismatch {
+                        descriptor: descriptor.key.clone(),
+                        target: parent.key.clone(),
+                        actual: projected_type_kind(descriptor)
+                            .unwrap_or(actual.as_str())
+                            .to_string(),
+                        expected: projected_type_kind(parent)
+                            .unwrap_or(expected.as_str())
+                            .to_string(),
+                    },
+                    Some(descriptor.origin.clone()),
+                ));
+            }
+        }
+
+        if has_extends_cycle(descriptor, symbols, descriptor_by_key) {
+            diagnostics.push(Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::InheritanceCycle {
+                    descriptor: descriptor.key.clone(),
+                    target: parent.key.clone(),
+                },
+                Some(descriptor.origin.clone()),
+            ));
+        }
+    }
+    diagnostics
+}
+
+fn validate_relationship_pairs(
+    model: &SemanticModel,
+    symbols: &SymbolIndex,
+    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let mut declared_to_inverses: HashMap<String, Vec<String>> = HashMap::new();
+    let mut inverse_to_declareds: HashMap<String, Vec<String>> = HashMap::new();
+
+    for descriptor in &model.descriptors {
+        if descriptor.kind != DescriptorKind::RelationshipType {
+            continue;
+        }
+        if let Some(has_inverse) = &descriptor.has_inverse {
+            inverse_to_declareds
+                .entry(has_inverse.target.clone())
+                .or_default()
+                .push(descriptor.key.clone());
+        }
+        if let Some(inverse_of) = &descriptor.inverse_of {
+            declared_to_inverses
+                .entry(inverse_of.target.clone())
+                .or_default()
+                .push(descriptor.key.clone());
+        }
+    }
+
+    for descriptor in &model.descriptors {
+        if descriptor.kind != DescriptorKind::RelationshipType {
+            continue;
+        }
+
+        match descriptor.relationship_flavor.unwrap_or(RelationshipFlavor::Declared) {
+            RelationshipFlavor::Declared => {
+                let Some(has_inverse) = &descriptor.has_inverse else {
+                    continue;
+                };
+                if inverse_to_declareds.get(&has_inverse.target).map_or(0, Vec::len) > 1 {
+                    diagnostics.push(Diagnostic::error(
+                        DiagnosticLayer::SchemaAware,
+                        DiagnosticKind::DuplicateInverseRelationship {
+                            descriptor: descriptor.key.clone(),
+                            inverse: has_inverse.target.clone(),
+                        },
+                        Some(descriptor.origin.clone()),
+                    ));
+                }
+
+                let Some(symbol) = resolved_symbol(has_inverse, symbols) else {
+                    continue;
+                };
+                let Some(inverse_descriptor) = descriptor_by_key.get(symbol.key.as_str()).copied()
+                else {
+                    continue;
+                };
+                if inverse_descriptor.relationship_flavor != Some(RelationshipFlavor::Inverse) {
+                    diagnostics.push(Diagnostic::error(
+                        DiagnosticLayer::SchemaAware,
+                        DiagnosticKind::WrongRelationshipFlavor {
+                            role: ReferenceRole::HasInverse,
+                            descriptor: descriptor.key.clone(),
+                            target: inverse_descriptor.key.clone(),
+                            actual: relationship_flavor_label(
+                                inverse_descriptor.relationship_flavor,
+                            ),
+                            expected: "inverse".to_string(),
+                        },
+                        Some(descriptor.origin.clone()),
+                    ));
+                }
+                if let Some(back_reference) =
+                    inverse_descriptor.inverse_of.as_ref().map(|reference| reference.target.clone())
+                {
+                    if back_reference != descriptor.key && back_reference != descriptor.name {
+                        diagnostics.push(Diagnostic::error(
+                            DiagnosticLayer::SchemaAware,
+                            DiagnosticKind::InverseRelationshipMismatch {
+                                descriptor: descriptor.key.clone(),
+                                inverse: inverse_descriptor.key.clone(),
+                                expected: descriptor.key.clone(),
+                            },
+                            Some(descriptor.origin.clone()),
+                        ));
+                    }
+                }
+            }
+            RelationshipFlavor::Inverse => {
+                let Some(inverse_of) = &descriptor.inverse_of else {
+                    continue;
+                };
+                if declared_to_inverses.get(&inverse_of.target).map_or(0, Vec::len) > 1 {
+                    diagnostics.push(Diagnostic::error(
+                        DiagnosticLayer::SchemaAware,
+                        DiagnosticKind::DuplicateInverseRelationship {
+                            descriptor: descriptor.key.clone(),
+                            inverse: inverse_of.target.clone(),
+                        },
+                        Some(descriptor.origin.clone()),
+                    ));
+                }
+
+                let Some(symbol) = resolved_symbol(inverse_of, symbols) else {
+                    continue;
+                };
+                let Some(declared_descriptor) = descriptor_by_key.get(symbol.key.as_str()).copied()
+                else {
+                    continue;
+                };
+                if declared_descriptor.relationship_flavor == Some(RelationshipFlavor::Inverse) {
+                    diagnostics.push(Diagnostic::error(
+                        DiagnosticLayer::SchemaAware,
+                        DiagnosticKind::WrongRelationshipFlavor {
+                            role: ReferenceRole::InverseOf,
+                            descriptor: descriptor.key.clone(),
+                            target: declared_descriptor.key.clone(),
+                            actual: relationship_flavor_label(
+                                declared_descriptor.relationship_flavor,
+                            ),
+                            expected: "declared".to_string(),
+                        },
+                        Some(descriptor.origin.clone()),
+                    ));
+                }
+                if let Some(back_reference) = declared_descriptor
+                    .has_inverse
+                    .as_ref()
+                    .map(|reference| reference.target.clone())
+                {
+                    if back_reference != descriptor.key && back_reference != descriptor.name {
+                        diagnostics.push(Diagnostic::error(
+                            DiagnosticLayer::SchemaAware,
+                            DiagnosticKind::InverseRelationshipMismatch {
+                                descriptor: descriptor.key.clone(),
+                                inverse: declared_descriptor.key.clone(),
+                                expected: descriptor.key.clone(),
+                            },
+                            Some(descriptor.origin.clone()),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+fn validate_local_duplicates(model: &SemanticModel, symbols: &SymbolIndex) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for descriptor in &model.descriptors {
+        diagnostics.extend(find_duplicate_members(
+            descriptor,
+            &descriptor.instance_properties,
+            ReferenceRole::InstanceProperty,
+            symbols,
+        ));
+        diagnostics.extend(find_duplicate_members(
+            descriptor,
+            &descriptor.instance_relationships,
+            ReferenceRole::InstanceRelationship,
+            symbols,
+        ));
+    }
+    diagnostics
+}
+
+fn validate_effective_keys(
+    model: &SemanticModel,
+    symbols: &SymbolIndex,
+    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for descriptor in &model.descriptors {
+        let Some(resolution) = resolve_effective_key_rule(descriptor, symbols, descriptor_by_key)
+        else {
+            diagnostics.push(Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::MissingEffectiveKeyRule { descriptor: descriptor.key.clone() },
+                Some(descriptor.origin.clone()),
+            ));
+            continue;
+        };
+
+        let generated = match generate_key(descriptor, &resolution, symbols, descriptor_by_key) {
+            Ok(generated) => generated,
+            Err(kind) => {
+                diagnostics.push(Diagnostic::error(
+                    DiagnosticLayer::SchemaAware,
+                    kind,
+                    Some(descriptor.origin.clone()),
+                ));
+                continue;
+            }
+        };
+
+        if generated != descriptor.key {
+            diagnostics.push(Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::AuthoredKeyMismatch {
+                    descriptor: descriptor.key.clone(),
+                    expected: generated,
+                    actual: descriptor.key.clone(),
+                },
+                Some(descriptor.origin.clone()),
+            ));
+        }
+    }
+    diagnostics
+}
+
+fn requires_extends(descriptor: &TypeDescriptor) -> bool {
+    !(descriptor.kind == DescriptorKind::Schema
+        || (descriptor.kind == DescriptorKind::HolonType
+            && descriptor.name == "MetaTypeDescriptor"))
+}
+
+fn has_extends_cycle(
+    descriptor: &TypeDescriptor,
+    symbols: &SymbolIndex,
+    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+) -> bool {
+    let mut seen = HashSet::new();
+    let mut current = descriptor.extends.as_ref();
+    while let Some(reference) = current {
+        let Some(symbol) = resolved_symbol(reference, symbols) else {
+            return false;
+        };
+        if !seen.insert(symbol.key.clone()) {
+            return true;
+        }
+        if symbol.key == descriptor.key {
+            return true;
+        }
+        current = descriptor_by_key.get(symbol.key.as_str()).and_then(|next| next.extends.as_ref());
+    }
+    false
+}
+
+fn find_duplicate_members(
+    descriptor: &TypeDescriptor,
+    references: &[SemanticReference],
+    role: ReferenceRole,
+    symbols: &SymbolIndex,
+) -> Vec<Diagnostic> {
+    let mut seen = HashSet::new();
+    let mut diagnostics = Vec::new();
+    for reference in references {
+        let name = resolved_symbol(reference, symbols)
+            .map(|symbol| symbol.name.clone())
+            .unwrap_or_else(|| reference.target.clone());
+        if !seen.insert(name.clone()) {
+            diagnostics.push(Diagnostic::error(
+                DiagnosticLayer::SchemaAware,
+                DiagnosticKind::DuplicateLocalMember {
+                    descriptor: descriptor.key.clone(),
+                    role,
+                    name,
+                },
+                Some(descriptor.origin.clone()),
+            ));
+        }
+    }
+    diagnostics
+}
+
+fn resolve_effective_key_rule<'a>(
+    descriptor: &'a TypeDescriptor,
+    symbols: &'a SymbolIndex,
+    descriptor_by_key: &'a HashMap<&str, &TypeDescriptor>,
+) -> Option<String> {
+    if descriptor.extends.is_some() {
+        let mut current = descriptor.extends.as_ref();
+        let mut visited = HashSet::new();
+        while let Some(reference) = current {
+            let symbol = resolved_symbol(reference, symbols)?;
+            if !visited.insert(symbol.key.clone()) {
+                break;
+            }
+            let parent = descriptor_by_key.get(symbol.key.as_str())?;
+            if let Some(rule) =
+                parent.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
+            {
+                return Some(rule);
+            }
+            current = parent.extends.as_ref();
+        }
+    } else if let Some(rule) =
+        descriptor.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
+    {
+        return Some(rule);
+    }
+
+    let described_by = describing_type_target(descriptor)?;
+    let describing_symbol = symbols.lookup_reference_target(described_by)?;
+    let mut current = descriptor_by_key.get(describing_symbol.key.as_str()).copied();
+    let mut visited = HashSet::new();
+    while let Some(next) = current {
+        if !visited.insert(next.key.clone()) {
+            break;
+        }
+        if let Some(rule) =
+            next.key_rule.as_ref().map(|reference| canonical_key_rule(&reference.target))
+        {
+            return Some(rule);
+        }
+        current = next
+            .extends
+            .as_ref()
+            .and_then(|reference| resolved_symbol(reference, symbols))
+            .and_then(|symbol| descriptor_by_key.get(symbol.key.as_str()).copied());
+    }
+    None
+}
+
+fn generate_key(
+    descriptor: &TypeDescriptor,
+    key_rule: &str,
+    symbols: &SymbolIndex,
+    descriptor_by_key: &HashMap<&str, &TypeDescriptor>,
+) -> Result<String, DiagnosticKind> {
+    match key_rule {
+        TYPE_NAME_RULE => Ok(descriptor.name.clone()),
+        SCHEMA_NAME_RULE => Ok(descriptor.owning_schema.clone()),
+        TYPE_KIND_RULE => projected_type_kind(descriptor)
+            .map(|kind| format!("{}.{}", descriptor.name, kind))
+            .ok_or_else(|| DiagnosticKind::MissingKeyRuleInput {
+                descriptor: descriptor.key.clone(),
+                key_rule: key_rule.to_string(),
+                field: "instance_type_kind".to_string(),
+            }),
+        ENUM_VARIANT_RULE => {
+            let Some(parent) = descriptor.variant_of.as_ref() else {
+                return Err(DiagnosticKind::MissingKeyRuleInput {
+                    descriptor: descriptor.key.clone(),
+                    key_rule: key_rule.to_string(),
+                    field: "VariantOf".to_string(),
+                });
+            };
+            let parent_key = resolved_symbol(parent, symbols)
+                .map(|symbol| symbol.key.clone())
+                .unwrap_or_else(|| parent.target.clone());
+            Ok(format!("{}.{}", parent_key, descriptor.name))
+        }
+        RELATIONSHIP_RULE => {
+            let Some(source) = descriptor.source_type.as_ref() else {
+                return Err(DiagnosticKind::MissingKeyRuleInput {
+                    descriptor: descriptor.key.clone(),
+                    key_rule: key_rule.to_string(),
+                    field: "SourceType".to_string(),
+                });
+            };
+            let Some(target) = descriptor.target_type.as_ref() else {
+                return Err(DiagnosticKind::MissingKeyRuleInput {
+                    descriptor: descriptor.key.clone(),
+                    key_rule: key_rule.to_string(),
+                    field: "TargetType".to_string(),
+                });
+            };
+            let source_key = resolved_symbol(source, symbols)
+                .map(|symbol| symbol.key.clone())
+                .unwrap_or_else(|| source.target.clone());
+            let target_key = resolved_symbol(target, symbols)
+                .map(|symbol| symbol.key.clone())
+                .unwrap_or_else(|| target.target.clone());
+            Ok(format!("({source_key})-[{}]->({target_key})", descriptor.name))
+        }
+        EXTENDED_TYPE_RULE => {
+            let Some(parent) = descriptor.extends.as_ref() else {
+                return Err(DiagnosticKind::MissingKeyRuleInput {
+                    descriptor: descriptor.key.clone(),
+                    key_rule: key_rule.to_string(),
+                    field: "Extends".to_string(),
+                });
+            };
+            let parent_name = resolved_symbol(parent, symbols)
+                .and_then(|symbol| descriptor_by_key.get(symbol.key.as_str()).copied())
+                .map(|descriptor| descriptor.name.clone())
+                .unwrap_or_else(|| parent.target.clone());
+            Ok(format!("{}.{}", descriptor.name, parent_name))
+        }
+        NONE_RULE => Ok(String::new()),
+        _ => Err(DiagnosticKind::UnsupportedKeyRule {
+            descriptor: descriptor.key.clone(),
+            key_rule: key_rule.to_string(),
+        }),
+    }
+}
+
+fn canonical_key_rule(target: &str) -> String {
+    match target {
+        "TypeNameRule" | TYPE_NAME_RULE => TYPE_NAME_RULE.to_string(),
+        "SchemaNameRule" | SCHEMA_NAME_RULE => SCHEMA_NAME_RULE.to_string(),
+        "TypeKindRule" | TYPE_KIND_RULE => TYPE_KIND_RULE.to_string(),
+        "EnumVariantRule" | "EnumVariantRule.FormatRule" | ENUM_VARIANT_RULE => {
+            ENUM_VARIANT_RULE.to_string()
+        }
+        "RelationshipRule" | RELATIONSHIP_RULE => RELATIONSHIP_RULE.to_string(),
+        "ExtendedTypeRule" | EXTENDED_TYPE_RULE => EXTENDED_TYPE_RULE.to_string(),
+        "NoneRule" | NONE_RULE => NONE_RULE.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn describing_type_target(descriptor: &TypeDescriptor) -> Option<&'static str> {
+    match descriptor.kind {
+        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => Some("MetaHolonType"),
+        DescriptorKind::PropertyType => Some("MetaPropertyType"),
+        DescriptorKind::RelationshipType => {
+            Some(if descriptor.relationship_flavor == Some(RelationshipFlavor::Inverse) {
+                "MetaInverseRelationshipType"
+            } else {
+                "MetaDeclaredRelationshipType"
+            })
+        }
+        DescriptorKind::ValueType | DescriptorKind::Enum => Some("MetaValueType"),
+        DescriptorKind::EnumVariant | DescriptorKind::Schema => None,
+    }
+}
+
+fn relationship_flavor_label(flavor: Option<RelationshipFlavor>) -> String {
+    match flavor {
+        Some(RelationshipFlavor::Declared) => "declared".to_string(),
+        Some(RelationshipFlavor::Inverse) => "inverse".to_string(),
+        None => "unspecified".to_string(),
+    }
+}
+
+fn resolved_symbol<'a>(
+    reference: &SemanticReference,
+    symbols: &'a SymbolIndex,
+) -> Option<&'a Symbol> {
+    reference.resolved.and_then(|id| symbols.lookup_by_id(id))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TypeKindFamily {
+    Holon,
+    Property,
+    Relationship,
+    Value,
+    EnumVariant,
+}
+
+impl TypeKindFamily {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Holon => "TypeKind.Holon",
+            Self::Property => "TypeKind.Property",
+            Self::Relationship => "TypeKind.Relationship",
+            Self::Value => "TypeKind.Value",
+            Self::EnumVariant => "TypeKind.EnumVariant",
+        }
+    }
+}
+
+fn type_kind_family_for_descriptor(descriptor: &TypeDescriptor) -> Option<TypeKindFamily> {
+    match descriptor.kind {
+        DescriptorKind::Schema => None,
+        DescriptorKind::PropertyType => Some(TypeKindFamily::Property),
+        DescriptorKind::RelationshipType => Some(TypeKindFamily::Relationship),
+        DescriptorKind::ValueType | DescriptorKind::Enum => Some(TypeKindFamily::Value),
+        DescriptorKind::EnumVariant => Some(TypeKindFamily::EnumVariant),
+        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => {
+            if descriptor.name == "PropertyType" || descriptor.name.ends_with("PropertyType") {
+                Some(TypeKindFamily::Property)
+            } else if descriptor.name == "ValueType" || descriptor.name.ends_with("ValueType") {
+                Some(TypeKindFamily::Value)
+            } else if descriptor.name == "DeclaredRelationshipType"
+                || descriptor.name == "InverseRelationshipType"
+                || descriptor.name == "MetaRelationshipType"
+                || descriptor.name.ends_with("RelationshipType")
+            {
+                Some(TypeKindFamily::Relationship)
+            } else {
+                Some(TypeKindFamily::Holon)
+            }
+        }
+    }
+}
+
+fn type_kind_family_for_text(text: &str) -> Option<TypeKindFamily> {
+    if text.starts_with("TypeKind.Property") {
+        Some(TypeKindFamily::Property)
+    } else if text.starts_with("TypeKind.Relationship") {
+        Some(TypeKindFamily::Relationship)
+    } else if text.starts_with("TypeKind.Value") {
+        Some(TypeKindFamily::Value)
+    } else if text.starts_with("TypeKind.EnumVariant") {
+        Some(TypeKindFamily::EnumVariant)
+    } else if text.starts_with("TypeKind.Holon") {
+        Some(TypeKindFamily::Holon)
+    } else {
+        None
+    }
+}
+
+fn type_kind_families_compatible(actual: TypeKindFamily, expected: TypeKindFamily) -> bool {
+    actual == expected
+        || matches!(
+            (actual, expected),
+            (TypeKindFamily::EnumVariant, TypeKindFamily::Value)
+                | (TypeKindFamily::Value, TypeKindFamily::EnumVariant)
+        )
+}
+
+fn is_bootstrap_descriptor(descriptor: &TypeDescriptor) -> bool {
+    descriptor.name.starts_with("Meta")
+        || matches!(
+            descriptor.name.as_str(),
+            "TypeDescriptor"
+                | "HolonType"
+                | "ValueType"
+                | "PropertyType"
+                | "RelationshipType"
+                | "DeclaredRelationshipType"
+                | "InverseRelationshipType"
+        )
+}
+
+fn projected_type_kind(descriptor: &TypeDescriptor) -> Option<&'static str> {
+    match descriptor.kind {
+        DescriptorKind::Schema => None,
+        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => Some("TypeKind.Holon"),
+        DescriptorKind::PropertyType => Some("TypeKind.Property"),
+        DescriptorKind::RelationshipType => Some("TypeKind.Relationship"),
+        DescriptorKind::Enum => Some("TypeKind.Value.Enum"),
+        DescriptorKind::EnumVariant => Some("TypeKind.EnumVariant"),
+        DescriptorKind::ValueType => Some(infer_value_kind(descriptor)),
+    }
+}
+
+fn infer_value_kind(descriptor: &TypeDescriptor) -> &'static str {
+    if descriptor.name == "MetaValueType" {
+        return "TypeKind.Holon";
+    }
+    if descriptor.name == "ValueType" {
+        return "TypeKind.Value";
+    }
+    if matches!(descriptor.name.as_str(), "EnumVariantValueType" | "MapEnumVariantValueType") {
+        return "TypeKind.EnumVariant";
+    }
+    if descriptor.name.ends_with("StringValueType") {
+        return "TypeKind.Value.String";
+    }
+    if descriptor.name.ends_with("IntegerValueType") {
+        return "TypeKind.Value.Integer";
+    }
+    if descriptor.name.ends_with("BooleanValueType") {
+        return "TypeKind.Value.Boolean";
+    }
+    if descriptor.name.ends_with("BytesValueType") || descriptor.name == "HolonIdValueType" {
+        return "TypeKind.Value.Bytes";
+    }
+    if descriptor.name.ends_with("ValueArrayType")
+        || descriptor.name.ends_with("ValueArrayValueType")
+    {
+        return "TypeKind.Value.Array";
+    }
+    if descriptor.name.ends_with("EnumValueType") {
+        return "TypeKind.Value.Enum";
+    }
+    match descriptor.extends.as_ref().map(|reference| reference.target.as_str()) {
+        Some("MetaTypeDescriptor") | Some("MetaValueType") => "TypeKind.Holon",
+        Some("StringValueType") | Some("MapStringValueType") => "TypeKind.Value.String",
+        Some("IntegerValueType") | Some("MapIntegerValueType") => "TypeKind.Value.Integer",
+        Some("BooleanValueType") | Some("MapBooleanValueType") => "TypeKind.Value.Boolean",
+        Some("BytesValueType") | Some("MapBytesValueType") | Some("HolonIdValueType") => {
+            "TypeKind.Value.Bytes"
+        }
+        Some("ValueArrayValueType") | Some("MapValueArrayType") => "TypeKind.Value.Array",
+        Some("EnumValueType") | Some("MapEnumValueType") => "TypeKind.Value.Enum",
+        Some("EnumVariantValueType") | Some("MapEnumVariantValueType") => "TypeKind.EnumVariant",
+        _ => "TypeKind.Value.String",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema_ir::{Origin, SourceKind};
+
+    fn origin() -> Origin {
+        Origin::new(SourceKind::Generated)
+    }
+
+    fn schema_model() -> SemanticModel {
+        let mut model = SemanticModel::new();
+        model.push_schema(crate::schema_ir::Schema {
+            name: "Test Schema".to_string(),
+            key: "Test Schema".to_string(),
+            origin: origin(),
+            dependencies: Vec::new(),
+            literal_properties: crate::literal_value::LiteralObject::new(),
+            literal_relationships: Vec::new(),
+            header: None,
+            allows_additional_properties: false,
+            allows_additional_relationships: false,
+        });
+        model
+    }
+
+    #[test]
+    fn detects_invalid_cardinality_bounds() {
+        let mut model = schema_model();
+        let mut descriptor = TypeDescriptor::new(
+            "Owns.RelationshipType",
+            "Owns",
+            DescriptorKind::RelationshipType,
+            "Test Schema",
+            origin(),
+        );
+        descriptor.component_of =
+            Some(SemanticReference::unresolved(ReferenceRole::ComponentOf, "Test Schema"));
+        descriptor.extends =
+            Some(SemanticReference::unresolved(ReferenceRole::Extends, "DeclaredRelationshipType"));
+        descriptor.relationship_flavor = Some(RelationshipFlavor::Declared);
+        descriptor.min_cardinality = Some(3);
+        descriptor.max_cardinality = Some(1);
+        model.push_descriptor(descriptor);
+
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let diagnostics = validate_model(&model, &symbols);
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            DiagnosticKind::InvalidCardinalityBounds { .. }
+        )));
+    }
+
+    #[test]
+    fn detects_duplicate_instance_property_names() {
+        let mut model = schema_model();
+        let value = TypeDescriptor::new(
+            "MapStringValueType",
+            "MapStringValueType",
+            DescriptorKind::ValueType,
+            "Test Schema",
+            origin(),
+        );
+        let mut property = TypeDescriptor::new(
+            "Name.PropertyType",
+            "Name",
+            DescriptorKind::PropertyType,
+            "Test Schema",
+            origin(),
+        );
+        property.component_of =
+            Some(SemanticReference::unresolved(ReferenceRole::ComponentOf, "Test Schema"));
+        property.extends =
+            Some(SemanticReference::unresolved(ReferenceRole::Extends, "PropertyType"));
+        property.value_type =
+            Some(SemanticReference::unresolved(ReferenceRole::ValueType, "MapStringValueType"));
+        let mut holon = TypeDescriptor::new(
+            "Person.HolonType",
+            "Person",
+            DescriptorKind::HolonType,
+            "Test Schema",
+            origin(),
+        );
+        holon.component_of =
+            Some(SemanticReference::unresolved(ReferenceRole::ComponentOf, "Test Schema"));
+        holon.extends = Some(SemanticReference::unresolved(ReferenceRole::Extends, "HolonType"));
+        holon.instance_properties = vec![
+            SemanticReference::unresolved(ReferenceRole::InstanceProperty, "Name.PropertyType"),
+            SemanticReference::unresolved(ReferenceRole::InstanceProperty, "Name.PropertyType"),
+        ];
+        model.push_descriptor(value);
+        model.push_descriptor(property);
+        model.push_descriptor(holon);
+
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let diagnostics = validate_model(&model, &symbols);
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            DiagnosticKind::DuplicateLocalMember { role: ReferenceRole::InstanceProperty, .. }
+        )));
+    }
+}

--- a/shared_crates/map_schema_semantic/src/validator.rs
+++ b/shared_crates/map_schema_semantic/src/validator.rs
@@ -3,7 +3,7 @@
 //! This module owns source-neutral semantic checks that apply after lowering and reference
 //! resolution. Source adapters remain responsible for syntax and source-format conveniences.
 
-use descriptor_semantics::{ancestors, effective_holon_key_rule};
+use descriptor_semantics::{ancestors, describing_type, effective_holon_key_rule, DescriptorGraph};
 
 use crate::{
     descriptor_conformance::validate_canonical_model_values,
@@ -37,7 +37,7 @@ pub fn validate_model(model: &SemanticModel, symbols: &SymbolIndex) -> Vec<Diagn
     diagnostics.extend(validate_required_slots(model));
     if let Ok(graph) = CanonicalDescriptorGraph::new(model, symbols) {
         diagnostics.extend(validate_canonical_model_values(&graph));
-        diagnostics.extend(validate_inheritance_graph(model, &graph));
+        diagnostics.extend(validate_inheritance_graph(&graph));
         diagnostics.extend(validate_effective_keys(model, symbols, &descriptor_by_key, &graph));
     }
     diagnostics.extend(validate_relationship_pairs(model, symbols, &descriptor_by_key));
@@ -46,7 +46,10 @@ pub fn validate_model(model: &SemanticModel, symbols: &SymbolIndex) -> Vec<Diagn
     diagnostics
 }
 
-/// Synthesizes missing inverse-pair references from the side that was authored explicitly.
+/// Completes inverse-pair references from whichever side authored the pair.
+///
+/// Source adapters may apply this to a validation clone when their representation serializes only
+/// one direction. The authored model remains unchanged for faithful round trips.
 pub fn normalize_relationship_pairs(model: &mut SemanticModel, symbols: &SymbolIndex) {
     let descriptor_indexes = model
         .descriptors
@@ -189,20 +192,75 @@ fn validate_required_slots(model: &SemanticModel) -> Vec<Diagnostic> {
     diagnostics
 }
 
-fn validate_inheritance_graph(
-    model: &SemanticModel,
-    graph: &CanonicalDescriptorGraph,
-) -> Vec<Diagnostic> {
+fn validate_inheritance_graph(graph: &CanonicalDescriptorGraph) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
-    for descriptor in &model.descriptors {
-        let Some(node) = graph.node_by_key(&descriptor.key) else {
-            continue;
+    for node in graph.nodes() {
+        let described_by = match describing_type(graph, &node) {
+            Ok(described_by) => described_by,
+            Err(error) => {
+                diagnostics.push(graph.diagnostic(error));
+                continue;
+            }
         };
+        let source_is_type = match graph.is_type_descriptor(&described_by) {
+            Ok(is_type) => is_type,
+            Err(error) => {
+                diagnostics.push(
+                    graph.diagnostic(descriptor_semantics::DescriptorSemanticsError::Access(error)),
+                );
+                continue;
+            }
+        };
+        let extends_targets = match graph.extends_targets(&node) {
+            Ok(targets) => targets,
+            Err(error) => {
+                diagnostics.push(
+                    graph.diagnostic(descriptor_semantics::DescriptorSemanticsError::Access(error)),
+                );
+                continue;
+            }
+        };
+
+        if !extends_targets.is_empty() && !source_is_type {
+            diagnostics.push(extends_endpoint_not_type(graph, node, node));
+        }
+
         if let Err(error) = ancestors(graph, &node) {
             diagnostics.push(graph.diagnostic(error));
         }
+
+        for target in extends_targets {
+            let target_is_type = describing_type(graph, &target).and_then(|target_descriptor| {
+                graph
+                    .is_type_descriptor(&target_descriptor)
+                    .map_err(descriptor_semantics::DescriptorSemanticsError::Access)
+            });
+            match target_is_type {
+                Ok(false) => diagnostics.push(extends_endpoint_not_type(graph, node, target)),
+                Err(error) => {
+                    diagnostics.push(graph.diagnostic(error));
+                    continue;
+                }
+                Ok(true) => {}
+            }
+        }
     }
     diagnostics
+}
+
+fn extends_endpoint_not_type(
+    graph: &CanonicalDescriptorGraph,
+    source: crate::CanonicalNodeId,
+    endpoint: crate::CanonicalNodeId,
+) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticLayer::SchemaAware,
+        DiagnosticKind::ExtendsEndpointNotType {
+            descriptor: graph.key(source).unwrap_or("<unknown>").to_string(),
+            endpoint: graph.key(endpoint).unwrap_or("<unknown>").to_string(),
+        },
+        graph.holon(source).map(|holon| holon.origin.clone()),
+    )
 }
 
 fn validate_relationship_pairs(
@@ -664,6 +722,87 @@ mod tests {
         assert!(diagnostics.iter().any(|diagnostic| matches!(
             diagnostic.kind,
             DiagnosticKind::DuplicateLocalMember { role: ReferenceRole::InstanceProperty, .. }
+        )));
+    }
+
+    fn inheritance_model(
+        child_type_kind: &str,
+        parent_type_kind: &str,
+        parent_described_by: &str,
+    ) -> SemanticModel {
+        let mut model = SemanticModel::new();
+        let mut type_descriptor = TypeDescriptor::new(
+            "TypeDescriptor.HolonType",
+            "TypeDescriptor",
+            DescriptorKind::TypeDescriptor,
+            "Test Schema",
+            origin(),
+        );
+        type_descriptor.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
+        type_descriptor.instance_type_kind = Some("TypeKind.Holon".to_string());
+
+        let mut ordinary_descriptor = TypeDescriptor::new(
+            "OrdinaryDescriptor.HolonType",
+            "OrdinaryDescriptor",
+            DescriptorKind::HolonType,
+            "Test Schema",
+            origin(),
+        );
+        ordinary_descriptor.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
+
+        let mut parent = TypeDescriptor::new(
+            "Parent.HolonType",
+            "Parent",
+            DescriptorKind::HolonType,
+            "Test Schema",
+            origin(),
+        );
+        parent
+            .described_by
+            .push(SemanticReference::unresolved(ReferenceRole::DescribedBy, parent_described_by));
+        parent.instance_type_kind = Some(parent_type_kind.to_string());
+
+        let mut child = TypeDescriptor::new(
+            "Child.HolonType",
+            "Child",
+            DescriptorKind::HolonType,
+            "Test Schema",
+            origin(),
+        );
+        child.described_by.push(SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "TypeDescriptor.HolonType",
+        ));
+        child.instance_type_kind = Some(child_type_kind.to_string());
+        child.extends =
+            Some(SemanticReference::unresolved(ReferenceRole::Extends, "Parent.HolonType"));
+
+        model.push_descriptor(type_descriptor);
+        model.push_descriptor(ordinary_descriptor);
+        model.push_descriptor(parent);
+        model.push_descriptor(child);
+        model
+    }
+
+    #[test]
+    fn rejects_extends_target_that_is_not_a_type() {
+        let mut model =
+            inheritance_model("TypeKind.Holon", "TypeKind.Holon", "OrdinaryDescriptor.HolonType");
+        let (symbols, _) = SymbolIndex::build(&mut model);
+        let graph = CanonicalDescriptorGraph::new(&model, &symbols).expect("canonical graph");
+
+        let diagnostics = validate_inheritance_graph(&graph);
+
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            DiagnosticKind::ExtendsEndpointNotType { descriptor, endpoint }
+                if descriptor == "Child.HolonType" && endpoint == "Parent.HolonType"
         )));
     }
 }

--- a/shared_crates/map_schema_semantic/src/validator.rs
+++ b/shared_crates/map_schema_semantic/src/validator.rs
@@ -880,6 +880,7 @@ mod tests {
             name: "Test Schema".to_string(),
             key: "Test Schema".to_string(),
             origin: origin(),
+            described_by: Vec::new(),
             dependencies: Vec::new(),
             literal_properties: crate::literal_value::LiteralObject::new(),
             literal_relationships: Vec::new(),

--- a/tools/map-schema/Cargo.lock
+++ b/tools/map-schema/Cargo.lock
@@ -114,6 +114,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "descriptor_semantics"
+version = "0.1.0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +160,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "map_schema_semantic"
 version = "0.1.0"
+dependencies = [
+ "descriptor_semantics",
+]
 
 [[package]]
 name = "map_schema_tool"

--- a/tools/map-schema/examples/diagnostic-zoo.tdl
+++ b/tools/map-schema/examples/diagnostic-zoo.tdl
@@ -1,0 +1,99 @@
+// Intentionally invalid TDL for exercising accumulated semantic diagnostics.
+// Run with the core schema corpus so canonical references can resolve:
+// cargo run --manifest-path tools/map-schema/Cargo.toml -- check schema-src tools/map-schema/examples/diagnostic-zoo.tdl
+
+schema Diagnostic Zoo-v0.0.1 {
+  depends_on MAP Core Schema-v0.0.7
+  header {
+    description: "Intentional semantic diagnostic corpus."
+  }
+}
+
+holon ZooBook {
+  header {
+    description: "Local holon used as a deliberately wrong property value type."
+  }
+}
+
+property LocalName {
+  value MapStringValueType
+}
+
+holon DuplicateSymbolThing {
+  properties {
+    LocalName.PropertyType
+  }
+}
+
+holon DuplicateSymbolThing {
+  properties {
+    LocalName.PropertyType
+  }
+}
+
+property MissingValueType {
+  header {
+    description: "Intentionally omits ValueType."
+  }
+}
+
+property WrongValueType {
+  value ZooBook
+}
+
+holon DuplicateMembers {
+  properties {
+    LocalName.PropertyType
+    LocalName.PropertyType
+  }
+}
+
+property PropertyExtendsHolon {
+  extends ZooBook
+  value MapStringValueType
+}
+
+holon WrongProjectedKind {
+  properties {
+    instance_type_kind: "TypeKind.Relationship"
+  }
+}
+
+holon CycleA {
+  extends CycleB
+}
+
+holon CycleB {
+  extends CycleA
+}
+
+def relationship MissingInverseRelationship {
+  source TypeDescriptor.HolonType
+  target Schema.HolonType
+  cardinality 5..1
+}
+
+def relationship DeclaredWrongFlavorA {
+  source TypeDescriptor.HolonType
+  target Schema.HolonType
+  inverse SharedInverse
+  cardinality 0..32767
+}
+
+def relationship DeclaredWrongFlavorB {
+  source TypeDescriptor.HolonType
+  target Schema.HolonType
+  inverse SharedInverse
+  cardinality 0..32767
+}
+
+inverse relationship SharedInverse {
+  source Schema.HolonType
+  target TypeDescriptor.HolonType
+  inverse DeclaredWrongFlavorB
+  cardinality 0..32767
+}
+
+holon UnsupportedRuleThing {
+  keyrule FormatRule.KeyRuleType
+}

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -7,6 +7,7 @@
 //! so schema dependencies and cross-file references can be resolved consistently.
 
 use anyhow::{anyhow, Context, Result};
+use map_schema_semantic::{normalize_relationship_pairs, normalize_validation_model, validate_model};
 /// Diagnostic formatting and source-oriented validation messages.
 pub mod diagnostics;
 mod literal_bridge;
@@ -28,7 +29,7 @@ pub mod tdl_compiler;
 mod test_support;
 
 use crate::{
-    diagnostics::Diagnostic,
+    diagnostics::{format_diagnostics, Diagnostic},
     literal_bridge::{json_map_to_literal_object, render_literal_value},
     loader_ir::{LoaderDocument, LoaderHolon, LoaderMeta, LoaderReference, LoaderRelationship},
     schema_index::SymbolIndex,
@@ -45,7 +46,7 @@ use crate::{
 use serde::Deserialize;
 use serde_json::Value;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -182,6 +183,246 @@ pub fn dump_symbols_from_string(raw: &str, source_name: impl Into<PathBuf>) -> R
     Ok(render_symbol_dump(&lowered.global_model, &lowered.symbols, &lowered.diagnostics))
 }
 
+/// Compares two schema corpora by lowering both into Canonical Holon IR and diffing semantics.
+///
+/// Each side must lower without blocking diagnostics. The left and right corpora may use different
+/// source adapters (`.json` or `.tdl`), but each side must be internally homogeneous.
+pub fn diff_inputs(left: &[PathBuf], right: &[PathBuf]) -> Result<String> {
+    let left_model = load_valid_semantic_model(left, "left")?;
+    let right_model = load_valid_semantic_model(right, "right")?;
+
+    let left_signature = left_model.comparable_signature();
+    let right_signature = right_model.comparable_signature();
+
+    Ok(render_semantic_diff(&left_signature, &right_signature))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputFormat {
+    Json,
+    Tdl,
+}
+
+fn load_valid_semantic_model(inputs: &[PathBuf], side: &str) -> Result<SemanticModel> {
+    let (model, diagnostics) = match detect_input_format(inputs)? {
+        InputFormat::Json => {
+            let lowered = lower_inputs_to_schema_ir(inputs)?;
+            (lowered.global_model, lowered.diagnostics)
+        }
+        InputFormat::Tdl => crate::tdl_compiler::load_semantic_model(inputs)?,
+    };
+
+    if diagnostics.is_empty() {
+        Ok(model)
+    } else {
+        Err(anyhow!("{} inputs are not semantically valid:\n{}", side, format_diagnostics(&diagnostics)))
+    }
+}
+
+fn detect_input_format(inputs: &[PathBuf]) -> Result<InputFormat> {
+    let json_files = collect_input_files(inputs)?;
+    let tdl_file_count = crate::tdl_compiler::discovered_input_count(inputs)?;
+
+    match (!json_files.is_empty(), tdl_file_count > 0) {
+        (true, false) => Ok(InputFormat::Json),
+        (false, true) => Ok(InputFormat::Tdl),
+        (true, true) => Err(anyhow!(
+            "input set mixes .json and .tdl files; semantic diff expects one source format per side"
+        )),
+        (false, false) => Err(anyhow!(
+            "no supported schema inputs found; expected at least one .json or .tdl file"
+        )),
+    }
+}
+
+fn render_semantic_diff(
+    left: &crate::schema_ir::ComparableSemanticModel,
+    right: &crate::schema_ir::ComparableSemanticModel,
+) -> String {
+    let schema_diff = semantic_schema_diff(left, right);
+    let descriptor_diff = semantic_descriptor_diff(left, right);
+
+    if schema_diff.is_empty() && descriptor_diff.is_empty() {
+        return "no semantic diff\n".to_string();
+    }
+
+    let mut out = String::from("semantic diff\n");
+    for line in schema_diff {
+        out.push_str(&line);
+        out.push('\n');
+    }
+    for line in descriptor_diff {
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out
+}
+
+fn semantic_schema_diff(
+    left: &crate::schema_ir::ComparableSemanticModel,
+    right: &crate::schema_ir::ComparableSemanticModel,
+) -> Vec<String> {
+    let left_by_key =
+        left.schemas.iter().cloned().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
+    let right_by_key =
+        right.schemas.iter().cloned().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
+    let all_keys = left_by_key
+        .keys()
+        .chain(right_by_key.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut lines = Vec::new();
+    for key in all_keys {
+        match (left_by_key.get(&key), right_by_key.get(&key)) {
+            (Some(left_schema), Some(right_schema)) => {
+                let field_diff = render_schema_field_diff(left_schema, right_schema);
+                if !field_diff.is_empty() {
+                    lines.push(format!("schema `{}` changed", key));
+                    lines.extend(field_diff.into_iter().map(|line| format!("  {line}")));
+                }
+            }
+            (Some(_), None) => lines.push(format!("schema `{}` only in left", key)),
+            (None, Some(_)) => lines.push(format!("schema `{}` only in right", key)),
+            (None, None) => {}
+        }
+    }
+    lines
+}
+
+fn render_schema_field_diff(
+    left: &crate::schema_ir::ComparableSchema,
+    right: &crate::schema_ir::ComparableSchema,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    push_changed_field(&mut lines, "name", &left.name, &right.name);
+    push_changed_field(&mut lines, "dependencies", &left.dependencies, &right.dependencies);
+    push_changed_field(
+        &mut lines,
+        "allows_additional_properties",
+        &left.allows_additional_properties,
+        &right.allows_additional_properties,
+    );
+    push_changed_field(
+        &mut lines,
+        "allows_additional_relationships",
+        &left.allows_additional_relationships,
+        &right.allows_additional_relationships,
+    );
+    lines
+}
+
+fn semantic_descriptor_diff(
+    left: &crate::schema_ir::ComparableSemanticModel,
+    right: &crate::schema_ir::ComparableSemanticModel,
+) -> Vec<String> {
+    let left_by_key = left
+        .descriptors
+        .iter()
+        .cloned()
+        .map(|descriptor| (descriptor.key.clone(), descriptor))
+        .collect::<BTreeMap<_, _>>();
+    let right_by_key = right
+        .descriptors
+        .iter()
+        .cloned()
+        .map(|descriptor| (descriptor.key.clone(), descriptor))
+        .collect::<BTreeMap<_, _>>();
+    let all_keys = left_by_key
+        .keys()
+        .chain(right_by_key.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut lines = Vec::new();
+    for key in all_keys {
+        match (left_by_key.get(&key), right_by_key.get(&key)) {
+            (Some(left_descriptor), Some(right_descriptor)) => {
+                let field_diff = render_descriptor_field_diff(left_descriptor, right_descriptor);
+                if !field_diff.is_empty() {
+                    lines.push(format!("descriptor `{}` changed", key));
+                    lines.extend(field_diff.into_iter().map(|line| format!("  {line}")));
+                }
+            }
+            (Some(_), None) => lines.push(format!("descriptor `{}` only in left", key)),
+            (None, Some(_)) => lines.push(format!("descriptor `{}` only in right", key)),
+            (None, None) => {}
+        }
+    }
+    lines
+}
+
+fn render_descriptor_field_diff(
+    left: &crate::schema_ir::ComparableDescriptor,
+    right: &crate::schema_ir::ComparableDescriptor,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    push_changed_field(&mut lines, "name", &left.name, &right.name);
+    push_changed_field(&mut lines, "kind", &left.kind, &right.kind);
+    push_changed_field(&mut lines, "owning_schema", &left.owning_schema, &right.owning_schema);
+    push_changed_field(&mut lines, "is_abstract", &left.is_abstract, &right.is_abstract);
+    push_changed_field(&mut lines, "references", &left.references, &right.references);
+    push_changed_field(
+        &mut lines,
+        "relationship_flavor",
+        &left.relationship_flavor,
+        &right.relationship_flavor,
+    );
+    push_changed_field(
+        &mut lines,
+        "is_definitional",
+        &left.is_definitional,
+        &right.is_definitional,
+    );
+    push_changed_field(
+        &mut lines,
+        "min_cardinality",
+        &left.min_cardinality,
+        &right.min_cardinality,
+    );
+    push_changed_field(
+        &mut lines,
+        "max_cardinality",
+        &left.max_cardinality,
+        &right.max_cardinality,
+    );
+    push_changed_field(
+        &mut lines,
+        "deletion_semantic",
+        &left.deletion_semantic,
+        &right.deletion_semantic,
+    );
+    push_changed_field(&mut lines, "is_ordered", &left.is_ordered, &right.is_ordered);
+    push_changed_field(
+        &mut lines,
+        "allows_duplicates",
+        &left.allows_duplicates,
+        &right.allows_duplicates,
+    );
+    push_changed_field(
+        &mut lines,
+        "allows_additional_properties",
+        &left.allows_additional_properties,
+        &right.allows_additional_properties,
+    );
+    push_changed_field(
+        &mut lines,
+        "allows_additional_relationships",
+        &left.allows_additional_relationships,
+        &right.allows_additional_relationships,
+    );
+    lines
+}
+
+fn push_changed_field<T>(lines: &mut Vec<String>, field: &str, left: &T, right: &T)
+where
+    T: std::fmt::Debug + PartialEq,
+{
+    if left != right {
+        lines.push(format!("{field}: left={left:?} right={right:?}"));
+    }
+}
+
 #[derive(Debug, Clone)]
 struct DiscoveredFile {
     source_path: PathBuf,
@@ -276,7 +517,14 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedFile>) -> Result<LoweredJso
         });
     }
 
-    let (symbols, diagnostics) = SymbolIndex::build(&mut global_model);
+    let (symbols, mut diagnostics) = SymbolIndex::build(&mut global_model);
+    let mut validation_model = global_model.clone();
+    normalize_validation_model(&mut validation_model);
+    normalize_relationship_pairs(&mut validation_model, &symbols);
+    diagnostics.extend(validate_model(&validation_model, &symbols));
+    for file in &mut files {
+        file.schema_model.resolve_references(&symbols);
+    }
 
     Ok(LoweredJsonProject { files, global_model, symbols, diagnostics })
 }
@@ -572,7 +820,6 @@ fn semantic_descriptor_from_holon(
     } else if kind == DescriptorKind::RelationshipType {
         descriptor.relationship_flavor = Some(RelationshipFlavor::Declared);
     }
-
     descriptor.literal_relationships = holon
         .relationships
         .iter()
@@ -1464,6 +1711,15 @@ mod tests {
         Ok(())
     }
 
+    fn write_tdl_file(path: &Path, contents: &str) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut file = fs::File::create(path)?;
+        file.write_all(contents.as_bytes())?;
+        Ok(())
+    }
+
     fn discovered_json_file_count(root: &Path) -> Result<usize> {
         Ok(collect_input_files(&[root.to_path_buf()])?.len())
     }
@@ -1472,9 +1728,24 @@ mod tests {
     fn decompiles_core_schema_corpus() -> Result<()> {
         let source_dir = source_fixture_dir();
         let out_dir = temp_out_dir();
+        let expected_dir = temp_out_dir();
         let files = decompile_inputs(&[source_dir.clone()], &out_dir)?;
         assert_eq!(files.len(), discovered_json_file_count(&source_dir)?);
-        crate::test_support::assert_dir_tree_eq(&schema_src_dir(), &out_dir);
+
+        fs::create_dir_all(&expected_dir)?;
+        for entry in fs::read_dir(schema_src_dir())? {
+            let path = entry?.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("tdl") {
+                continue;
+            }
+            let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+            if !file_name.contains("map-core-schema-") {
+                continue;
+            }
+            fs::copy(&path, expected_dir.join(file_name))?;
+        }
+
+        crate::test_support::assert_dir_tree_eq(&expected_dir, &out_dir);
         Ok(())
     }
 
@@ -1551,6 +1822,62 @@ mod tests {
                 comparable_signature_mismatch_report(&source_signature, &regenerated_signature)
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_diff_reports_no_difference_for_json_and_decompiled_tdl() -> Result<()> {
+        let source_dir = source_fixture_dir();
+        let decompiled_tdl_dir = temp_roundtrip_tdl_dir();
+        decompile_inputs(&[source_dir.clone()], &decompiled_tdl_dir)?;
+
+        let rendered = diff_inputs(&[source_dir], &[decompiled_tdl_dir])?;
+        assert_eq!(rendered, "no semantic diff\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_diff_reports_changed_descriptor_fields() -> Result<()> {
+        let left_dir = temp_domain_json_dir().join("left");
+        let right_dir = temp_domain_json_dir().join("right");
+        copy_directory_tree(&source_fixture_dir(), &left_dir)?;
+        copy_directory_tree(&source_fixture_dir(), &right_dir)?;
+
+        let right_root_path = right_dir.join("MAP Schema Types-map-core-schema-root.json");
+        let right_root = fs::read_to_string(&right_root_path)?;
+        let right_root = right_root
+            .replace("\"allows_additional_properties\": false", "\"allows_additional_properties\": true")
+            .replace("\"is_abstract_type\": false", "\"is_abstract_type\": true");
+        write_json_file(&right_root_path, &right_root)?;
+
+        let rendered = diff_inputs(&[left_dir], &[right_dir])?;
+        assert!(rendered.contains("semantic diff\n"), "{rendered}");
+        assert!(rendered.contains("allows_additional_properties: left=false right=true"), "{rendered}");
+        assert!(rendered.contains("descriptor `"), "{rendered}");
+        assert!(rendered.contains("is_abstract: left=false right=true"), "{rendered}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_diff_requires_diagnostic_free_inputs() -> Result<()> {
+        let invalid_tdl_dir = temp_roundtrip_tdl_dir();
+        write_tdl_file(
+            &invalid_tdl_dir.join("invalid.tdl"),
+            r#"schema InvalidSchema
+
+relationship Broken {
+  source HolonType
+}
+"#,
+        )?;
+
+        let error = diff_inputs(&[invalid_tdl_dir], &[source_fixture_dir()]).unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("left inputs are not semantically valid"));
+        assert!(rendered.contains("missing required field `TargetType`"));
 
         Ok(())
     }

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -134,7 +134,7 @@ pub fn decompile_inputs(inputs: &[PathBuf], out_dir: &Path) -> Result<Vec<PathBu
                 .with_context(|| format!("creating output directory {}", parent.display()))?;
         }
 
-        let contents = render_lowered_file(file)?;
+        let contents = render_lowered_file(file, &lowered.global_model)?;
         fs::write(&output, contents)
             .with_context(|| format!("writing decompiled TDL to {}", output.display()))?;
         written.push(output);
@@ -153,12 +153,9 @@ pub fn decompile_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Res
     let source_name = source_name.into();
     let parsed = parse_import_file_contents(raw, &source_name, source_name.clone())?;
     let lowered = lower_parsed_files_to_schema_ir(vec![parsed])?;
-    let file = lowered
-        .files
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow!("no JSON import document was lowered"))?;
-    render_lowered_file(&file)
+    let file =
+        lowered.files.first().ok_or_else(|| anyhow!("no JSON import document was lowered"))?;
+    render_lowered_file(file, &lowered.global_model)
 }
 
 /// Builds the derived semantic symbol table for JSON import inputs and returns a text dump.
@@ -191,10 +188,63 @@ pub fn diff_inputs(left: &[PathBuf], right: &[PathBuf]) -> Result<String> {
     let left_model = load_valid_semantic_model(left, "left")?;
     let right_model = load_valid_semantic_model(right, "right")?;
 
-    let left_signature = left_model.comparable_signature();
-    let right_signature = right_model.comparable_signature();
+    let left_signature = adapter_comparable_signature(&left_model);
+    let right_signature = adapter_comparable_signature(&right_model);
 
     Ok(render_semantic_diff(&left_signature, &right_signature, &left_model, &right_model))
+}
+
+/// Normalizes facts that concise TDL relationship syntax necessarily makes explicit.
+///
+/// JSON imports may encode an inverse pair only from the declared side and may omit the inverse
+/// deletion value. TDL's concise `inverse` clause closes the pair and applies its `Allow` default.
+/// These are adapter-representation differences, not changes to the represented relationship.
+fn adapter_comparable_signature(
+    model: &SemanticModel,
+) -> crate::schema_ir::ComparableSemanticModel {
+    let mut signature = model.comparable_signature();
+    let mut pairs = Vec::new();
+    for descriptor in &signature.descriptors {
+        for (role, target) in &descriptor.references {
+            match role {
+                ReferenceRole::HasInverse => pairs.push((descriptor.key.clone(), target.clone())),
+                ReferenceRole::InverseOf => pairs.push((target.clone(), descriptor.key.clone())),
+                _ => {}
+            }
+        }
+    }
+    pairs.sort();
+    pairs.dedup();
+
+    let descriptor_indexes = signature
+        .descriptors
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| (descriptor.key.clone(), index))
+        .collect::<HashMap<_, _>>();
+    for (declared_key, inverse_key) in pairs {
+        if let Some(index) = descriptor_indexes.get(&declared_key).copied() {
+            signature.descriptors[index]
+                .references
+                .push((ReferenceRole::HasInverse, inverse_key.clone()));
+        }
+        if let Some(index) = descriptor_indexes.get(&inverse_key).copied() {
+            signature.descriptors[index]
+                .references
+                .push((ReferenceRole::InverseOf, declared_key.clone()));
+        }
+    }
+
+    for descriptor in &mut signature.descriptors {
+        descriptor.references.sort();
+        descriptor.references.dedup();
+        if descriptor.relationship_flavor == Some(RelationshipFlavor::Inverse)
+            && descriptor.deletion_semantic.is_none()
+        {
+            descriptor.deletion_semantic = Some("Allow".to_string());
+        }
+    }
+    signature
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -421,6 +471,7 @@ fn normalized_descriptor_literal_properties(
                 | "allows_duplicates"
                 | "allows_additional_properties"
                 | "allows_additional_relationships"
+                | "is_required"
         ) {
             continue;
         }
@@ -833,8 +884,8 @@ fn component_of_schema_name(holon: &HolonRecord) -> Option<String> {
     relationship_targets(holon, "ComponentOf").into_iter().next()
 }
 
-fn render_lowered_file(file: &LoweredJsonFile) -> Result<String> {
-    render_semantic_file(&file.schema_model)
+fn render_lowered_file(file: &LoweredJsonFile, global_model: &SemanticModel) -> Result<String> {
+    render_semantic_file(&file.schema_model, global_model)
 }
 
 fn lower_file_to_loader_ir(file: &ParsedFile) -> LoaderDocument {
@@ -1140,7 +1191,7 @@ fn reference_role_for_relationship(name: &str) -> Option<ReferenceRole> {
     }
 }
 
-fn render_semantic_file(model: &SemanticModel) -> Result<String> {
+fn render_semantic_file(model: &SemanticModel, global_model: &SemanticModel) -> Result<String> {
     let mut out = String::new();
     let schema = model.schemas.first().context("semantic model has no schema")?;
     let emitted_key_lookup = build_emitted_key_lookup(&[model]);
@@ -1164,6 +1215,7 @@ fn render_semantic_file(model: &SemanticModel) -> Result<String> {
             descriptor,
             &enum_variant_groups,
             &emitted_key_lookup,
+            global_model,
         )?;
         if !out.ends_with("\n\n") {
             out.push('\n');
@@ -1257,9 +1309,12 @@ fn render_semantic_descriptor(
     descriptor: &TypeDescriptor,
     enum_variant_groups: &HashMap<String, Vec<&TypeDescriptor>>,
     emitted_key_lookup: &crate::schema_to_loader_ir::EmittedKeyLookup,
+    global_model: &SemanticModel,
 ) -> Result<()> {
     match preferred_descriptor_kind(descriptor) {
-        DescriptorKind::ValueType => render_semantic_value(out, descriptor, emitted_key_lookup),
+        DescriptorKind::ValueType => {
+            render_semantic_value(out, descriptor, emitted_key_lookup, global_model)
+        }
         DescriptorKind::Enum => {
             render_semantic_enum(out, descriptor, enum_variant_groups, emitted_key_lookup)
         }
@@ -1332,6 +1387,7 @@ fn render_semantic_value(
     out: &mut String,
     descriptor: &TypeDescriptor,
     emitted_key_lookup: &crate::schema_to_loader_ir::EmittedKeyLookup,
+    global_model: &SemanticModel,
 ) -> Result<()> {
     let head = descriptor_head("value", descriptor);
     let mut clauses = Vec::new();
@@ -1352,12 +1408,36 @@ fn render_semantic_value(
     if descriptor.allows_additional_relationships {
         clauses.push("allows_additional_relationships".to_string());
     }
-    append_semantic_body_with_lines(
-        &head,
-        out,
-        &clauses,
-        &descriptor_body_lines(descriptor, uses_literal_body),
-    )
+    let mut body_lines = descriptor_body_lines(descriptor, uses_literal_body);
+    if !uses_literal_body && value_type_kind_requires_literal(descriptor, global_model) {
+        let mut literal_lines = vec!["properties {".to_string()];
+        literal_lines.extend(
+            descriptor.literal_properties.iter().map(|(name, value)| {
+                format!("{}{}: {}", INDENT, name, render_literal_value(value))
+            }),
+        );
+        literal_lines.push("}".to_string());
+        body_lines.splice(0..0, literal_lines);
+    }
+    append_semantic_body_with_lines(&head, out, &clauses, &body_lines)
+}
+
+fn value_type_kind_requires_literal(
+    descriptor: &TypeDescriptor,
+    global_model: &SemanticModel,
+) -> bool {
+    let Some(kind) = descriptor.instance_type_kind.as_deref() else {
+        return false;
+    };
+    let Some(parent) = descriptor.extends.as_ref() else {
+        return true;
+    };
+    let parent_descriptor = global_model
+        .descriptors
+        .iter()
+        .find(|candidate| candidate.key == parent.target || candidate.name == parent.target);
+
+    parent_descriptor.and_then(|parent| parent.instance_type_kind.as_deref()) != Some(kind)
 }
 
 fn render_semantic_enum(
@@ -2177,7 +2257,8 @@ mod tests {
         );
         assert!(
             regenerated_lowered.diagnostics.is_empty(),
-            "round-tripped JSON should remain diagnostic-free"
+            "round-tripped JSON should remain diagnostic-free:\n{}",
+            format_diagnostics(&regenerated_lowered.diagnostics)
         );
 
         assert_eq!(
@@ -2197,8 +2278,8 @@ mod tests {
             source_lowered.symbols.symbols().len(),
             regenerated_lowered.symbols.symbols().len()
         );
-        let source_signature = source_lowered.global_model.comparable_signature();
-        let regenerated_signature = regenerated_lowered.global_model.comparable_signature();
+        let source_signature = adapter_comparable_signature(&source_lowered.global_model);
+        let regenerated_signature = adapter_comparable_signature(&regenerated_lowered.global_model);
         if source_signature != regenerated_signature {
             panic!(
                 "round-tripped JSON should preserve schema semantics\n{}",
@@ -2436,8 +2517,8 @@ relationship Broken {
 
         let regenerated_lowered = lower_inputs_to_schema_ir(&[regenerated_dir.clone()])?;
         assert_eq!(
-            lowered.global_model.comparable_signature(),
-            regenerated_lowered.global_model.comparable_signature()
+            adapter_comparable_signature(&lowered.global_model),
+            adapter_comparable_signature(&regenerated_lowered.global_model)
         );
 
         Ok(())

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -960,6 +960,12 @@ fn semantic_model_from_loader_document(
             .map(|holon| holon.key.clone())
             .unwrap_or_else(|| file.schema_name.clone()),
         origin: origin.clone(),
+        described_by: vec![SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            schema_holon
+                .map(|holon| holon.descriptor_type.clone())
+                .unwrap_or_else(|| "Schema.HolonType".to_string()),
+        )],
         dependencies,
         literal_properties: schema_holon
             .map(|holon| json_map_to_literal_object(&holon.properties))
@@ -1036,6 +1042,10 @@ fn semantic_descriptor_from_holon(
     let kind = semantic_kind(holon);
     let mut descriptor =
         TypeDescriptor::new(holon.key.clone(), descriptor_name(holon), kind, schema_name, origin);
+    descriptor.described_by.push(SemanticReference::unresolved(
+        ReferenceRole::DescribedBy,
+        holon.descriptor_type.clone(),
+    ));
     descriptor.header = semantic_header(&holon.properties);
     descriptor.literal_properties = json_map_to_literal_object(&holon.properties);
     descriptor.is_abstract = bool_property(&holon.properties, "is_abstract_type");
@@ -2003,6 +2013,57 @@ mod tests {
             tdl.contains("schema BookAuthorInverseSchema {\n  depends_on MAP Core Schema-v0.0.7")
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn json_lowering_preserves_descriptor_identity_and_unvalidated_property_values() -> Result<()> {
+        let input_dir = temp_domain_json_dir();
+        write_json_file(
+            &input_dir.join("invalid-type-kind.json"),
+            r#"{
+  "meta": { "load_with": [] },
+  "holons": [
+    {
+      "key": "ExampleSchema",
+      "type": "Schema.HolonType",
+      "properties": { "schema_name": "ExampleSchema" },
+      "relationships": []
+    },
+    {
+      "key": "Person.HolonType",
+      "type": "TypeDescriptor.HolonType",
+      "properties": {
+        "type_name": "Person",
+        "instance_type_kind": "TypeKind.HolonFoo"
+      },
+      "relationships": [
+        { "name": "ComponentOf", "target": { "$ref": "ExampleSchema" } }
+      ]
+    }
+  ]
+}"#,
+        )?;
+
+        let lowered = lower_inputs_to_schema_ir(&[input_dir])?;
+        let person = lowered
+            .global_model
+            .canonical_holons()
+            .into_iter()
+            .find(|holon| holon.key == "Person.HolonType")
+            .expect("Person canonical holon");
+
+        assert_eq!(
+            person.described_by,
+            vec![map_schema_semantic::CanonicalReference {
+                target: "TypeDescriptor.HolonType".to_string(),
+                resolved: None,
+            }]
+        );
+        assert_eq!(
+            person.properties.get("instance_type_kind").and_then(|value| value.as_str()),
+            Some("TypeKind.HolonFoo")
+        );
         Ok(())
     }
 

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tdl_compiler;
 mod test_support;
 
 use crate::{
-    diagnostics::{format_diagnostics, Diagnostic},
+    diagnostics::{format_diagnostics, Diagnostic, DiagnosticKind, DiagnosticLayer},
     literal_bridge::{json_map_to_literal_object, render_literal_value},
     loader_ir::{LoaderDocument, LoaderHolon, LoaderMeta, LoaderReference, LoaderRelationship},
     schema_index::SymbolIndex,
@@ -207,10 +207,7 @@ enum InputFormat {
 
 fn load_valid_semantic_model(inputs: &[PathBuf], side: &str) -> Result<SemanticModel> {
     let (model, diagnostics) = match detect_input_format(inputs)? {
-        InputFormat::Json => {
-            let lowered = lower_inputs_to_schema_ir(inputs)?;
-            (lowered.global_model, lowered.diagnostics)
-        }
+        InputFormat::Json => load_json_semantic_model(inputs)?,
         InputFormat::Tdl => crate::tdl_compiler::load_semantic_model(inputs)?,
     };
 
@@ -223,6 +220,17 @@ fn load_valid_semantic_model(inputs: &[PathBuf], side: &str) -> Result<SemanticM
             format_diagnostics(&diagnostics)
         ))
     }
+}
+
+fn load_json_semantic_model(inputs: &[PathBuf]) -> Result<(SemanticModel, Vec<Diagnostic>)> {
+    let files = collect_input_files(inputs)?;
+    let (parsed, diagnostics) = parse_files_for_validation(&files)?;
+    if !diagnostics.is_empty() {
+        return Ok((SemanticModel::new(), diagnostics));
+    }
+
+    let lowered = lower_parsed_files_to_schema_ir(parsed)?;
+    Ok((lowered.global_model, lowered.diagnostics))
 }
 
 fn detect_input_format(inputs: &[PathBuf]) -> Result<InputFormat> {
@@ -654,16 +662,66 @@ fn parse_files(discovered: &[DiscoveredFile]) -> Result<Vec<ParsedFile>> {
     Ok(parsed)
 }
 
+fn parse_files_for_validation(
+    discovered: &[DiscoveredFile],
+) -> Result<(Vec<ParsedFile>, Vec<Diagnostic>)> {
+    let mut parsed = Vec::with_capacity(discovered.len());
+    let mut diagnostics = Vec::new();
+
+    for discovered_file in discovered {
+        let path = &discovered_file.source_path;
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("reading JSON import file {}", path.display()))?;
+        let import = match parse_json_import(&raw, discovered_file.relative_path.clone()) {
+            Ok(import) => import,
+            Err(diagnostic) => {
+                diagnostics.push(diagnostic);
+                continue;
+            }
+        };
+        let schema_name = infer_schema_name(&import)
+            .with_context(|| format!("inferring schema name for {}", path.display()))?;
+        parsed.push(ParsedFile {
+            relative_path: discovered_file.relative_path.clone(),
+            schema_name,
+            import,
+        });
+    }
+
+    Ok((parsed, diagnostics))
+}
+
 fn parse_import_file_contents(
     raw: &str,
     source_path: &Path,
     relative_path: PathBuf,
 ) -> Result<ParsedFile> {
-    let import: ImportFile = serde_json::from_str(raw)
-        .with_context(|| format!("parsing JSON import file {}", source_path.display()))?;
+    let import = parse_json_import(raw, relative_path.clone())
+        .map_err(|diagnostic| anyhow!(diagnostic.to_string()))?;
     let schema_name = infer_schema_name(&import)
         .with_context(|| format!("inferring schema name for {}", source_path.display()))?;
     Ok(ParsedFile { relative_path, schema_name, import })
+}
+
+fn parse_json_import(
+    raw: &str,
+    relative_path: PathBuf,
+) -> std::result::Result<ImportFile, Diagnostic> {
+    serde_json::from_str::<ImportFile>(raw).map_err(|error| {
+        Diagnostic::error(
+            DiagnosticLayer::Syntax,
+            DiagnosticKind::InvalidSyntax {
+                context: "JSON import".to_string(),
+                message: error.to_string(),
+            },
+            Some(Origin {
+                source_kind: SourceKind::JsonImport,
+                file_path: Some(relative_path),
+                line: u32::try_from(error.line()).ok(),
+                column: u32::try_from(error.column()).ok(),
+            }),
+        )
+    })
 }
 
 fn lower_inputs_to_schema_ir(inputs: &[PathBuf]) -> Result<LoweredJsonProject> {
@@ -2071,6 +2129,23 @@ relationship Broken {
         let rendered = error.to_string();
         assert!(rendered.contains("left inputs are not semantically valid"));
         assert!(rendered.contains("missing required field `TargetType`"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_diff_reports_malformed_json_as_a_syntax_diagnostic() -> Result<()> {
+        let invalid_json_dir = temp_domain_json_dir();
+        write_json_file(&invalid_json_dir.join("malformed-a.json"), "{\n  \"holons\": [\n")?;
+        write_json_file(&invalid_json_dir.join("malformed-b.json"), "{ not-json }\n")?;
+
+        let error = diff_inputs(&[invalid_json_dir], &[source_fixture_dir()]).unwrap_err();
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("left inputs are not semantically valid"), "{rendered}");
+        assert!(rendered.contains("error[syntax]"), "{rendered}");
+        assert!(rendered.contains("malformed-a.json:"), "{rendered}");
+        assert!(rendered.contains("malformed-b.json:"), "{rendered}");
 
         Ok(())
     }

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -2084,6 +2084,31 @@ mod tests {
     }
 
     #[test]
+    fn json_lowering_preserves_single_sided_inverse_metadata_and_validates_the_pair() -> Result<()>
+    {
+        let lowered = lower_inputs_to_schema_ir(&[source_fixture_dir()])?;
+        let inverse = lowered
+            .global_model
+            .descriptors
+            .iter()
+            .find(|descriptor| {
+                descriptor.key == "(Schema.HolonType)-[Components]->(TypeDescriptor.HolonType)"
+            })
+            .expect("Components inverse descriptor");
+
+        assert!(inverse.inverse_of.is_none(), "JSON omissions must not be synthesized");
+        assert!(!lowered.diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            DiagnosticKind::MissingRequiredField { descriptor, field }
+                if descriptor
+                    == "(Schema.HolonType)-[Components]->(TypeDescriptor.HolonType)"
+                    && field == "InverseOf"
+        )));
+
+        Ok(())
+    }
+
+    #[test]
     fn json_corpus_rejects_invalid_type_kind_through_descriptor_enum_policy() -> Result<()> {
         let input_dir = temp_domain_json_dir();
         fs::create_dir_all(&input_dir)?;

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -7,9 +7,7 @@
 //! so schema dependencies and cross-file references can be resolved consistently.
 
 use anyhow::{anyhow, Context, Result};
-use map_schema_semantic::{
-    normalize_relationship_pairs, normalize_validation_model, validate_model,
-};
+use map_schema_semantic::{normalize_relationship_pairs, validate_model};
 /// Diagnostic formatting and source-oriented validation messages.
 pub mod diagnostics;
 mod literal_bridge;
@@ -753,7 +751,6 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedFile>) -> Result<LoweredJso
 
     let (symbols, mut diagnostics) = SymbolIndex::build(&mut global_model);
     let mut validation_model = global_model.clone();
-    normalize_validation_model(&mut validation_model);
     normalize_relationship_pairs(&mut validation_model, &symbols);
     diagnostics.extend(validate_model(&validation_model, &symbols));
     for file in &mut files {
@@ -1048,6 +1045,8 @@ fn semantic_descriptor_from_holon(
     ));
     descriptor.header = semantic_header(&holon.properties);
     descriptor.literal_properties = json_map_to_literal_object(&holon.properties);
+    descriptor.instance_type_kind = string_property(&holon.properties, "instance_type_kind");
+    descriptor.property_required = holon.properties.get("is_required").and_then(Value::as_bool);
     descriptor.is_abstract = bool_property(&holon.properties, "is_abstract_type");
     descriptor.is_definitional = bool_property(&holon.properties, "is_definitional");
     descriptor.min_cardinality = integer_property(&holon.properties, "min_cardinality");
@@ -1403,7 +1402,10 @@ fn render_semantic_property(
     descriptor: &TypeDescriptor,
     emitted_key_lookup: &crate::schema_to_loader_ir::EmittedKeyLookup,
 ) -> Result<()> {
-    let head = descriptor_head("property", descriptor);
+    let mut head = descriptor_head("property", descriptor);
+    if descriptor.property_required == Some(false) {
+        head.push('?');
+    }
     let mut clauses = Vec::new();
     let uses_literal_body = descriptor_uses_literal_body(descriptor, emitted_key_lookup);
     if !uses_literal_body {
@@ -2017,7 +2019,7 @@ mod tests {
     }
 
     #[test]
-    fn json_lowering_preserves_descriptor_identity_and_unvalidated_property_values() -> Result<()> {
+    fn json_lowering_preserves_descriptor_identity_and_authored_property_values() -> Result<()> {
         let input_dir = temp_domain_json_dir();
         write_json_file(
             &input_dir.join("invalid-type-kind.json"),
@@ -2061,9 +2063,61 @@ mod tests {
             }]
         );
         assert_eq!(
-            person.properties.get("instance_type_kind").and_then(|value| value.as_str()),
+            person.properties.get("TypeKind").and_then(|value| value.as_str()),
             Some("TypeKind.HolonFoo")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn json_lowering_does_not_apply_tdl_boolean_omission_defaults() -> Result<()> {
+        let lowered = lower_inputs_to_schema_ir(&[source_fixture_dir()])?;
+        let descriptor = lowered
+            .global_model
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.key == "DeclaredRelationshipType")
+            .expect("DeclaredRelationshipType descriptor");
+
+        assert!(descriptor.materialized_properties.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn json_corpus_rejects_invalid_type_kind_through_descriptor_enum_policy() -> Result<()> {
+        let input_dir = temp_domain_json_dir();
+        fs::create_dir_all(&input_dir)?;
+        for entry in fs::read_dir(source_fixture_dir())? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let mut document = serde_json::from_str::<Value>(&fs::read_to_string(&path)?)?;
+            if let Some(person) =
+                document.get_mut("holons").and_then(Value::as_array_mut).and_then(|holons| {
+                    holons.iter_mut().find(|holon| {
+                        holon.get("key").and_then(Value::as_str) == Some("HolonSpace.HolonType")
+                    })
+                })
+            {
+                person["properties"]["instance_type_kind"] =
+                    Value::String("TypeKind.HolonFoo".to_string());
+            }
+            fs::write(
+                input_dir.join(path.file_name().expect("fixture file name")),
+                serde_json::to_string_pretty(&document)?,
+            )?;
+        }
+
+        let lowered = lower_inputs_to_schema_ir(&[input_dir])?;
+        assert!(lowered.diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            DiagnosticKind::InvalidConformanceValue { holon, property, value, .. }
+                if holon == "HolonSpace.HolonType"
+                    && property == "TypeKind"
+                    && value == "TypeKind.HolonFoo"
+        )));
         Ok(())
     }
 
@@ -2091,7 +2145,11 @@ mod tests {
 
         let source_lowered = lower_inputs_to_schema_ir(&[source_dir.clone()])?;
         let regenerated_lowered = lower_inputs_to_schema_ir(&[regenerated_json_dir.clone()])?;
-        assert!(source_lowered.diagnostics.is_empty(), "source JSON should remain diagnostic-free");
+        assert!(
+            source_lowered.diagnostics.is_empty(),
+            "source JSON should remain diagnostic-free:\n{}",
+            format_diagnostics(&source_lowered.diagnostics)
+        );
         assert!(
             regenerated_lowered.diagnostics.is_empty(),
             "round-tripped JSON should remain diagnostic-free"
@@ -2259,7 +2317,7 @@ relationship Broken {
         let source_dir = source_fixture_dir();
         let lowered = lower_inputs_to_schema_ir(&[source_fixture_dir()])?;
 
-        assert!(lowered.diagnostics.is_empty());
+        assert!(lowered.diagnostics.is_empty(), "{}", format_diagnostics(&lowered.diagnostics));
         assert_eq!(lowered.files.len(), discovered_json_file_count(&source_dir)?);
         assert!(!lowered.global_model.schemas.is_empty());
         assert!(!lowered.global_model.descriptors.is_empty());

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -7,7 +7,9 @@
 //! so schema dependencies and cross-file references can be resolved consistently.
 
 use anyhow::{anyhow, Context, Result};
-use map_schema_semantic::{normalize_relationship_pairs, normalize_validation_model, validate_model};
+use map_schema_semantic::{
+    normalize_relationship_pairs, normalize_validation_model, validate_model,
+};
 /// Diagnostic formatting and source-oriented validation messages.
 pub mod diagnostics;
 mod literal_bridge;
@@ -194,7 +196,7 @@ pub fn diff_inputs(left: &[PathBuf], right: &[PathBuf]) -> Result<String> {
     let left_signature = left_model.comparable_signature();
     let right_signature = right_model.comparable_signature();
 
-    Ok(render_semantic_diff(&left_signature, &right_signature))
+    Ok(render_semantic_diff(&left_signature, &right_signature, &left_model, &right_model))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -215,7 +217,11 @@ fn load_valid_semantic_model(inputs: &[PathBuf], side: &str) -> Result<SemanticM
     if diagnostics.is_empty() {
         Ok(model)
     } else {
-        Err(anyhow!("{} inputs are not semantically valid:\n{}", side, format_diagnostics(&diagnostics)))
+        Err(anyhow!(
+            "{} inputs are not semantically valid:\n{}",
+            side,
+            format_diagnostics(&diagnostics)
+        ))
     }
 }
 
@@ -238,39 +244,213 @@ fn detect_input_format(inputs: &[PathBuf]) -> Result<InputFormat> {
 fn render_semantic_diff(
     left: &crate::schema_ir::ComparableSemanticModel,
     right: &crate::schema_ir::ComparableSemanticModel,
+    left_model: &SemanticModel,
+    right_model: &SemanticModel,
 ) -> String {
-    let schema_diff = semantic_schema_diff(left, right);
-    let descriptor_diff = semantic_descriptor_diff(left, right);
+    let canonical_schema_diff = semantic_schema_diff(left, right);
+    let canonical_descriptor_diff = semantic_descriptor_diff(left, right);
+    let residue_diff = semantic_residue_diff(left_model, right_model);
 
-    if schema_diff.is_empty() && descriptor_diff.is_empty() {
+    if canonical_schema_diff.is_empty()
+        && canonical_descriptor_diff.is_empty()
+        && residue_diff.is_empty()
+    {
         return "no semantic diff\n".to_string();
     }
 
     let mut out = String::from("semantic diff\n");
-    for line in schema_diff {
-        out.push_str(&line);
-        out.push('\n');
+    if !canonical_schema_diff.is_empty() || !canonical_descriptor_diff.is_empty() {
+        out.push_str("canonical semantic changes\n");
+        for line in canonical_schema_diff {
+            out.push_str(&line);
+            out.push('\n');
+        }
+        for line in canonical_descriptor_diff {
+            out.push_str(&line);
+            out.push('\n');
+        }
     }
-    for line in descriptor_diff {
-        out.push_str(&line);
-        out.push('\n');
+    if !residue_diff.is_empty() {
+        out.push_str("preserved literal residue changes\n");
+        for line in residue_diff {
+            out.push_str(&line);
+            out.push('\n');
+        }
     }
     out
+}
+
+fn semantic_residue_diff(left: &SemanticModel, right: &SemanticModel) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let left_schemas =
+        left.schemas.iter().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
+    let right_schemas =
+        right.schemas.iter().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
+    let schema_keys =
+        left_schemas.keys().chain(right_schemas.keys()).cloned().collect::<BTreeSet<_>>();
+    for key in schema_keys {
+        if let (Some(left_schema), Some(right_schema)) =
+            (left_schemas.get(&key), right_schemas.get(&key))
+        {
+            let mut field_lines = Vec::new();
+            push_changed_field(
+                &mut field_lines,
+                "header",
+                &left_schema.header,
+                &right_schema.header,
+            );
+            push_changed_field(
+                &mut field_lines,
+                "literal_properties",
+                &normalized_schema_literal_properties(left_schema),
+                &normalized_schema_literal_properties(right_schema),
+            );
+            push_changed_field(
+                &mut field_lines,
+                "literal_relationships",
+                &normalized_schema_literal_relationships(left_schema),
+                &normalized_schema_literal_relationships(right_schema),
+            );
+            if !field_lines.is_empty() {
+                lines.push(format!("schema `{}` residue changed", key));
+                lines.extend(field_lines.into_iter().map(|line| format!("  {line}")));
+            }
+        }
+    }
+
+    let left_descriptors = left
+        .descriptors
+        .iter()
+        .map(|descriptor| (descriptor.key.clone(), descriptor))
+        .collect::<BTreeMap<_, _>>();
+    let right_descriptors = right
+        .descriptors
+        .iter()
+        .map(|descriptor| (descriptor.key.clone(), descriptor))
+        .collect::<BTreeMap<_, _>>();
+    let descriptor_keys =
+        left_descriptors.keys().chain(right_descriptors.keys()).cloned().collect::<BTreeSet<_>>();
+    for key in descriptor_keys {
+        if let (Some(left_descriptor), Some(right_descriptor)) =
+            (left_descriptors.get(&key), right_descriptors.get(&key))
+        {
+            let mut field_lines = Vec::new();
+            push_changed_field(
+                &mut field_lines,
+                "header",
+                &left_descriptor.header,
+                &right_descriptor.header,
+            );
+            push_changed_field(
+                &mut field_lines,
+                "literal_properties",
+                &normalized_descriptor_literal_properties(left_descriptor),
+                &normalized_descriptor_literal_properties(right_descriptor),
+            );
+            push_changed_field(
+                &mut field_lines,
+                "literal_relationships",
+                &normalized_descriptor_literal_relationships(left_descriptor),
+                &normalized_descriptor_literal_relationships(right_descriptor),
+            );
+            if !field_lines.is_empty() {
+                lines.push(format!("descriptor `{}` residue changed", key));
+                lines.extend(field_lines.into_iter().map(|line| format!("  {line}")));
+            }
+        }
+    }
+
+    lines
+}
+
+fn normalized_schema_literal_properties(schema: &Schema) -> map_schema_semantic::LiteralObject {
+    let mut normalized = map_schema_semantic::LiteralObject::new();
+    for (key, value) in schema.literal_properties.iter() {
+        if matches!(
+            key.as_str(),
+            "description"
+                | "display_name"
+                | "display_name_plural"
+                | "type_name_plural"
+                | "schema_name"
+                | "allows_additional_properties"
+                | "allows_additional_relationships"
+        ) {
+            continue;
+        }
+        normalized.insert(key.clone(), value.clone());
+    }
+    normalized
+}
+
+fn normalized_schema_literal_relationships(schema: &Schema) -> Vec<LiteralRelationship> {
+    schema
+        .literal_relationships
+        .iter()
+        .filter(|relationship| relationship.name != "DependsOn")
+        .cloned()
+        .collect()
+}
+
+fn normalized_descriptor_literal_properties(
+    descriptor: &TypeDescriptor,
+) -> map_schema_semantic::LiteralObject {
+    let mut normalized = map_schema_semantic::LiteralObject::new();
+    for (key, value) in descriptor.literal_properties.iter() {
+        if matches!(
+            key.as_str(),
+            "type_name"
+                | "type_name_plural"
+                | "display_name"
+                | "display_name_plural"
+                | "description"
+                | "instance_type_kind"
+                | "is_abstract_type"
+                | "is_definitional"
+                | "min_cardinality"
+                | "max_cardinality"
+                | "deletion_semantic"
+                | "is_ordered"
+                | "allows_duplicates"
+                | "allows_additional_properties"
+                | "allows_additional_relationships"
+        ) {
+            continue;
+        }
+        normalized.insert(key.clone(), value.clone());
+    }
+    normalized
+}
+
+fn normalized_descriptor_literal_relationships(
+    descriptor: &TypeDescriptor,
+) -> Vec<LiteralRelationship> {
+    descriptor
+        .literal_relationships
+        .iter()
+        .filter(|relationship| reference_role_for_relationship(&relationship.name).is_none())
+        .cloned()
+        .collect()
 }
 
 fn semantic_schema_diff(
     left: &crate::schema_ir::ComparableSemanticModel,
     right: &crate::schema_ir::ComparableSemanticModel,
 ) -> Vec<String> {
-    let left_by_key =
-        left.schemas.iter().cloned().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
-    let right_by_key =
-        right.schemas.iter().cloned().map(|schema| (schema.key.clone(), schema)).collect::<BTreeMap<_, _>>();
-    let all_keys = left_by_key
-        .keys()
-        .chain(right_by_key.keys())
+    let left_by_key = left
+        .schemas
+        .iter()
         .cloned()
-        .collect::<BTreeSet<_>>();
+        .map(|schema| (schema.key.clone(), schema))
+        .collect::<BTreeMap<_, _>>();
+    let right_by_key = right
+        .schemas
+        .iter()
+        .cloned()
+        .map(|schema| (schema.key.clone(), schema))
+        .collect::<BTreeMap<_, _>>();
+    let all_keys = left_by_key.keys().chain(right_by_key.keys()).cloned().collect::<BTreeSet<_>>();
 
     let mut lines = Vec::new();
     for key in all_keys {
@@ -328,11 +508,7 @@ fn semantic_descriptor_diff(
         .cloned()
         .map(|descriptor| (descriptor.key.clone(), descriptor))
         .collect::<BTreeMap<_, _>>();
-    let all_keys = left_by_key
-        .keys()
-        .chain(right_by_key.keys())
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    let all_keys = left_by_key.keys().chain(right_by_key.keys()).cloned().collect::<BTreeSet<_>>();
 
     let mut lines = Vec::new();
     for key in all_keys {
@@ -1641,8 +1817,11 @@ mod tests {
     use std::{
         env,
         io::Write,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn source_fixture_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1667,24 +1846,26 @@ mod tests {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("..").join("schema-src")
     }
 
-    fn temp_out_dir() -> PathBuf {
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-decompile-{nanos}"))
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("{prefix}-{nanos}-{counter}"))
+    }
+
+    fn temp_out_dir() -> PathBuf {
+        unique_temp_dir("map-schema-decompile")
     }
 
     fn temp_roundtrip_tdl_dir() -> PathBuf {
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-roundtrip-tdl-{nanos}"))
+        unique_temp_dir("map-schema-roundtrip-tdl")
     }
 
     fn temp_roundtrip_json_dir() -> PathBuf {
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-roundtrip-json-{nanos}"))
+        unique_temp_dir("map-schema-roundtrip-json")
     }
 
     fn temp_domain_json_dir() -> PathBuf {
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-domain-json-{nanos}"))
+        unique_temp_dir("map-schema-domain-json")
     }
 
     fn copy_directory_tree(source: &Path, target: &Path) -> Result<()> {
@@ -1827,13 +2008,18 @@ mod tests {
     }
 
     #[test]
-    fn semantic_diff_reports_no_difference_for_json_and_decompiled_tdl() -> Result<()> {
+    fn semantic_diff_reports_no_canonical_difference_for_json_and_decompiled_tdl() -> Result<()> {
         let source_dir = source_fixture_dir();
         let decompiled_tdl_dir = temp_roundtrip_tdl_dir();
         decompile_inputs(&[source_dir.clone()], &decompiled_tdl_dir)?;
 
         let rendered = diff_inputs(&[source_dir], &[decompiled_tdl_dir])?;
-        assert_eq!(rendered, "no semantic diff\n");
+        assert!(
+            rendered == "no semantic diff\n"
+                || (rendered.contains("semantic diff\n")
+                    && !rendered.contains("canonical semantic changes")),
+            "{rendered}"
+        );
 
         Ok(())
     }
@@ -1848,13 +2034,20 @@ mod tests {
         let right_root_path = right_dir.join("MAP Schema Types-map-core-schema-root.json");
         let right_root = fs::read_to_string(&right_root_path)?;
         let right_root = right_root
-            .replace("\"allows_additional_properties\": false", "\"allows_additional_properties\": true")
+            .replace(
+                "\"allows_additional_properties\": false",
+                "\"allows_additional_properties\": true",
+            )
             .replace("\"is_abstract_type\": false", "\"is_abstract_type\": true");
         write_json_file(&right_root_path, &right_root)?;
 
         let rendered = diff_inputs(&[left_dir], &[right_dir])?;
         assert!(rendered.contains("semantic diff\n"), "{rendered}");
-        assert!(rendered.contains("allows_additional_properties: left=false right=true"), "{rendered}");
+        assert!(rendered.contains("canonical semantic changes"), "{rendered}");
+        assert!(
+            rendered.contains("allows_additional_properties: left=false right=true"),
+            "{rendered}"
+        );
         assert!(rendered.contains("descriptor `"), "{rendered}");
         assert!(rendered.contains("is_abstract: left=false right=true"), "{rendered}");
 
@@ -1878,6 +2071,29 @@ relationship Broken {
         let rendered = error.to_string();
         assert!(rendered.contains("left inputs are not semantically valid"));
         assert!(rendered.contains("missing required field `TargetType`"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_diff_reports_preserved_literal_residue_changes() -> Result<()> {
+        let left_dir = temp_domain_json_dir().join("left-residue");
+        let right_dir = temp_domain_json_dir().join("right-residue");
+        copy_directory_tree(&source_fixture_dir(), &left_dir)?;
+        copy_directory_tree(&source_fixture_dir(), &right_dir)?;
+
+        let right_root_path = right_dir.join("MAP Schema Types-map-core-schema-root.json");
+        let right_root = fs::read_to_string(&right_root_path)?;
+        let right_root = right_root.replace(
+            "\"description\": \"Schema containing all meta-level descriptors for MAP type definitions, including the TypeDescriptor itself.\"",
+            "\"description\": \"Schema containing all meta-level descriptors for MAP type definitions, including the TypeDescriptor itself. Residue diff.\"",
+        );
+        write_json_file(&right_root_path, &right_root)?;
+
+        let rendered = diff_inputs(&[left_dir], &[right_dir])?;
+        assert!(rendered.contains("preserved literal residue changes"), "{rendered}");
+        assert!(rendered.contains("schema `MAP Core Schema-v0.0.7` residue changed"), "{rendered}");
+        assert!(rendered.contains("header: left="), "{rendered}");
 
         Ok(())
     }

--- a/tools/map-schema/src/main.rs
+++ b/tools/map-schema/src/main.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use map_schema_tool::{
-    decompile_input_string, decompile_inputs, dump_symbols, dump_symbols_from_string,
-    diff_inputs,
+    decompile_input_string, decompile_inputs, diff_inputs, dump_symbols, dump_symbols_from_string,
     tdl_compiler::{
         check_input_string, check_inputs, compile_input_string, compile_inputs, render_check_output,
     },

--- a/tools/map-schema/src/main.rs
+++ b/tools/map-schema/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use map_schema_tool::{
     decompile_input_string, decompile_inputs, dump_symbols, dump_symbols_from_string,
+    diff_inputs,
     tdl_compiler::{
         check_input_string, check_inputs, compile_input_string, compile_inputs, render_check_output,
     },
@@ -54,6 +55,17 @@ enum Commands {
         /// Input TDL files or directories containing TDL files.
         inputs: Vec<PathBuf>,
     },
+
+    /// Compare two schema corpora by Canonical Holon IR semantics.
+    Diff {
+        /// Left-hand input files or directories. One source format per side.
+        #[arg(long = "left", required = true)]
+        left: Vec<PathBuf>,
+
+        /// Right-hand input files or directories. One source format per side.
+        #[arg(long = "right", required = true)]
+        right: Vec<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -102,6 +114,9 @@ fn main() -> Result<()> {
             };
             print!("{}", render_check_output(&diagnostics));
         }
+        Commands::Diff { left, right } => {
+            print!("{}", diff_inputs(&left, &right)?);
+        }
     }
 
     Ok(())
@@ -126,6 +141,10 @@ Commands:
   check [TDL_FILE_OR_DIR ...]
       Validate TDL syntax and semantic references without writing JSON.
 
+  diff --left <JSON_OR_TDL_FILE_OR_DIR ...> --right <JSON_OR_TDL_FILE_OR_DIR ...>
+      Compare two schema corpora by Canonical Holon IR semantics. Each side must
+      lower without blocking diagnostics before a diff is produced.
+
   symbols [JSON_FILE_OR_DIR ...]
       Print the semantic symbol table derived from JSON imports.
 
@@ -138,6 +157,7 @@ Direct examples:
   cargo run --manifest-path tools/map-schema/Cargo.toml -- decompile host/import_files/map-schema/core-schema --out-dir schema-src
   cargo run --manifest-path tools/map-schema/Cargo.toml -- check schema-src
   cargo run --manifest-path tools/map-schema/Cargo.toml -- compile schema-src --out-dir generated/json-imports
+  cargo run --manifest-path tools/map-schema/Cargo.toml -- diff --left host/import_files/map-schema/core-schema --right generated/json-imports
 
 Single-file stdin/stdout mode:
   map-schema decompile < input.json > output.tdl
@@ -150,6 +170,9 @@ Notes:
   Compile validates semantic references against the TDL files passed in the
   same invocation. A dependent standalone file may fail until its core schema
   dependencies are included in the input corpus.
+
+  Diff accepts JSON on one side and TDL on the other, but a single side must
+  not mix source formats.
 "#
 }
 

--- a/tools/map-schema/src/schema_to_loader_ir.rs
+++ b/tools/map-schema/src/schema_to_loader_ir.rs
@@ -1,5 +1,5 @@
 use crate::{
-    literal_bridge::literal_object_to_json_map,
+    literal_bridge::{literal_object_to_json_map, literal_value_to_json},
     loader_ir::{LoaderDocument, LoaderHolon, LoaderMeta, LoaderReference, LoaderRelationship},
     schema_ir::{DescriptorKind, Schema, SemanticModel, SemanticReference, TypeDescriptor},
 };
@@ -201,7 +201,9 @@ fn descriptor_type(references: &[SemanticReference], fallback: &str) -> String {
 
 fn lower_descriptor_properties(descriptor: &TypeDescriptor) -> serde_json::Map<String, Value> {
     if !descriptor.literal_properties.is_empty() {
-        return literal_object_to_json_map(&descriptor.literal_properties);
+        let mut properties = literal_object_to_json_map(&descriptor.literal_properties);
+        append_materialized_properties(&mut properties, descriptor);
+        return properties;
     }
 
     lower_descriptor_properties_semantic(descriptor)
@@ -240,16 +242,19 @@ fn lower_descriptor_properties_semantic(
             .insert("display_name_plural".to_string(), json!(pluralize_name(&descriptor.name)));
     }
 
-    let instance_type_kind = match descriptor.kind {
-        DescriptorKind::HolonType => Some(json!("TypeKind.Holon")),
-        DescriptorKind::PropertyType => Some(json!("TypeKind.Property")),
-        DescriptorKind::RelationshipType => Some(json!("TypeKind.Relationship")),
-        DescriptorKind::ValueType => Some(json!(infer_value_kind(descriptor))),
-        DescriptorKind::Enum => Some(json!("TypeKind.Value.Enum")),
-        DescriptorKind::EnumVariant => Some(json!("TypeKind.EnumVariant")),
-        DescriptorKind::TypeDescriptor => Some(json!("TypeKind.Holon")),
-        DescriptorKind::Schema => None,
-    };
+    let instance_type_kind =
+        descriptor.instance_type_kind.as_ref().map(|value| json!(value)).or_else(
+            || match descriptor.kind {
+                DescriptorKind::HolonType => Some(json!("TypeKind.Holon")),
+                DescriptorKind::PropertyType => Some(json!("TypeKind.Property")),
+                DescriptorKind::RelationshipType => Some(json!("TypeKind.Relationship")),
+                DescriptorKind::ValueType => Some(json!(infer_value_kind(descriptor))),
+                DescriptorKind::Enum => Some(json!("TypeKind.Value.Enum")),
+                DescriptorKind::EnumVariant => Some(json!("TypeKind.EnumVariant")),
+                DescriptorKind::TypeDescriptor => Some(json!("TypeKind.Holon")),
+                DescriptorKind::Schema => None,
+            },
+        );
     if let Some(instance_type_kind) = instance_type_kind {
         properties.insert("instance_type_kind".to_string(), instance_type_kind);
     }
@@ -280,13 +285,50 @@ fn lower_descriptor_properties_semantic(
                 properties.insert("max_cardinality".to_string(), json!(max));
             }
         }
-        DescriptorKind::PropertyType
-        | DescriptorKind::ValueType
+        DescriptorKind::PropertyType => {
+            if let Some(required) = descriptor.property_required {
+                properties.insert("is_required".to_string(), json!(required));
+            }
+        }
+        DescriptorKind::ValueType
         | DescriptorKind::Enum
         | DescriptorKind::EnumVariant
         | DescriptorKind::Schema => {}
     }
+    append_materialized_properties(&mut properties, descriptor);
     properties
+}
+
+fn append_materialized_properties(
+    properties: &mut serde_json::Map<String, Value>,
+    descriptor: &TypeDescriptor,
+) {
+    for (name, value) in descriptor.materialized_properties.iter() {
+        properties
+            .entry(canonical_property_to_snake_case(name))
+            .or_insert_with(|| literal_value_to_json(value));
+    }
+}
+
+fn canonical_property_to_snake_case(name: &str) -> String {
+    let characters = name.chars().collect::<Vec<_>>();
+    let mut snake = String::with_capacity(name.len());
+    for (index, character) in characters.iter().copied().enumerate() {
+        let previous_is_lowercase = index
+            .checked_sub(1)
+            .and_then(|previous| characters.get(previous))
+            .is_some_and(|previous| previous.is_ascii_lowercase() || previous.is_ascii_digit());
+        let next_is_lowercase =
+            characters.get(index + 1).is_some_and(|next| next.is_ascii_lowercase());
+        if character.is_ascii_uppercase()
+            && index > 0
+            && (previous_is_lowercase || next_is_lowercase)
+        {
+            snake.push('_');
+        }
+        snake.push(character.to_ascii_lowercase());
+    }
+    snake
 }
 
 fn infer_value_kind(descriptor: &TypeDescriptor) -> &'static str {

--- a/tools/map-schema/src/schema_to_loader_ir.rs
+++ b/tools/map-schema/src/schema_to_loader_ir.rs
@@ -242,21 +242,8 @@ fn lower_descriptor_properties_semantic(
             .insert("display_name_plural".to_string(), json!(pluralize_name(&descriptor.name)));
     }
 
-    let instance_type_kind =
-        descriptor.instance_type_kind.as_ref().map(|value| json!(value)).or_else(
-            || match descriptor.kind {
-                DescriptorKind::HolonType => Some(json!("TypeKind.Holon")),
-                DescriptorKind::PropertyType => Some(json!("TypeKind.Property")),
-                DescriptorKind::RelationshipType => Some(json!("TypeKind.Relationship")),
-                DescriptorKind::ValueType => Some(json!(infer_value_kind(descriptor))),
-                DescriptorKind::Enum => Some(json!("TypeKind.Value.Enum")),
-                DescriptorKind::EnumVariant => Some(json!("TypeKind.EnumVariant")),
-                DescriptorKind::TypeDescriptor => Some(json!("TypeKind.Holon")),
-                DescriptorKind::Schema => None,
-            },
-        );
-    if let Some(instance_type_kind) = instance_type_kind {
-        properties.insert("instance_type_kind".to_string(), instance_type_kind);
+    if let Some(instance_type_kind) = &descriptor.instance_type_kind {
+        properties.insert("instance_type_kind".to_string(), json!(instance_type_kind));
     }
     properties.insert("is_abstract_type".to_string(), json!(descriptor.is_abstract));
 
@@ -331,53 +318,6 @@ fn canonical_property_to_snake_case(name: &str) -> String {
     snake
 }
 
-fn infer_value_kind(descriptor: &TypeDescriptor) -> &'static str {
-    if matches!(descriptor.name.as_str(), "MetaValueType" | "ValueType") {
-        return "TypeKind.Holon";
-    }
-
-    if matches!(descriptor.name.as_str(), "EnumVariantValueType" | "MapEnumVariantValueType") {
-        return "TypeKind.EnumVariant";
-    }
-
-    if descriptor.name.ends_with("StringValueType") {
-        return "TypeKind.Value.String";
-    }
-    if descriptor.name.ends_with("IntegerValueType") {
-        return "TypeKind.Value.Integer";
-    }
-    if descriptor.name.ends_with("BooleanValueType") {
-        return "TypeKind.Value.Boolean";
-    }
-    if descriptor.name.ends_with("BytesValueType") || descriptor.name == "HolonIdValueType" {
-        return "TypeKind.Value.Bytes";
-    }
-    if descriptor.name.ends_with("ValueArrayType")
-        || descriptor.name.ends_with("ValueArrayValueType")
-    {
-        return "TypeKind.Value.Array";
-    }
-    if descriptor.name.ends_with("EnumValueType") {
-        return "TypeKind.Value.Enum";
-    }
-
-    if let Some(extends) = descriptor.extends.as_ref().map(|extends| extends.target.as_str()) {
-        match extends {
-            "MetaTypeDescriptor" | "MetaValueType" => "TypeKind.Holon",
-            "StringValueType" | "MapStringValueType" => "TypeKind.Value.String",
-            "IntegerValueType" | "MapIntegerValueType" => "TypeKind.Value.Integer",
-            "BooleanValueType" | "MapBooleanValueType" => "TypeKind.Value.Boolean",
-            "BytesValueType" | "MapBytesValueType" | "HolonIdValueType" => "TypeKind.Value.Bytes",
-            "ValueArrayValueType" | "MapValueArrayType" => "TypeKind.Value.Array",
-            "EnumValueType" | "MapEnumValueType" => "TypeKind.Value.Enum",
-            "EnumVariantValueType" | "MapEnumVariantValueType" => "TypeKind.EnumVariant",
-            _ => "TypeKind.Value.String",
-        }
-    } else {
-        "TypeKind.Value.String"
-    }
-}
-
 fn lower_descriptor_relationships(
     descriptor: &TypeDescriptor,
     emitted_key_lookup: &EmittedKeyLookup,
@@ -386,6 +326,7 @@ fn lower_descriptor_relationships(
         return descriptor
             .literal_relationships
             .iter()
+            .filter(|relationship| relationship.name != "InverseOf")
             .map(|relationship| {
                 loader_relationship(
                     &relationship.name,
@@ -415,12 +356,6 @@ fn lower_descriptor_relationships_semantic(
         relationships.push(loader_relationship(
             "Extends",
             vec![normalize_emitted_reference_target(&extends.target, emitted_key_lookup)],
-        ));
-    }
-    if let Some(inverse_of) = &descriptor.inverse_of {
-        relationships.push(loader_relationship(
-            "InverseOf",
-            vec![normalize_inverse_reference_target(descriptor, inverse_of, emitted_key_lookup)],
         ));
     }
     if let Some(has_inverse) = &descriptor.has_inverse {
@@ -513,34 +448,6 @@ fn normalize_emitted_reference_target(
         .get(target)
         .cloned()
         .unwrap_or_else(|| target.to_string())
-}
-
-fn normalize_inverse_reference_target(
-    descriptor: &TypeDescriptor,
-    inverse_of: &SemanticReference,
-    emitted_key_lookup: &EmittedKeyLookup,
-) -> String {
-    let inverse_target = &inverse_of.target;
-    if inverse_target.contains(")-[") {
-        return normalize_emitted_reference_target(inverse_target, emitted_key_lookup);
-    }
-
-    match (
-        descriptor.relationship_flavor,
-        descriptor.source_type.as_ref(),
-        descriptor.target_type.as_ref(),
-    ) {
-        (
-            Some(crate::schema_ir::RelationshipFlavor::Inverse),
-            Some(source_type),
-            Some(target_type),
-        ) => {
-            format!("({})-[{}]->({})", target_type.target, inverse_target, source_type.target)
-        }
-        _ => emitted_key_lookup.unique_keys_by_name.get(inverse_target).cloned().unwrap_or_else(
-            || normalize_emitted_reference_target(inverse_target, emitted_key_lookup),
-        ),
-    }
 }
 
 fn schema_literal_property_is_renderable(key: &str) -> bool {
@@ -734,5 +641,61 @@ fn pluralize_name(name: &str) -> String {
         format!("{name}es")
     } else {
         format!("{name}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema_ir::{
+        LiteralRelationship, Origin, ReferenceRole, RelationshipFlavor, SourceKind,
+    };
+
+    #[test]
+    fn loader_projection_emits_only_the_declared_side_of_an_inverse_pair() {
+        let declared_key = "(Book.HolonType)-[WrittenBy]->(Person.HolonType)";
+        let inverse_key = "(Person.HolonType)-[AuthorOf]->(Book.HolonType)";
+
+        let mut declared = TypeDescriptor::new(
+            declared_key,
+            "WrittenBy",
+            DescriptorKind::RelationshipType,
+            "TestSchema",
+            Origin::new(SourceKind::TdlSource),
+        );
+        declared.relationship_flavor = Some(RelationshipFlavor::Declared);
+        declared.has_inverse =
+            Some(SemanticReference::unresolved(ReferenceRole::HasInverse, inverse_key));
+
+        let mut inverse = TypeDescriptor::new(
+            inverse_key,
+            "AuthorOf",
+            DescriptorKind::RelationshipType,
+            "TestSchema",
+            Origin::new(SourceKind::TdlSource),
+        );
+        inverse.relationship_flavor = Some(RelationshipFlavor::Inverse);
+        inverse.inverse_of =
+            Some(SemanticReference::unresolved(ReferenceRole::InverseOf, declared_key));
+
+        let emitted_key_lookup = EmittedKeyLookup::default();
+        let declared_relationships = lower_descriptor_relationships(&declared, &emitted_key_lookup);
+        let semantic_inverse_relationships =
+            lower_descriptor_relationships(&inverse, &emitted_key_lookup);
+        inverse.literal_relationships.push(LiteralRelationship {
+            name: "InverseOf".to_string(),
+            targets: vec![declared_key.to_string()],
+        });
+        let literal_inverse_relationships =
+            lower_descriptor_relationships(&inverse, &emitted_key_lookup);
+
+        assert!(declared_relationships
+            .iter()
+            .any(|relationship| relationship.name == "HasInverse"));
+        assert!(!declared_relationships
+            .iter()
+            .chain(semantic_inverse_relationships.iter())
+            .chain(literal_inverse_relationships.iter())
+            .any(|relationship| relationship.name == "InverseOf"));
     }
 }

--- a/tools/map-schema/src/schema_to_loader_ir.rs
+++ b/tools/map-schema/src/schema_to_loader_ir.rs
@@ -105,7 +105,7 @@ fn lower_schema_holon(schema: &Schema) -> LoaderHolon {
     if !schema.literal_properties.is_empty() || !schema.literal_relationships.is_empty() {
         return LoaderHolon {
             key: schema.name.clone(),
-            descriptor_type: "Schema.HolonType".to_string(),
+            descriptor_type: descriptor_type(&schema.described_by, "Schema.HolonType"),
             properties: if schema.literal_properties.is_empty() {
                 let mut properties = serde_json::Map::new();
                 properties.insert("schema_name".to_string(), json!(schema.name));
@@ -158,7 +158,7 @@ fn lower_schema_holon_semantic(schema: &Schema) -> LoaderHolon {
 
     LoaderHolon {
         key: schema.name.clone(),
-        descriptor_type: "Schema.HolonType".to_string(),
+        descriptor_type: descriptor_type(&schema.described_by, "Schema.HolonType"),
         properties,
         relationships,
     }
@@ -171,7 +171,7 @@ fn lower_descriptor_holon(
     if !descriptor.literal_properties.is_empty() || !descriptor.literal_relationships.is_empty() {
         return LoaderHolon {
             key: descriptor.key.clone(),
-            descriptor_type: "TypeDescriptor.HolonType".to_string(),
+            descriptor_type: descriptor_type(&descriptor.described_by, "TypeDescriptor.HolonType"),
             properties: lower_descriptor_properties(descriptor),
             relationships: lower_descriptor_relationships(descriptor, emitted_key_lookup),
         };
@@ -186,10 +186,17 @@ fn lower_descriptor_holon_semantic(
 ) -> LoaderHolon {
     LoaderHolon {
         key: descriptor.key.clone(),
-        descriptor_type: "TypeDescriptor.HolonType".to_string(),
+        descriptor_type: descriptor_type(&descriptor.described_by, "TypeDescriptor.HolonType"),
         properties: lower_descriptor_properties_semantic(descriptor),
         relationships: lower_descriptor_relationships_semantic(descriptor, emitted_key_lookup),
     }
+}
+
+fn descriptor_type(references: &[SemanticReference], fallback: &str) -> String {
+    references
+        .first()
+        .map(|reference| reference.target.clone())
+        .unwrap_or_else(|| fallback.to_string())
 }
 
 fn lower_descriptor_properties(descriptor: &TypeDescriptor) -> serde_json::Map<String, Value> {

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -12,6 +12,7 @@ use crate::{
     },
 };
 use anyhow::{anyhow, Context, Result};
+use map_schema_semantic::{normalize_relationship_pairs, normalize_validation_model, validate_model};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -149,6 +150,13 @@ pub fn check_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<
     Ok(lower_parsed_files_to_schema_ir(vec![parsed])?.diagnostics)
 }
 
+pub(crate) fn load_semantic_model(
+    inputs: &[PathBuf],
+) -> Result<(SemanticModel, Vec<Diagnostic>)> {
+    let lowered = lower_inputs_to_schema_ir(inputs)?;
+    Ok((lowered.global_model, lowered.diagnostics))
+}
+
 struct Compilation {
     files: Vec<CompiledLoaderFile>,
     diagnostics: Vec<Diagnostic>,
@@ -201,6 +209,10 @@ fn collect_tdl_files(inputs: &[PathBuf]) -> Result<Vec<DiscoveredFile>> {
     ensure_unique_relative_paths(&files)?;
     files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     Ok(files)
+}
+
+pub(crate) fn discovered_input_count(inputs: &[PathBuf]) -> Result<usize> {
+    Ok(collect_tdl_files(inputs)?.len())
 }
 
 fn collect_tdl_files_recursive(
@@ -1097,9 +1109,12 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<Lowered
     }
 
     let (symbols, mut diagnostics) = SymbolIndex::build(&mut global_model);
+    let mut validation_model = global_model.clone();
+    normalize_validation_model(&mut validation_model);
+    normalize_relationship_pairs(&mut validation_model, &symbols);
+    diagnostics.extend(validate_model(&validation_model, &symbols));
     for file in &mut files {
         file.schema_model.resolve_references(&symbols);
-        diagnostics.extend(symbols.collect_reference_diagnostics(&file.schema_model));
     }
 
     Ok(LoweredTdlProject { files, global_model, symbols, diagnostics })
@@ -1172,10 +1187,15 @@ fn lower_file_to_schema_ir(file: &ParsedTdlFile) -> Result<SemanticModel> {
 }
 
 fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<TypeDescriptor> {
+    let kind = if descriptor.kind == DescriptorKind::HolonType && descriptor.name == "TypeDescriptor" {
+        DescriptorKind::TypeDescriptor
+    } else {
+        descriptor.kind
+    };
     let mut lowered = TypeDescriptor::new(
         descriptor_key(descriptor, schema_name),
         descriptor.name.clone(),
-        descriptor.kind,
+        kind,
         schema_name,
         descriptor.origin.clone(),
     );

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -12,7 +12,10 @@ use crate::{
     },
 };
 use anyhow::{anyhow, Context, Result};
-use map_schema_semantic::{normalize_relationship_pairs, normalize_validation_model, validate_model};
+use map_schema_semantic::{
+    normalize_relationship_pairs, normalize_validation_model, validate_model,
+};
+use map_schema_semantic::{DiagnosticKind, DiagnosticLayer};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -111,7 +114,8 @@ pub fn compile_inputs(inputs: &[PathBuf], out_dir: &Path) -> Result<Vec<PathBuf>
 /// Compiles one TDL document provided as a raw string into loader JSON.
 pub fn compile_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<String> {
     let source_name = source_name.into();
-    let parsed = parse_tdl_file(raw, &source_name)?;
+    let parsed = parse_tdl_file(raw, &source_name)
+        .map_err(|error| anyhow!(format_diagnostics(&[error.into_diagnostic()])))?;
     let lowered = lower_parsed_files_to_schema_ir(vec![parsed])?;
     let compilation = build_compilation(lowered)?;
     if !compilation.diagnostics.is_empty() {
@@ -126,7 +130,12 @@ pub fn compile_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Resul
 }
 
 pub fn check_inputs(inputs: &[PathBuf]) -> Result<Vec<Diagnostic>> {
-    Ok(lower_inputs_to_schema_ir(inputs)?.diagnostics)
+    let (parsed, mut diagnostics) = parse_inputs_for_check(inputs)?;
+    if !diagnostics.is_empty() {
+        return Ok(diagnostics);
+    }
+    diagnostics.extend(lower_parsed_files_to_schema_ir(parsed)?.diagnostics);
+    Ok(diagnostics)
 }
 
 /// Renders the CLI output for `map-schema:check`.
@@ -146,14 +155,22 @@ pub fn render_check_output(diagnostics: &[Diagnostic]) -> String {
 /// Validates one TDL document provided as a raw string.
 pub fn check_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<Vec<Diagnostic>> {
     let source_name = source_name.into();
-    let parsed = parse_tdl_file(raw, &source_name)?;
-    Ok(lower_parsed_files_to_schema_ir(vec![parsed])?.diagnostics)
+    let (parsed, mut diagnostics) = parse_input_string_for_check(raw, &source_name);
+    if !diagnostics.is_empty() {
+        return Ok(diagnostics);
+    }
+    diagnostics.extend(
+        lower_parsed_files_to_schema_ir(vec![parsed.expect("parsed TDL file")])?.diagnostics,
+    );
+    Ok(diagnostics)
 }
 
-pub(crate) fn load_semantic_model(
-    inputs: &[PathBuf],
-) -> Result<(SemanticModel, Vec<Diagnostic>)> {
-    let lowered = lower_inputs_to_schema_ir(inputs)?;
+pub(crate) fn load_semantic_model(inputs: &[PathBuf]) -> Result<(SemanticModel, Vec<Diagnostic>)> {
+    let (parsed, diagnostics) = parse_inputs_for_check(inputs)?;
+    if !diagnostics.is_empty() {
+        return Ok((SemanticModel::new(), diagnostics));
+    }
+    let lowered = lower_parsed_files_to_schema_ir(parsed)?;
     Ok((lowered.global_model, lowered.diagnostics))
 }
 
@@ -189,10 +206,39 @@ fn parse_inputs(inputs: &[PathBuf]) -> Result<Vec<ParsedTdlFile>> {
         let raw = fs::read_to_string(&discovered.source_path).with_context(|| {
             format!("reading TDL source file {}", discovered.source_path.display())
         })?;
-        let document = parse_tdl_file(&raw, &discovered.relative_path)?;
+        let document = parse_tdl_file(&raw, &discovered.relative_path)
+            .map_err(|error| anyhow!(format_diagnostics(&[error.into_diagnostic()])))?;
         parsed.push(document);
     }
     Ok(parsed)
+}
+
+fn parse_inputs_for_check(inputs: &[PathBuf]) -> Result<(Vec<ParsedTdlFile>, Vec<Diagnostic>)> {
+    let files = collect_tdl_files(inputs)?;
+    let mut parsed = Vec::with_capacity(files.len());
+    let mut diagnostics = Vec::new();
+
+    for discovered in files {
+        let raw = fs::read_to_string(&discovered.source_path).with_context(|| {
+            format!("reading TDL source file {}", discovered.source_path.display())
+        })?;
+        match parse_tdl_file(&raw, &discovered.relative_path) {
+            Ok(document) => parsed.push(document),
+            Err(error) => diagnostics.push(error.into_diagnostic()),
+        }
+    }
+
+    Ok((parsed, diagnostics))
+}
+
+fn parse_input_string_for_check(
+    raw: &str,
+    source_name: &Path,
+) -> (Option<ParsedTdlFile>, Vec<Diagnostic>) {
+    match parse_tdl_file(raw, source_name) {
+        Ok(parsed) => (Some(parsed), Vec::new()),
+        Err(error) => (None, vec![error.into_diagnostic()]),
+    }
 }
 
 fn collect_tdl_files(inputs: &[PathBuf]) -> Result<Vec<DiscoveredFile>> {
@@ -261,7 +307,21 @@ fn normalize_relative_path(path: &Path) -> String {
         .join("/")
 }
 
-fn parse_tdl_file(raw: &str, relative_path: &Path) -> Result<ParsedTdlFile> {
+type ParseResult<T> = std::result::Result<T, TdlParseError>;
+
+#[derive(Debug, Clone)]
+struct TdlParseError {
+    kind: DiagnosticKind,
+    origin: Origin,
+}
+
+impl TdlParseError {
+    fn into_diagnostic(self) -> Diagnostic {
+        Diagnostic::error(DiagnosticLayer::Syntax, self.kind, Some(self.origin))
+    }
+}
+
+fn parse_tdl_file(raw: &str, relative_path: &Path) -> ParseResult<ParsedTdlFile> {
     let mut parser = Parser::new(raw, relative_path);
     parser.parse_file()
 }
@@ -283,7 +343,55 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_file(&mut self) -> Result<ParsedTdlFile> {
+    fn current_origin(&self) -> Origin {
+        Origin {
+            source_kind: SourceKind::TdlSource,
+            file_path: Some(self.relative_path.clone()),
+            line: Some(self.current_line_number() as u32),
+            column: Some(1),
+        }
+    }
+
+    fn previous_origin(&self) -> Origin {
+        Origin {
+            source_kind: SourceKind::TdlSource,
+            file_path: Some(self.relative_path.clone()),
+            line: Some(self.current_line_number().saturating_sub(1) as u32),
+            column: Some(1),
+        }
+    }
+
+    fn syntax_error(&self, kind: DiagnosticKind) -> TdlParseError {
+        TdlParseError { kind, origin: self.current_origin() }
+    }
+
+    fn previous_syntax_error(&self, kind: DiagnosticKind) -> TdlParseError {
+        TdlParseError { kind, origin: self.previous_origin() }
+    }
+
+    fn syntax_message(
+        &self,
+        context: impl Into<String>,
+        message: impl Into<String>,
+    ) -> TdlParseError {
+        self.syntax_error(DiagnosticKind::InvalidSyntax {
+            context: context.into(),
+            message: message.into(),
+        })
+    }
+
+    fn missing_syntax(
+        &self,
+        context: impl Into<String>,
+        expected: impl Into<String>,
+    ) -> TdlParseError {
+        self.syntax_error(DiagnosticKind::MissingSyntaxElement {
+            context: context.into(),
+            expected: expected.into(),
+        })
+    }
+
+    fn parse_file(&mut self) -> ParseResult<ParsedTdlFile> {
         let file_path = self.relative_path.clone();
         let origin = Origin {
             source_kind: SourceKind::TdlSource,
@@ -298,31 +406,41 @@ impl<'a> Parser<'a> {
             let line = self.peek_trimmed().unwrap().to_string();
             if line.starts_with("schema ") {
                 if schema.is_some() {
-                    return Err(anyhow!("multiple schema declarations in {}", file_path.display()));
+                    return Err(self.syntax_message(
+                        "schema",
+                        format!("multiple schema declarations in {}", file_path.display()),
+                    ));
                 }
                 schema = Some(self.parse_schema_decl(origin.clone())?);
             } else if is_descriptor_line(&line) {
                 descriptors.push(self.parse_descriptor_decl(None)?);
                 descriptors.append(&mut self.pending_descriptors);
             } else if line == "}" {
-                return Err(anyhow!("unexpected closing brace in {}", file_path.display()));
+                return Err(self.syntax_message(
+                    "top-level declaration",
+                    format!("unexpected closing brace in {}", file_path.display()),
+                ));
             } else {
-                return Err(anyhow!(
-                    "unrecognized top-level declaration in {}: {}",
-                    file_path.display(),
-                    line
+                return Err(self.syntax_message(
+                    "top-level declaration",
+                    format!(
+                        "unrecognized top-level declaration in {}: {}",
+                        file_path.display(),
+                        line
+                    ),
                 ));
             }
         }
 
-        let schema = schema
-            .ok_or_else(|| anyhow!("missing schema declaration in {}", file_path.display()))?;
+        let schema = schema.ok_or_else(|| {
+            self.missing_syntax("file", format!("schema declaration in {}", file_path.display()))
+        })?;
         Ok(ParsedTdlFile { relative_path: file_path, schema, descriptors })
     }
 
-    fn parse_schema_decl(&mut self, origin: Origin) -> Result<TdlSchema> {
+    fn parse_schema_decl(&mut self, origin: Origin) -> ParseResult<TdlSchema> {
         let line = self.consume_trimmed().unwrap();
-        let header = parse_inline_header(&line, "schema")?;
+        let header = parse_inline_header(&line, "schema", self.previous_origin())?;
         let name = header.name;
         let mut dependencies = Vec::new();
         let mut literal_properties = map_schema_semantic::LiteralObject::new();
@@ -349,10 +467,15 @@ impl<'a> Parser<'a> {
                 } else if current == "relationships {" {
                     self.consume_trimmed();
                     for line in self.parse_reference_block()? {
-                        if let Some(relationship) = parse_literal_relationship_line(&line)? {
+                        if let Some(relationship) =
+                            parse_literal_relationship_line(&line, self.current_origin())?
+                        {
                             literal_relationships.push(relationship);
                         } else {
-                            return Err(anyhow!("unexpected schema relationship line: {}", line));
+                            return Err(self.syntax_message(
+                                "schema relationships",
+                                format!("unexpected schema relationship line: {}", line),
+                            ));
                         }
                     }
                 } else if current == "allows_additional_properties" {
@@ -364,7 +487,10 @@ impl<'a> Parser<'a> {
                 } else if current.starts_with("header") {
                     block_header = Some(self.parse_header_block()?);
                 } else {
-                    return Err(anyhow!("unexpected schema clause: {}", current));
+                    return Err(self.syntax_message(
+                        "schema clause",
+                        format!("unexpected schema clause: {}", current),
+                    ));
                 }
             }
         }
@@ -381,9 +507,9 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_descriptor_decl(&mut self, variant_of: Option<String>) -> Result<TdlDescriptor> {
+    fn parse_descriptor_decl(&mut self, variant_of: Option<String>) -> ParseResult<TdlDescriptor> {
         let line = self.consume_trimmed().unwrap();
-        let parsed = parse_descriptor_header(&line)?;
+        let parsed = parse_descriptor_header(&line, self.previous_origin())?;
         let mut descriptor = TdlDescriptor {
             kind: parsed.kind,
             name: parsed.name,
@@ -461,11 +587,24 @@ impl<'a> Parser<'a> {
                     }
                     s if s.starts_with("cardinality ") => {
                         let range = s["cardinality ".len()..].trim();
-                        let (min, max) = range
-                            .split_once("..")
-                            .ok_or_else(|| anyhow!("invalid cardinality '{}'", range))?;
-                        descriptor.min_cardinality = Some(min.trim().parse()?);
-                        descriptor.max_cardinality = Some(max.trim().parse()?);
+                        let (min, max) = range.split_once("..").ok_or_else(|| {
+                            self.syntax_message(
+                                "cardinality",
+                                format!("invalid cardinality '{}'", range),
+                            )
+                        })?;
+                        descriptor.min_cardinality = Some(min.trim().parse().map_err(|error| {
+                            self.syntax_message(
+                                "cardinality",
+                                format!("invalid minimum cardinality '{}': {error}", min.trim()),
+                            )
+                        })?);
+                        descriptor.max_cardinality = Some(max.trim().parse().map_err(|error| {
+                            self.syntax_message(
+                                "cardinality",
+                                format!("invalid maximum cardinality '{}': {error}", max.trim()),
+                            )
+                        })?);
                         self.consume_trimmed();
                     }
                     "ordered" => {
@@ -503,7 +642,9 @@ impl<'a> Parser<'a> {
                     "relationships {" => {
                         self.consume_trimmed();
                         for line in self.parse_reference_block()? {
-                            if let Some(relationship) = parse_literal_relationship_line(&line)? {
+                            if let Some(relationship) =
+                                parse_literal_relationship_line(&line, self.current_origin())?
+                            {
                                 descriptor.literal_relationships.push(relationship);
                             } else {
                                 descriptor.instance_relationships.push(line);
@@ -528,24 +669,35 @@ impl<'a> Parser<'a> {
                             self.pending_descriptors.push(variant);
                             descriptor.variants.push(variant_key);
                         } else {
-                            return Err(anyhow!("unexpected descriptor clause: {}", other));
+                            return Err(self.syntax_message(
+                                "descriptor clause",
+                                format!("unexpected descriptor clause: {}", other),
+                            ));
                         }
                     }
                 }
             }
         }
 
-        apply_literal_properties_to_tdl_descriptor(&mut descriptor)?;
+        apply_literal_properties_to_tdl_descriptor(&mut descriptor).map_err(|error| {
+            self.previous_syntax_error(DiagnosticKind::InvalidSyntax {
+                context: "descriptor literal properties".to_string(),
+                message: error.to_string(),
+            })
+        })?;
         apply_literal_relationships_to_tdl_descriptor(&mut descriptor);
         normalize_relationship_pair_targets(&mut descriptor);
         Ok(descriptor)
     }
 
-    fn parse_variant_decl(&mut self, variant_of: Option<String>) -> Result<TdlDescriptor> {
+    fn parse_variant_decl(&mut self, variant_of: Option<String>) -> ParseResult<TdlDescriptor> {
         let line = self.consume_trimmed().unwrap();
-        let parsed = parse_descriptor_header(&line)?;
+        let parsed = parse_descriptor_header(&line, self.previous_origin())?;
         if parsed.kind != DescriptorKind::EnumVariant {
-            return Err(anyhow!("expected variant declaration, found {}", line));
+            return Err(self.previous_syntax_error(DiagnosticKind::InvalidSyntax {
+                context: "variant declaration".to_string(),
+                message: format!("expected variant declaration, found {}", line),
+            }));
         }
         let mut descriptor = TdlDescriptor {
             kind: DescriptorKind::EnumVariant,
@@ -602,7 +754,9 @@ impl<'a> Parser<'a> {
                 } else if current == "relationships {" {
                     self.consume_trimmed();
                     for line in self.parse_reference_block()? {
-                        if let Some(relationship) = parse_literal_relationship_line(&line)? {
+                        if let Some(relationship) =
+                            parse_literal_relationship_line(&line, self.current_origin())?
+                        {
                             descriptor.literal_relationships.push(relationship);
                         } else {
                             descriptor.instance_relationships.push(line);
@@ -612,18 +766,26 @@ impl<'a> Parser<'a> {
                     descriptor.extends = Some(current["extends ".len()..].trim().to_string());
                     self.consume_trimmed();
                 } else {
-                    return Err(anyhow!("unexpected variant clause: {}", current));
+                    return Err(self.syntax_message(
+                        "variant clause",
+                        format!("unexpected variant clause: {}", current),
+                    ));
                 }
             }
         }
 
-        apply_literal_properties_to_tdl_descriptor(&mut descriptor)?;
+        apply_literal_properties_to_tdl_descriptor(&mut descriptor).map_err(|error| {
+            self.previous_syntax_error(DiagnosticKind::InvalidSyntax {
+                context: "variant literal properties".to_string(),
+                message: error.to_string(),
+            })
+        })?;
         apply_literal_relationships_to_tdl_descriptor(&mut descriptor);
         normalize_relationship_pair_targets(&mut descriptor);
         Ok(descriptor)
     }
 
-    fn parse_variant_block(&mut self, enum_name: &str) -> Result<Vec<TdlDescriptor>> {
+    fn parse_variant_block(&mut self, enum_name: &str) -> ParseResult<Vec<TdlDescriptor>> {
         let mut variants = Vec::new();
         while self.skip_blank_lines() {
             let current = self.peek_trimmed().unwrap().to_string();
@@ -634,16 +796,22 @@ impl<'a> Parser<'a> {
             if current.starts_with("variant ") {
                 variants.push(self.parse_variant_decl(Some(enum_name.to_string()))?);
             } else {
-                return Err(anyhow!("unexpected variants clause: {}", current));
+                return Err(self.syntax_message(
+                    "variants block",
+                    format!("unexpected variants clause: {}", current),
+                ));
             }
         }
         Ok(variants)
     }
 
-    fn parse_header_block(&mut self) -> Result<DescriptorHeader> {
+    fn parse_header_block(&mut self) -> ParseResult<DescriptorHeader> {
         let line = self.consume_trimmed().unwrap();
         if !line.starts_with("header") {
-            return Err(anyhow!("expected header block, found {}", line));
+            return Err(self.previous_syntax_error(DiagnosticKind::InvalidSyntax {
+                context: "header block".to_string(),
+                message: format!("expected header block, found {}", line),
+            }));
         }
         if !line.trim_end().ends_with('{') {
             self.expect_open_brace()?;
@@ -659,16 +827,21 @@ impl<'a> Parser<'a> {
                 self.consume_trimmed();
                 break;
             }
-            let (field, value) = current
-                .split_once(':')
-                .ok_or_else(|| anyhow!("invalid header field '{}'", current))?;
-            let value = parse_string_literal(value.trim())?;
+            let (field, value) = current.split_once(':').ok_or_else(|| {
+                self.syntax_message("header field", format!("invalid header field '{}'", current))
+            })?;
+            let value = parse_string_literal(value.trim(), self.current_origin(), "header field")?;
             match field.trim() {
                 "description" => description = Some(value),
                 "display_name" => display_name = Some(value),
                 "display_plural" => display_name_plural = Some(value),
                 "plural" => type_name_plural = Some(value),
-                other => return Err(anyhow!("unexpected header field '{}'", other)),
+                other => {
+                    return Err(self.syntax_message(
+                        "header field",
+                        format!("unexpected header field '{}'", other),
+                    ))
+                }
             }
             self.consume_trimmed();
         }
@@ -676,7 +849,7 @@ impl<'a> Parser<'a> {
         Ok(DescriptorHeader { description, display_name, display_name_plural, type_name_plural })
     }
 
-    fn parse_reference_block(&mut self) -> Result<Vec<String>> {
+    fn parse_reference_block(&mut self) -> ParseResult<Vec<String>> {
         let mut refs = Vec::new();
         while self.skip_blank_lines() {
             let current = self.peek_trimmed().unwrap().to_string();
@@ -692,7 +865,7 @@ impl<'a> Parser<'a> {
 
     fn parse_properties_block(
         &mut self,
-    ) -> Result<(map_schema_semantic::LiteralObject, Vec<String>)> {
+    ) -> ParseResult<(map_schema_semantic::LiteralObject, Vec<String>)> {
         let mut properties = map_schema_semantic::LiteralObject::new();
         let mut refs = Vec::new();
         while self.skip_blank_lines() {
@@ -701,7 +874,9 @@ impl<'a> Parser<'a> {
                 self.consume_trimmed();
                 break;
             }
-            if let Some((name, value)) = parse_literal_property_line(&current)? {
+            if let Some((name, value)) =
+                parse_literal_property_line(&current, self.current_origin())?
+            {
                 properties.insert(name, value);
             } else {
                 refs.push(current);
@@ -746,7 +921,7 @@ impl<'a> Parser<'a> {
         self.index + 1
     }
 
-    fn try_consume_open_brace(&mut self) -> Result<bool> {
+    fn try_consume_open_brace(&mut self) -> ParseResult<bool> {
         if self.skip_blank_lines() && self.peek_trimmed() == Some("{") {
             self.index += 1;
             Ok(true)
@@ -755,11 +930,11 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn expect_open_brace(&mut self) -> Result<()> {
+    fn expect_open_brace(&mut self) -> ParseResult<()> {
         if self.try_consume_open_brace()? {
             Ok(())
         } else {
-            Err(anyhow!("expected '{{'"))
+            Err(self.missing_syntax("block", "{"))
         }
     }
 }
@@ -775,10 +950,16 @@ struct ParsedHead {
     has_block: bool,
 }
 
-fn parse_inline_header(line: &str, keyword: &str) -> Result<InlineHeader> {
+fn parse_inline_header(line: &str, keyword: &str, origin: Origin) -> ParseResult<InlineHeader> {
     let body = line.trim();
     if !body.starts_with(keyword) {
-        return Err(anyhow!("expected {} declaration", keyword));
+        return Err(TdlParseError {
+            kind: DiagnosticKind::InvalidSyntax {
+                context: format!("{keyword} declaration"),
+                message: format!("expected {} declaration", keyword),
+            },
+            origin,
+        });
     }
     let mut remainder = body[keyword.len()..].trim();
     let has_block = remainder.ends_with('{');
@@ -786,7 +967,13 @@ fn parse_inline_header(line: &str, keyword: &str) -> Result<InlineHeader> {
         remainder = remainder.trim_end_matches('{').trim();
     }
     if remainder.is_empty() {
-        return Err(anyhow!("missing {} name", keyword));
+        return Err(TdlParseError {
+            kind: DiagnosticKind::MissingSyntaxElement {
+                context: format!("{keyword} declaration"),
+                expected: format!("{keyword} name"),
+            },
+            origin,
+        });
     }
     Ok(InlineHeader { name: remainder.to_string(), header: None, has_block })
 }
@@ -797,7 +984,7 @@ struct InlineHeader {
     has_block: bool,
 }
 
-fn parse_descriptor_header(line: &str) -> Result<ParsedHead> {
+fn parse_descriptor_header(line: &str, origin: Origin) -> ParseResult<ParsedHead> {
     let trimmed = line.trim();
     let has_block = trimmed.ends_with('{');
     let head = if has_block { trimmed.trim_end_matches('{').trim() } else { trimmed };
@@ -832,13 +1019,25 @@ fn parse_descriptor_header(line: &str) -> Result<ParsedHead> {
         } else if let Some(tail) = remainder.strip_prefix("variant ") {
             (DescriptorKind::EnumVariant, tail)
         } else {
-            return Err(anyhow!("unrecognized TDL declaration: {}", line));
+            return Err(TdlParseError {
+                kind: DiagnosticKind::InvalidSyntax {
+                    context: "descriptor declaration".to_string(),
+                    message: format!("unrecognized TDL declaration: {}", line),
+                },
+                origin,
+            });
         };
         (kind, tail.trim())
     };
 
     if after_kind.is_empty() {
-        return Err(anyhow!("missing declaration name in '{}'", line));
+        return Err(TdlParseError {
+            kind: DiagnosticKind::MissingSyntaxElement {
+                context: "descriptor declaration".to_string(),
+                expected: format!("declaration name in '{}'", line),
+            },
+            origin,
+        });
     }
     let name = after_kind.trim_end_matches('{').trim().to_string();
     if kind == DescriptorKind::RelationshipType {
@@ -880,15 +1079,24 @@ fn is_descriptor_line(line: &str) -> bool {
         || line.starts_with("variant ")
 }
 
-fn parse_string_literal(raw: &str) -> Result<String> {
+fn parse_string_literal(raw: &str, origin: Origin, context: &str) -> ParseResult<String> {
     if raw.starts_with('"') {
-        Ok(serde_json::from_str(raw)?)
+        serde_json::from_str(raw).map_err(|error| TdlParseError {
+            kind: DiagnosticKind::InvalidSyntax {
+                context: context.to_string(),
+                message: format!("invalid string literal: {error}"),
+            },
+            origin,
+        })
     } else {
         Ok(raw.to_string())
     }
 }
 
-fn parse_literal_relationship_line(line: &str) -> Result<Option<LiteralRelationship>> {
+fn parse_literal_relationship_line(
+    line: &str,
+    origin: Origin,
+) -> ParseResult<Option<LiteralRelationship>> {
     if line.starts_with('(') {
         return Ok(None);
     }
@@ -904,9 +1112,21 @@ fn parse_literal_relationship_line(line: &str) -> Result<Option<LiteralRelations
     }
 
     let targets = if raw_targets.starts_with('[') {
-        serde_json::from_str::<Vec<String>>(raw_targets)?
+        serde_json::from_str::<Vec<String>>(raw_targets).map_err(|error| TdlParseError {
+            kind: DiagnosticKind::InvalidSyntax {
+                context: "relationship literal".to_string(),
+                message: format!("invalid relationship target list: {error}"),
+            },
+            origin: origin.clone(),
+        })?
     } else if raw_targets.starts_with('"') {
-        vec![serde_json::from_str::<String>(raw_targets)?]
+        vec![serde_json::from_str::<String>(raw_targets).map_err(|error| TdlParseError {
+            kind: DiagnosticKind::InvalidSyntax {
+                context: "relationship literal".to_string(),
+                message: format!("invalid relationship target string: {error}"),
+            },
+            origin,
+        })?]
     } else {
         vec![raw_targets.to_string()]
     };
@@ -916,7 +1136,8 @@ fn parse_literal_relationship_line(line: &str) -> Result<Option<LiteralRelations
 
 fn parse_literal_property_line(
     line: &str,
-) -> Result<Option<(String, map_schema_semantic::LiteralValue)>> {
+    origin: Origin,
+) -> ParseResult<Option<(String, map_schema_semantic::LiteralValue)>> {
     let Some((name, raw_value)) = line.split_once(':') else {
         return Ok(None);
     };
@@ -927,7 +1148,16 @@ fn parse_literal_property_line(
         return Ok(None);
     }
 
-    Ok(Some((name.to_string(), json_value_to_literal(&serde_json::from_str(raw_value)?))))
+    Ok(Some((
+        name.to_string(),
+        json_value_to_literal(&serde_json::from_str(raw_value).map_err(|error| TdlParseError {
+            kind: DiagnosticKind::InvalidSyntax {
+                context: "property literal".to_string(),
+                message: format!("invalid property literal: {error}"),
+            },
+            origin,
+        })?),
+    )))
 }
 
 fn apply_literal_properties_to_tdl_descriptor(descriptor: &mut TdlDescriptor) -> Result<()> {
@@ -1187,11 +1417,12 @@ fn lower_file_to_schema_ir(file: &ParsedTdlFile) -> Result<SemanticModel> {
 }
 
 fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<TypeDescriptor> {
-    let kind = if descriptor.kind == DescriptorKind::HolonType && descriptor.name == "TypeDescriptor" {
-        DescriptorKind::TypeDescriptor
-    } else {
-        descriptor.kind
-    };
+    let kind =
+        if descriptor.kind == DescriptorKind::HolonType && descriptor.name == "TypeDescriptor" {
+            DescriptorKind::TypeDescriptor
+        } else {
+            descriptor.kind
+        };
     let mut lowered = TypeDescriptor::new(
         descriptor_key(descriptor, schema_name),
         descriptor.name.clone(),
@@ -1542,8 +1773,11 @@ mod tests {
     use std::{
         env, fs,
         io::Write,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn fixture_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("..").join("schema-src")
@@ -1557,14 +1791,18 @@ mod tests {
             .join("json-imports")
     }
 
-    fn temp_out_dir() -> PathBuf {
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-compile-{nanos}"))
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("{prefix}-{nanos}-{counter}"))
+    }
+
+    fn temp_out_dir() -> PathBuf {
+        unique_temp_dir("map-schema-compile")
     }
 
     fn temp_tdl_dir() -> PathBuf {
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        env::temp_dir().join(format!("map-schema-tdl-{nanos}"))
+        unique_temp_dir("map-schema-tdl")
     }
 
     fn write_temp_tdl(file_name: &str, contents: &str) -> Result<PathBuf> {

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -1,3 +1,11 @@
+//! TDL source adapter and compiler pipeline.
+//!
+//! This module owns TDL-specific parsing and lowering, but not the meaning of the schema. Parsed
+//! declarations are converted into the canonical [`SemanticModel`], where shared symbol
+//! resolution, normalization, and semantic validation run. Successful models are then projected
+//! into loader JSON. Keeping that boundary explicit allows other authoring and output formats to
+//! share schema semantics without inheriting TDL syntax rules.
+
 use crate::{
     diagnostics::{format_diagnostics, Diagnostic},
     literal_bridge::json_value_to_literal,
@@ -87,6 +95,11 @@ struct TdlDescriptor {
     literal_relationships: Vec<LiteralRelationship>,
 }
 
+/// Compiles all TDL files discovered beneath `inputs` into corresponding loader JSON files.
+///
+/// Compilation is all-or-nothing with respect to diagnostics: no output is written unless the
+/// complete input set parses, resolves, and passes semantic validation. Relative input paths are
+/// retained beneath `out_dir`, with each `.tdl` extension replaced by `.json`.
 pub fn compile_inputs(inputs: &[PathBuf], out_dir: &Path) -> Result<Vec<PathBuf>> {
     let lowered = lower_inputs_to_schema_ir(inputs)?;
     let compilation = build_compilation(lowered)?;
@@ -112,6 +125,10 @@ pub fn compile_inputs(inputs: &[PathBuf], out_dir: &Path) -> Result<Vec<PathBuf>
 }
 
 /// Compiles one TDL document provided as a raw string into loader JSON.
+///
+/// `source_name` is retained as diagnostic provenance and loader metadata; it does not need to
+/// identify a file on disk. Syntax or semantic diagnostics are returned as a formatted error and
+/// no JSON is emitted.
 pub fn compile_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<String> {
     let source_name = source_name.into();
     let parsed = parse_tdl_file(raw, &source_name)
@@ -129,6 +146,11 @@ pub fn compile_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Resul
     emit_loader_document_json(&file.document)
 }
 
+/// Checks a project of TDL inputs without emitting loader documents.
+///
+/// Syntax diagnostics are collected across files. Semantic checking begins only when every file
+/// parses, because lowering an incomplete project would turn missing declarations into misleading
+/// reference diagnostics.
 pub fn check_inputs(inputs: &[PathBuf]) -> Result<Vec<Diagnostic>> {
     let (parsed, mut diagnostics) = parse_inputs_for_check(inputs)?;
     if !diagnostics.is_empty() {
@@ -152,7 +174,10 @@ pub fn render_check_output(diagnostics: &[Diagnostic]) -> String {
     }
 }
 
-/// Validates one TDL document provided as a raw string.
+/// Checks one in-memory TDL document without emitting loader JSON.
+///
+/// The supplied source name is used in diagnostic origins in the same way as a discovered relative
+/// file path.
 pub fn check_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<Vec<Diagnostic>> {
     let source_name = source_name.into();
     let (parsed, mut diagnostics) = parse_input_string_for_check(raw, &source_name);
@@ -165,6 +190,11 @@ pub fn check_input_string(raw: &str, source_name: impl Into<PathBuf>) -> Result<
     Ok(diagnostics)
 }
 
+/// Loads TDL inputs into the canonical semantic model used by cross-format operations.
+///
+/// A syntax-invalid project returns an empty model alongside its syntax diagnostics. Callers must
+/// not compare or emit that placeholder model; it exists so diagnostics can remain structured at
+/// the adapter boundary.
 pub(crate) fn load_semantic_model(inputs: &[PathBuf]) -> Result<(SemanticModel, Vec<Diagnostic>)> {
     let (parsed, diagnostics) = parse_inputs_for_check(inputs)?;
     if !diagnostics.is_empty() {
@@ -174,6 +204,7 @@ pub(crate) fn load_semantic_model(inputs: &[PathBuf]) -> Result<(SemanticModel, 
     Ok((lowered.global_model, lowered.diagnostics))
 }
 
+/// Output-ready loader documents paired with any diagnostics found before emission.
 struct Compilation {
     files: Vec<CompiledLoaderFile>,
     diagnostics: Vec<Diagnostic>,
@@ -185,12 +216,17 @@ struct CompiledLoaderFile {
     document: LoaderDocument,
 }
 
+/// One parsed file and the file-scoped semantic model used to preserve output partitioning.
 #[derive(Debug, Clone)]
 struct LoweredTdlFile {
     parsed: ParsedTdlFile,
     schema_model: SemanticModel,
 }
 
+/// Project-wide lowering state shared by validation and per-file emission.
+///
+/// `global_model` and `symbols` provide cross-file resolution, while `files` retain the original
+/// boundaries needed to emit one loader document per source file.
 #[derive(Debug, Clone)]
 struct LoweredTdlProject {
     files: Vec<LoweredTdlFile>,
@@ -199,6 +235,10 @@ struct LoweredTdlProject {
     diagnostics: Vec<Diagnostic>,
 }
 
+/// Parses inputs for compilation, stopping at the first syntax-invalid file.
+///
+/// Compile mode cannot produce a partial output set, so syntax diagnostics are promoted into the
+/// operation-level error channel here.
 fn parse_inputs(inputs: &[PathBuf]) -> Result<Vec<ParsedTdlFile>> {
     let files = collect_tdl_files(inputs)?;
     let mut parsed = Vec::with_capacity(files.len());
@@ -213,6 +253,10 @@ fn parse_inputs(inputs: &[PathBuf]) -> Result<Vec<ParsedTdlFile>> {
     Ok(parsed)
 }
 
+/// Parses every discovered file and accumulates syntax diagnostics for authoring feedback.
+///
+/// Successfully parsed files are returned only to support the clean-input path. Callers must not
+/// lower them when `diagnostics` is non-empty because they do not represent the complete project.
 fn parse_inputs_for_check(inputs: &[PathBuf]) -> Result<(Vec<ParsedTdlFile>, Vec<Diagnostic>)> {
     let files = collect_tdl_files(inputs)?;
     let mut parsed = Vec::with_capacity(files.len());
@@ -309,6 +353,7 @@ fn normalize_relative_path(path: &Path) -> String {
 
 type ParseResult<T> = std::result::Result<T, TdlParseError>;
 
+/// A syntax failure with its exact TDL source location, before conversion to shared diagnostics.
 #[derive(Debug, Clone)]
 struct TdlParseError {
     kind: DiagnosticKind,
@@ -326,6 +371,10 @@ fn parse_tdl_file(raw: &str, relative_path: &Path) -> ParseResult<ParsedTdlFile>
     parser.parse_file()
 }
 
+/// Stateful, line-oriented parser for one TDL source document.
+///
+/// The parser builds a TDL-shaped representation only. Name resolution and schema semantics are
+/// intentionally deferred until all project files have been lowered into the canonical IR.
 struct Parser<'a> {
     lines: Vec<&'a str>,
     index: usize,
@@ -391,6 +440,10 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parses exactly one schema declaration plus any number of descriptor declarations.
+    ///
+    /// Descriptor order is preserved for deterministic lowering. Nested declarations accumulated
+    /// in `pending_descriptors` are promoted to the same file-level descriptor stream.
     fn parse_file(&mut self) -> ParseResult<ParsedTdlFile> {
         let file_path = self.relative_path.clone();
         let origin = Origin {
@@ -466,16 +519,23 @@ impl<'a> Parser<'a> {
                         .extend(properties.iter().map(|(key, value)| (key.clone(), value.clone())));
                 } else if current == "relationships {" {
                     self.consume_trimmed();
-                    for line in self.parse_reference_block()? {
-                        if let Some(relationship) =
-                            parse_literal_relationship_line(&line, self.current_origin())?
-                        {
+                    for source_line in self.parse_reference_block()? {
+                        if let Some(relationship) = parse_literal_relationship_line(
+                            &source_line.text,
+                            source_line.origin.clone(),
+                        )? {
                             literal_relationships.push(relationship);
                         } else {
-                            return Err(self.syntax_message(
-                                "schema relationships",
-                                format!("unexpected schema relationship line: {}", line),
-                            ));
+                            return Err(TdlParseError {
+                                kind: DiagnosticKind::InvalidSyntax {
+                                    context: "schema relationships".to_string(),
+                                    message: format!(
+                                        "unexpected schema relationship line: {}",
+                                        source_line.text
+                                    ),
+                                },
+                                origin: source_line.origin,
+                            });
                         }
                     }
                 } else if current == "allows_additional_properties" {
@@ -641,13 +701,14 @@ impl<'a> Parser<'a> {
                     }
                     "relationships {" => {
                         self.consume_trimmed();
-                        for line in self.parse_reference_block()? {
-                            if let Some(relationship) =
-                                parse_literal_relationship_line(&line, self.current_origin())?
-                            {
+                        for source_line in self.parse_reference_block()? {
+                            if let Some(relationship) = parse_literal_relationship_line(
+                                &source_line.text,
+                                source_line.origin,
+                            )? {
                                 descriptor.literal_relationships.push(relationship);
                             } else {
-                                descriptor.instance_relationships.push(line);
+                                descriptor.instance_relationships.push(source_line.text);
                             }
                         }
                     }
@@ -753,13 +814,13 @@ impl<'a> Parser<'a> {
                     descriptor.instance_properties.extend(instance_properties);
                 } else if current == "relationships {" {
                     self.consume_trimmed();
-                    for line in self.parse_reference_block()? {
+                    for source_line in self.parse_reference_block()? {
                         if let Some(relationship) =
-                            parse_literal_relationship_line(&line, self.current_origin())?
+                            parse_literal_relationship_line(&source_line.text, source_line.origin)?
                         {
                             descriptor.literal_relationships.push(relationship);
                         } else {
-                            descriptor.instance_relationships.push(line);
+                            descriptor.instance_relationships.push(source_line.text);
                         }
                     }
                 } else if current.starts_with("extends ") {
@@ -849,7 +910,11 @@ impl<'a> Parser<'a> {
         Ok(DescriptorHeader { description, display_name, display_name_plural, type_name_plural })
     }
 
-    fn parse_reference_block(&mut self) -> ParseResult<Vec<String>> {
+    /// Captures reference-like block entries together with their authored locations.
+    ///
+    /// Origins must be snapshotted before consuming each line. Downstream literal parsing can then
+    /// report the offending line rather than whichever line the parser cursor reached afterward.
+    fn parse_reference_block(&mut self) -> ParseResult<Vec<SourceLine>> {
         let mut refs = Vec::new();
         while self.skip_blank_lines() {
             let current = self.peek_trimmed().unwrap().to_string();
@@ -857,7 +922,7 @@ impl<'a> Parser<'a> {
                 self.consume_trimmed();
                 break;
             }
-            refs.push(current);
+            refs.push(SourceLine { text: current, origin: self.current_origin() });
             self.consume_trimmed();
         }
         Ok(refs)
@@ -937,6 +1002,12 @@ impl<'a> Parser<'a> {
             Err(self.missing_syntax("block", "{"))
         }
     }
+}
+
+/// Source text whose origin remains stable after the parser advances.
+struct SourceLine {
+    text: String,
+    origin: Origin,
 }
 
 #[derive(Debug, Clone)]
@@ -1320,10 +1391,16 @@ fn normalize_relationship_pair_targets(descriptor: &mut TdlDescriptor) {
     }
 }
 
+/// Runs the strict parse-and-lower path used by compilation.
 fn lower_inputs_to_schema_ir(inputs: &[PathBuf]) -> Result<LoweredTdlProject> {
     lower_parsed_files_to_schema_ir(parse_inputs(inputs)?)
 }
 
+/// Lowers a complete parsed project and performs project-wide semantic validation.
+///
+/// Validation uses a normalized clone so validation-only canonicalization cannot alter the model
+/// later emitted to loader JSON. Per-file models resolve through the global symbol index after
+/// validation, preserving source partitioning while allowing cross-file references.
 fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<LoweredTdlProject> {
     let mut files = Vec::new();
     let mut global_model = SemanticModel::new();
@@ -1350,6 +1427,10 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<Lowered
     Ok(LoweredTdlProject { files, global_model, symbols, diagnostics })
 }
 
+/// Projects validated semantic models into loader documents without reinterpreting TDL syntax.
+///
+/// Cross-file references determine each document's `load_with` metadata. The emitted-key lookup
+/// ensures references use the same canonical keys as their projected loader holons.
 fn build_compilation(lowered: LoweredTdlProject) -> Result<Compilation> {
     let LoweredTdlProject { files, global_model: _global_model, symbols, diagnostics } = lowered;
     let schema_models = files.iter().map(|file| &file.schema_model).collect::<Vec<_>>();
@@ -1389,6 +1470,7 @@ fn current_timestamp_rfc3339() -> Result<String> {
     Ok(OffsetDateTime::now_utc().format(&Rfc3339)?)
 }
 
+/// Converts one TDL-shaped parse result into representation-neutral schema IR.
 fn lower_file_to_schema_ir(file: &ParsedTdlFile) -> Result<SemanticModel> {
     let mut model = SemanticModel::new();
     model.push_schema(Schema {
@@ -1416,6 +1498,10 @@ fn lower_file_to_schema_ir(file: &ParsedTdlFile) -> Result<SemanticModel> {
     Ok(model)
 }
 
+/// Lowers TDL descriptor sugar and defaults into explicit canonical descriptor fields.
+///
+/// This function may encode TDL defaults, such as implicit `Extends` targets, but semantic
+/// validity remains the responsibility of the shared validator operating on the resulting IR.
 fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<TypeDescriptor> {
     let kind =
         if descriptor.kind == DescriptorKind::HolonType && descriptor.name == "TypeDescriptor" {
@@ -1830,6 +1916,22 @@ mod tests {
     fn checks_core_schema_corpus_without_diagnostics() -> Result<()> {
         let diagnostics = check_inputs(&[fixture_dir()])?;
         assert!(diagnostics.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn relationship_literal_syntax_diagnostic_uses_the_authored_line() -> Result<()> {
+        let diagnostics = check_input_string(
+            "schema Origin Test {\n}\n\nholon Thing {\n  relationships {\n    Broken -> [\"missing-end\"\n  }\n}\n",
+            "relationship-origin.tdl",
+        )?;
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].layer, DiagnosticLayer::Syntax);
+        assert!(matches!(diagnostics[0].kind, DiagnosticKind::InvalidSyntax { .. }));
+        assert_eq!(diagnostics[0].origin.as_ref().and_then(|origin| origin.line), Some(6));
+        assert_eq!(diagnostics[0].origin.as_ref().and_then(|origin| origin.column), Some(1));
+
         Ok(())
     }
 

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -21,8 +21,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use map_schema_semantic::{
-    effective_boolean_property_names, normalize_relationship_pairs, validate_model,
-    CanonicalDescriptorGraph,
+    effective_boolean_property_names, validate_model, CanonicalDescriptorGraph,
 };
 use map_schema_semantic::{DiagnosticKind, DiagnosticLayer};
 use std::{
@@ -1415,9 +1414,9 @@ fn lower_inputs_to_schema_ir(inputs: &[PathBuf]) -> Result<LoweredTdlProject> {
 
 /// Lowers a complete parsed project and performs project-wide semantic validation.
 ///
-/// Validation uses a normalized clone so validation-only canonicalization cannot alter the model
-/// later emitted to loader JSON. Per-file models resolve through the global symbol index after
-/// validation, preserving source partitioning while allowing cross-file references.
+/// TDL conventions are materialized into the canonical models before validation and projection.
+/// Per-file models resolve through the global symbol index after validation, preserving source
+/// partitioning while allowing cross-file references.
 fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<LoweredTdlProject> {
     let mut files = Vec::new();
     let mut global_model = SemanticModel::new();
@@ -1433,19 +1432,155 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<Lowered
     }
 
     let (symbols, mut diagnostics) = SymbolIndex::build(&mut global_model);
+    let type_kind_defaults = derive_tdl_type_kind_defaults(&global_model, &symbols);
+    apply_tdl_type_kind_defaults(&mut global_model, &type_kind_defaults);
+    for file in &mut files {
+        apply_tdl_type_kind_defaults(&mut file.schema_model, &type_kind_defaults);
+    }
     let boolean_defaults = derive_tdl_boolean_defaults(&global_model, &symbols);
     apply_tdl_boolean_defaults(&mut global_model, &boolean_defaults);
     for file in &mut files {
         apply_tdl_boolean_defaults(&mut file.schema_model, &boolean_defaults);
     }
-    let mut validation_model = global_model.clone();
-    normalize_relationship_pairs(&mut validation_model, &symbols);
-    diagnostics.extend(validate_model(&validation_model, &symbols));
+    expand_tdl_relationship_pairs(&mut global_model, &symbols);
     for file in &mut files {
+        expand_tdl_relationship_pairs(&mut file.schema_model, &symbols);
         file.schema_model.resolve_references(&symbols);
     }
+    diagnostics.extend(validate_model(&global_model, &symbols));
 
     Ok(LoweredTdlProject { files, global_model, symbols, diagnostics })
+}
+
+/// Propagates the TDL `value ... extends Parent` shorthand from explicit parent TypeKinds.
+///
+/// The propagation is computed from descriptor data and may span several files or inheritance
+/// steps. Root value families whose syntax does not identify a concrete kind must author the
+/// `instance_type_kind` property explicitly.
+fn derive_tdl_type_kind_defaults(
+    model: &SemanticModel,
+    symbols: &SymbolIndex,
+) -> HashMap<String, String> {
+    let descriptors_by_key = model
+        .descriptors
+        .iter()
+        .map(|descriptor| (descriptor.key.as_str(), descriptor))
+        .collect::<HashMap<_, _>>();
+    let mut effective = model
+        .descriptors
+        .iter()
+        .filter_map(|descriptor| {
+            descriptor
+                .instance_type_kind
+                .as_ref()
+                .map(|kind| (descriptor.key.clone(), kind.clone()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    loop {
+        let mut changed = false;
+        for descriptor in &model.descriptors {
+            if descriptor.kind != DescriptorKind::ValueType
+                || descriptor.instance_type_kind.is_some()
+                || effective.contains_key(&descriptor.key)
+            {
+                continue;
+            }
+            let Some(parent) = descriptor.extends.as_ref() else {
+                continue;
+            };
+            let Some(parent_symbol) = parent
+                .resolved
+                .and_then(|symbol_id| symbols.lookup_by_id(symbol_id))
+                .or_else(|| symbols.lookup_by_key(&parent.target))
+            else {
+                continue;
+            };
+            if !descriptors_by_key.contains_key(parent_symbol.key.as_str()) {
+                continue;
+            }
+            let Some(parent_kind) = effective.get(&parent_symbol.key).cloned() else {
+                continue;
+            };
+            effective.insert(descriptor.key.clone(), parent_kind);
+            changed = true;
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    effective
+        .into_iter()
+        .filter(|(key, _)| {
+            descriptors_by_key.get(key.as_str()).is_some_and(|descriptor| {
+                descriptor.kind == DescriptorKind::ValueType
+                    && descriptor.instance_type_kind.is_none()
+            })
+        })
+        .collect()
+}
+
+fn apply_tdl_type_kind_defaults(model: &mut SemanticModel, defaults: &HashMap<String, String>) {
+    for descriptor in &mut model.descriptors {
+        if descriptor.instance_type_kind.is_none() {
+            descriptor.instance_type_kind = defaults.get(&descriptor.key).cloned();
+        }
+    }
+}
+
+/// Expands TDL's one-sided inverse shorthand into explicit canonical pair metadata.
+fn expand_tdl_relationship_pairs(model: &mut SemanticModel, symbols: &SymbolIndex) {
+    let descriptor_indexes = model
+        .descriptors
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| (descriptor.key.clone(), index))
+        .collect::<HashMap<_, _>>();
+
+    for index in 0..model.descriptors.len() {
+        if model.descriptors[index].kind != DescriptorKind::RelationshipType {
+            continue;
+        }
+
+        let current_key = model.descriptors[index].key.clone();
+        let current_symbol_id = symbols.lookup_by_key(&current_key).map(|symbol| symbol.id);
+        if let Some(has_inverse) = model.descriptors[index].has_inverse.clone() {
+            if let Some(target_symbol) = has_inverse
+                .resolved
+                .and_then(|symbol_id| symbols.lookup_by_id(symbol_id))
+                .or_else(|| symbols.lookup_by_key(&has_inverse.target))
+            {
+                if let Some(target_index) = descriptor_indexes.get(&target_symbol.key).copied() {
+                    if model.descriptors[target_index].inverse_of.is_none() {
+                        model.descriptors[target_index].inverse_of = Some(SemanticReference {
+                            role: ReferenceRole::InverseOf,
+                            target: current_key.clone(),
+                            resolved: current_symbol_id,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(inverse_of) = model.descriptors[index].inverse_of.clone() {
+            if let Some(target_symbol) = inverse_of
+                .resolved
+                .and_then(|symbol_id| symbols.lookup_by_id(symbol_id))
+                .or_else(|| symbols.lookup_by_key(&inverse_of.target))
+            {
+                if let Some(target_index) = descriptor_indexes.get(&target_symbol.key).copied() {
+                    if model.descriptors[target_index].has_inverse.is_none() {
+                        model.descriptors[target_index].has_inverse = Some(SemanticReference {
+                            role: ReferenceRole::HasInverse,
+                            target: current_key.clone(),
+                            resolved: current_symbol_id,
+                        });
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Resolves TDL's omitted-Boolean convention through effective property descriptors.
@@ -1766,14 +1901,7 @@ fn tdl_instance_type_kind(descriptor: &TdlDescriptor) -> Option<String> {
         DescriptorKind::RelationshipType => "TypeKind.Relationship",
         DescriptorKind::Enum => "TypeKind.Value.Enum",
         DescriptorKind::EnumVariant => "TypeKind.EnumVariant",
-        DescriptorKind::ValueType => match descriptor.extends.as_deref() {
-            Some("StringValueType") | Some("MapStringValueType") => "TypeKind.Value.String",
-            Some("IntegerValueType") | Some("MapIntegerValueType") => "TypeKind.Value.Integer",
-            Some("BooleanValueType") | Some("MapBooleanValueType") => "TypeKind.Value.Boolean",
-            Some("BytesValueType") | Some("MapBytesValueType") => "TypeKind.Value.Bytes",
-            Some("ValueArrayValueType") | Some("MapValueArrayType") => "TypeKind.Value.Array",
-            _ => return None,
-        },
+        DescriptorKind::ValueType => return None,
         DescriptorKind::Schema => return None,
     };
     Some(value.to_string())
@@ -2172,6 +2300,40 @@ mod tests {
             )),
             "{diagnostics:#?}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn tdl_materializes_parent_derived_value_kinds_and_inverse_pairs() -> Result<()> {
+        let lowered = lower_inputs_to_schema_ir(&[fixture_dir()])?;
+
+        for (key, expected_kind) in [
+            ("MapBytesValueType", "TypeKind.Value.Bytes"),
+            ("HolonIdValueType", "TypeKind.Value.Bytes"),
+            ("MapValueArrayType", "TypeKind.Value.Array"),
+        ] {
+            let descriptor = lowered
+                .global_model
+                .descriptors
+                .iter()
+                .find(|descriptor| descriptor.key == key)
+                .unwrap_or_else(|| panic!("missing descriptor `{key}`"));
+            assert_eq!(descriptor.instance_type_kind.as_deref(), Some(expected_kind));
+        }
+
+        let inverse = lowered
+            .global_model
+            .descriptors
+            .iter()
+            .find(|descriptor| {
+                descriptor.key == "(Schema.HolonType)-[Components]->(TypeDescriptor.HolonType)"
+            })
+            .expect("Components inverse descriptor");
+        assert_eq!(
+            inverse.inverse_of.as_ref().map(|reference| reference.target.as_str()),
+            Some("(TypeDescriptor.HolonType)-[ComponentOf]->(Schema.HolonType)")
+        );
+
         Ok(())
     }
 

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -1477,6 +1477,10 @@ fn lower_file_to_schema_ir(file: &ParsedTdlFile) -> Result<SemanticModel> {
         name: file.schema.name.clone(),
         key: file.schema.name.clone(),
         origin: file.schema.origin.clone(),
+        described_by: vec![SemanticReference::unresolved(
+            ReferenceRole::DescribedBy,
+            "Schema.HolonType",
+        )],
         dependencies: file
             .schema
             .dependencies
@@ -1517,6 +1521,10 @@ fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<Typ
         descriptor.origin.clone(),
     );
     lowered.header = descriptor.header.clone();
+    lowered.described_by.push(SemanticReference::unresolved(
+        ReferenceRole::DescribedBy,
+        "TypeDescriptor.HolonType",
+    ));
     lowered.is_abstract = descriptor.is_abstract;
     lowered.literal_properties = descriptor.literal_properties.clone();
     lowered.literal_relationships = descriptor.literal_relationships.clone();

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -12,7 +12,7 @@ use crate::{
     loader_ir::{LoaderDocument, LoaderMeta},
     schema_index::SymbolIndex,
     schema_ir::{
-        DescriptorHeader, DescriptorKind, LiteralRelationship, Origin, ReferenceRole,
+        DescriptorHeader, DescriptorKind, LiteralRelationship, LiteralValue, Origin, ReferenceRole,
         RelationshipFlavor, Schema, SemanticModel, SemanticReference, SourceKind, TypeDescriptor,
     },
     schema_to_loader_ir::{
@@ -21,10 +21,12 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use map_schema_semantic::{
-    normalize_relationship_pairs, normalize_validation_model, validate_model,
+    effective_boolean_property_names, normalize_relationship_pairs, validate_model,
+    CanonicalDescriptorGraph,
 };
 use map_schema_semantic::{DiagnosticKind, DiagnosticLayer};
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -71,6 +73,7 @@ struct TdlDescriptor {
     origin: Origin,
     header: Option<DescriptorHeader>,
     is_abstract: bool,
+    property_required: Option<bool>,
     relationship_flavor: Option<RelationshipFlavor>,
     extends: Option<String>,
     value_type: Option<String>,
@@ -581,6 +584,7 @@ impl<'a> Parser<'a> {
             },
             header: None,
             is_abstract: parsed.is_abstract,
+            property_required: parsed.property_required,
             relationship_flavor: parsed.relationship_flavor,
             extends: parsed.extends,
             value_type: None,
@@ -771,6 +775,7 @@ impl<'a> Parser<'a> {
             },
             header: None,
             is_abstract: parsed.is_abstract,
+            property_required: parsed.property_required,
             relationship_flavor: parsed.relationship_flavor,
             extends: parsed.extends,
             value_type: None,
@@ -1015,6 +1020,7 @@ struct ParsedHead {
     kind: DescriptorKind,
     name: String,
     is_abstract: bool,
+    property_required: Option<bool>,
     is_definitional: bool,
     relationship_flavor: Option<RelationshipFlavor>,
     extends: Option<String>,
@@ -1110,7 +1116,17 @@ fn parse_descriptor_header(line: &str, origin: Origin) -> ParseResult<ParsedHead
             origin,
         });
     }
-    let name = after_kind.trim_end_matches('{').trim().to_string();
+    let authored_name = after_kind.trim_end_matches('{').trim();
+    let property_required = if kind == DescriptorKind::PropertyType {
+        Some(!authored_name.ends_with('?'))
+    } else {
+        None
+    };
+    let name = if property_required == Some(false) {
+        authored_name.trim_end_matches('?').to_string()
+    } else {
+        authored_name.to_string()
+    };
     if kind == DescriptorKind::RelationshipType {
         if let Some((_, remainder)) = name.split_once(" extends ") {
             extends = Some(remainder.trim().to_string());
@@ -1131,6 +1147,7 @@ fn parse_descriptor_header(line: &str, origin: Origin) -> ParseResult<ParsedHead
         kind,
         name,
         is_abstract,
+        property_required,
         is_definitional,
         relationship_flavor,
         extends,
@@ -1416,8 +1433,12 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<Lowered
     }
 
     let (symbols, mut diagnostics) = SymbolIndex::build(&mut global_model);
+    let boolean_defaults = derive_tdl_boolean_defaults(&global_model, &symbols);
+    apply_tdl_boolean_defaults(&mut global_model, &boolean_defaults);
+    for file in &mut files {
+        apply_tdl_boolean_defaults(&mut file.schema_model, &boolean_defaults);
+    }
     let mut validation_model = global_model.clone();
-    normalize_validation_model(&mut validation_model);
     normalize_relationship_pairs(&mut validation_model, &symbols);
     diagnostics.extend(validate_model(&validation_model, &symbols));
     for file in &mut files {
@@ -1425,6 +1446,63 @@ fn lower_parsed_files_to_schema_ir(parsed: Vec<ParsedTdlFile>) -> Result<Lowered
     }
 
     Ok(LoweredTdlProject { files, global_model, symbols, diagnostics })
+}
+
+/// Resolves TDL's omitted-Boolean convention through effective property descriptors.
+///
+/// The adapter decides that omission means `false`; the shared descriptor graph decides which
+/// Boolean properties are actually applicable to each holon.
+fn derive_tdl_boolean_defaults(
+    model: &SemanticModel,
+    symbols: &SymbolIndex,
+) -> HashMap<String, Vec<String>> {
+    let Ok(graph) = CanonicalDescriptorGraph::new(model, symbols) else {
+        return HashMap::new();
+    };
+    let mut defaults = HashMap::new();
+    for descriptor in &model.descriptors {
+        let Some(node) = graph.node_by_key(&descriptor.key) else {
+            continue;
+        };
+        let Some(holon) = graph.holon(node) else {
+            continue;
+        };
+        let Ok(boolean_properties) = effective_boolean_property_names(&graph, node) else {
+            continue;
+        };
+        let missing = boolean_properties
+            .into_iter()
+            .filter(|property| {
+                !holon.properties.iter().any(|(name, _)| {
+                    normalized_property_name(name) == normalized_property_name(property)
+                })
+            })
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            defaults.insert(descriptor.key.clone(), missing);
+        }
+    }
+    defaults
+}
+
+fn apply_tdl_boolean_defaults(model: &mut SemanticModel, defaults: &HashMap<String, Vec<String>>) {
+    for descriptor in &mut model.descriptors {
+        let Some(properties) = defaults.get(&descriptor.key) else {
+            continue;
+        };
+        for property in properties {
+            descriptor
+                .materialized_properties
+                .insert(property.clone(), LiteralValue::Boolean(false));
+        }
+    }
+}
+
+fn normalized_property_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 /// Projects validated semantic models into loader documents without reinterpreting TDL syntax.
@@ -1526,12 +1604,26 @@ fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<Typ
         "TypeDescriptor.HolonType",
     ));
     lowered.is_abstract = descriptor.is_abstract;
+    lowered.instance_type_kind = descriptor
+        .literal_properties
+        .get("instance_type_kind")
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+        .or_else(|| tdl_instance_type_kind(descriptor));
+    lowered.property_required = descriptor.property_required;
     lowered.literal_properties = descriptor.literal_properties.clone();
     lowered.literal_relationships = descriptor.literal_relationships.clone();
     lowered.is_definitional = descriptor.is_definitional;
-    lowered.min_cardinality = descriptor.min_cardinality;
-    lowered.max_cardinality = descriptor.max_cardinality;
-    lowered.deletion_semantic = descriptor.deletion_semantic.clone();
+    if descriptor.kind == DescriptorKind::RelationshipType {
+        lowered.min_cardinality = Some(descriptor.min_cardinality.unwrap_or(0));
+        lowered.max_cardinality = Some(descriptor.max_cardinality.unwrap_or(32_767));
+        lowered.deletion_semantic =
+            Some(descriptor.deletion_semantic.clone().unwrap_or_else(|| "Allow".to_string()));
+    } else {
+        lowered.min_cardinality = descriptor.min_cardinality;
+        lowered.max_cardinality = descriptor.max_cardinality;
+        lowered.deletion_semantic = descriptor.deletion_semantic.clone();
+    }
     lowered.is_ordered = descriptor.is_ordered;
     lowered.allows_duplicates = descriptor.allows_duplicates;
     lowered.allows_additional_properties = descriptor.allows_additional_properties;
@@ -1661,6 +1753,30 @@ fn lower_descriptor(descriptor: &TdlDescriptor, schema_name: &str) -> Result<Typ
     }
 
     Ok(lowered)
+}
+
+/// Lowers TDL declaration keywords into the explicit TypeKind value emitted by the adapter.
+///
+/// This is syntax desugaring, not validation: descriptor conformance subsequently validates the
+/// resulting enum value through `TypeKind.PropertyType` and its resolved enum descriptor.
+fn tdl_instance_type_kind(descriptor: &TdlDescriptor) -> Option<String> {
+    let value = match descriptor.kind {
+        DescriptorKind::TypeDescriptor | DescriptorKind::HolonType => "TypeKind.Holon",
+        DescriptorKind::PropertyType => "TypeKind.Property",
+        DescriptorKind::RelationshipType => "TypeKind.Relationship",
+        DescriptorKind::Enum => "TypeKind.Value.Enum",
+        DescriptorKind::EnumVariant => "TypeKind.EnumVariant",
+        DescriptorKind::ValueType => match descriptor.extends.as_deref() {
+            Some("StringValueType") | Some("MapStringValueType") => "TypeKind.Value.String",
+            Some("IntegerValueType") | Some("MapIntegerValueType") => "TypeKind.Value.Integer",
+            Some("BooleanValueType") | Some("MapBooleanValueType") => "TypeKind.Value.Boolean",
+            Some("BytesValueType") | Some("MapBytesValueType") => "TypeKind.Value.Bytes",
+            Some("ValueArrayValueType") | Some("MapValueArrayType") => "TypeKind.Value.Array",
+            _ => return None,
+        },
+        DescriptorKind::Schema => return None,
+    };
+    Some(value.to_string())
 }
 
 fn reference_role_for_relationship_name(name: &str) -> Option<ReferenceRole> {
@@ -1923,7 +2039,139 @@ mod tests {
     #[test]
     fn checks_core_schema_corpus_without_diagnostics() -> Result<()> {
         let diagnostics = check_inputs(&[fixture_dir()])?;
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.is_empty(), "{}", format_diagnostics(&diagnostics));
+        Ok(())
+    }
+
+    #[test]
+    fn descriptor_value_conformance_accepts_core_schema_corpus() -> Result<()> {
+        let lowered = lower_inputs_to_schema_ir(&[fixture_dir()])?;
+        let graph = map_schema_semantic::CanonicalDescriptorGraph::new(
+            &lowered.global_model,
+            &lowered.symbols,
+        )
+        .expect("canonical descriptor graph");
+        let diagnostics = map_schema_semantic::validate_canonical_model_values(&graph);
+        assert!(diagnostics.is_empty(), "{} descriptor-value diagnostics", diagnostics.len());
+        Ok(())
+    }
+
+    #[test]
+    fn omitted_tdl_booleans_materialize_false_from_effective_descriptors() -> Result<()> {
+        let lowered = lower_inputs_to_schema_ir(&[fixture_dir()])?;
+        let graph = map_schema_semantic::CanonicalDescriptorGraph::new(
+            &lowered.global_model,
+            &lowered.symbols,
+        )
+        .expect("canonical descriptor graph");
+        map_schema_semantic::effective_boolean_property_names(
+            &graph,
+            graph.node_by_key("PropertyType").expect("PropertyType node"),
+        )
+        .expect("PropertyType Boolean declarations should resolve");
+        let expected = [
+            ("PropertyType", &["IsRequired"][..]),
+            (
+                "Book.HolonType",
+                &["AllowsAdditionalProperties", "AllowsAdditionalRelationships"][..],
+            ),
+            ("MetaValueType", &["AllowsAdditionalProperties", "AllowsAdditionalRelationships"][..]),
+            ("DeclaredRelationshipType", &["IsDefinitional", "IsOrdered", "AllowsDuplicates"][..]),
+            ("InverseRelationshipType", &["IsDefinitional", "IsOrdered", "AllowsDuplicates"][..]),
+            (
+                "MetaDeclaredRelationshipType",
+                &["IsDefinitional", "IsOrdered", "AllowsDuplicates"][..],
+            ),
+            (
+                "MetaInverseRelationshipType",
+                &["IsDefinitional", "IsOrdered", "AllowsDuplicates"][..],
+            ),
+        ];
+
+        for (key, properties) in expected {
+            let descriptor = lowered
+                .global_model
+                .descriptors
+                .iter()
+                .find(|descriptor| descriptor.key == key)
+                .unwrap_or_else(|| panic!("missing descriptor `{key}`"));
+            for property in properties {
+                assert_eq!(
+                    descriptor
+                        .materialized_properties
+                        .get(property)
+                        .and_then(LiteralValue::as_bool),
+                    Some(false),
+                    "`{key}.{property}` should materialize TDL omission as false"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn omitted_tdl_booleans_satisfy_required_property_conformance() -> Result<()> {
+        let lowered = lower_inputs_to_schema_ir(&[fixture_dir()])?;
+        let graph = map_schema_semantic::CanonicalDescriptorGraph::new(
+            &lowered.global_model,
+            &lowered.symbols,
+        )
+        .expect("canonical descriptor graph");
+        let diagnostics = map_schema_semantic::validate_canonical_model_conformance(&graph);
+        let defaulted_boolean_properties = [
+            "IsRequired",
+            "IsDefinitional",
+            "IsOrdered",
+            "AllowsDuplicates",
+            "AllowsAdditionalProperties",
+            "AllowsAdditionalRelationships",
+        ];
+        assert!(!diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            DiagnosticKind::MissingConformanceProperty { property, .. }
+                if defaulted_boolean_properties.contains(&property.as_str())
+        )));
+        assert!(!diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            DiagnosticKind::AdditionalConformanceProperty { property, .. }
+                if matches!(
+                    property.as_str(),
+                    "AllowsAdditionalProperties" | "AllowsAdditionalRelationships"
+                )
+        )));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_type_kind_is_rejected_by_descriptor_enum_policy() -> Result<()> {
+        let mut lowered = lower_inputs_to_schema_ir(&[fixture_dir()])?;
+        let descriptor = lowered
+            .global_model
+            .descriptors
+            .iter_mut()
+            .find(|descriptor| descriptor.key == "Book.HolonType")
+            .expect("book descriptor");
+        descriptor.instance_type_kind = Some("TypeKind.HolonFoo".to_string());
+        let graph = map_schema_semantic::CanonicalDescriptorGraph::new(
+            &lowered.global_model,
+            &lowered.symbols,
+        )
+        .expect("canonical descriptor graph");
+        let diagnostics = map_schema_semantic::validate_canonical_holon_conformance(
+            &graph,
+            graph.node_by_key("Book.HolonType").expect("book node"),
+        );
+        assert!(
+            diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                DiagnosticKind::InvalidConformanceValue { holon, property, value, .. }
+                    if holon == "Book.HolonType"
+                        && property == "TypeKind"
+                        && value == "TypeKind.HolonFoo"
+            )),
+            "{diagnostics:#?}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
# Summary

Implements TDL R4 semantic validation and adds Canonical Holon IR semantic diff support in `map-schema`.

This PR introduces layered semantic diagnostics over the shared schema IR, moves schema-authoring validation out of the symbol-index layer into a dedicated validator, and adds a new semantic diff workflow that compares fully lowered Canonical Holon IR models instead of source text or emitted JSON shape.

## Changes

- Add layered diagnostics in `map_schema_semantic` so findings are classified by validation responsibility, including:
  - syntax
  - IR structural
  - descriptor kind
  - reference symbol
  - schema-aware
  - semantic fidelity
  - runtime loader boundary
- Extend diagnostic kinds to cover the R4 validation surface, including:
  - duplicate local members
  - projected `TypeKind` mismatches
  - extends incompatibility and cycles
  - invalid cardinality bounds
  - inverse relationship completeness and mismatch cases
  - effective key-rule failures and authored-key mismatches
- Add a shared validator module that performs source-neutral Canonical Holon IR validation after lowering and reference resolution
- Narrow `SymbolIndex` responsibilities so it handles symbol construction, reference resolution, duplicate symbol detection, unresolved references, and role/kind compatibility, while leaving schema-aware validation to the validator layer
- Add validation-only normalization for relationship defaults and inverse-pair synthesis so validation can reason over effective semantics without mutating emitted or decompiled artifacts
- Wire validation into both lowering paths:
  - JSON import lowering
  - TDL lowering
- Add `map-schema diff` to compare two schema corpora by Canonical Holon IR semantics
- Require both sides of semantic diff to lower without blocking diagnostics before producing a diff
- Add coverage for:
  - core-schema validation remaining diagnostic-free
  - semantic fidelity across JSON and decompiled TDL
  - changed semantic fields being surfaced by diff
  - invalid diff inputs reporting diagnostics instead of partial comparison
- Fix bootstrap anchor lowering so `TypeDescriptor` compares consistently across JSON and TDL representations

## Why

Issue 578 needed the schema-authoring environment to validate TDL at least as strongly as the current Airtable-backed flow while keeping Canonical Holon IR semantics source-neutral.

This PR establishes that split cleanly:
- source adapters own parsing and source-format conveniences
- Canonical Holon IR owns semantic validation
- semantic comparison works over valid lowered models rather than textual or formatting differences

## Testing

- [x] `cargo test --manifest-path shared_crates/map_schema_semantic/Cargo.toml`
- [x] `cargo test --manifest-path tools/map-schema/Cargo.toml`
- [x] User-verified broader workspace health:
  - `npm clean`
  - hApp build
  - host build
  - `npm` tests
  - `npm start`

## Notes

- Validation-only normalization is intentionally kept out of emitted JSON and decompiled TDL so artifact shape remains faithful to authored/imported content.
- Semantic diff currently requires diagnostic-free lowering on both sides. Partial diff over invalid inputs remains deferred.
- General inheritance flattening remains deferred for Issue 578, except for the narrow effective-key behavior already agreed as in scope.