### PR TITLE
600 pvl pr 2 holonnode envelope validation vertical slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,11 +3466,13 @@ dependencies = [
 name = "holons_guest_integrity"
 version = "0.1.0"
 dependencies = [
+ "base_types",
  "derive-new",
  "hdi",
  "holochain_serialized_bytes",
  "integrity_core_types",
  "serde",
+ "shared_validation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,6 +3480,7 @@ name = "holons_integrity"
 version = "0.0.1"
 dependencies = [
  "hdi",
+ "holochain_serialized_bytes",
  "holons_guest_integrity",
  "integrity_core_types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,6 +3533,7 @@ dependencies = [
  "digest 0.11.0-rc.3",
  "ed25519 3.0.0-rc.0",
  "holochain",
+ "holochain_state",
  "holon_dance_builders",
  "holons_boundary",
  "holons_client",

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -744,6 +744,7 @@ name = "holons_integrity"
 version = "0.0.1"
 dependencies = [
  "hdi",
+ "holochain_serialized_bytes",
  "holons_guest_integrity",
  "integrity_core_types",
  "serde",

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -730,11 +730,13 @@ dependencies = [
 name = "holons_guest_integrity"
 version = "0.1.0"
 dependencies = [
+ "base_types",
  "derive-new",
  "hdi",
  "holochain_serialized_bytes",
  "integrity_core_types",
  "serde",
+ "shared_validation",
 ]
 
 [[package]]

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -411,6 +411,9 @@ fn commit_holon(
                 let predecessor_id = staged_holon.get_versioned_source_id()?;
                 staged_holon.prepare_full_relationship_commit_scope()?;
                 let node = staged_holon.into_node_model();
+                // Storage SL2 will replace this Create with a native update targeting the
+                // lineage-root Create, remove original_id from the persisted entry shape, and
+                // require the HolonNode serialization-parity fixtures to be revisited.
                 let record = create_holon_node(HolonNode::from(node))
                     .map_err(holon_error_from_wasm_error)?;
                 let new_local_id = LocalId(record.action_address().clone().into_inner());

--- a/happ/crates/holons_guest_integrity/Cargo.toml
+++ b/happ/crates/holons_guest_integrity/Cargo.toml
@@ -24,3 +24,9 @@ holochain_serialized_bytes = "*"
 
 [dependencies.integrity_core_types]
 path = "../../../shared_crates/type_system/integrity_core_types"
+
+[dependencies.shared_validation]
+path = "../../../shared_crates/shared_validation"
+
+[dev-dependencies.base_types]
+path = "../../../shared_crates/type_system/base_types"

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -1,0 +1,299 @@
+//! Holochain adapter for descriptor-independent HolonNode envelope validation.
+
+use hdi::prelude::*;
+use holochain_serialized_bytes::{decode, encode};
+use integrity_core_types::{HolonNodeModel, PvlMalformedReason, PvlViolation};
+use shared_validation::{validate_holon_node_decoded, validate_holon_node_size};
+
+use crate::HolonNode;
+
+const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
+
+/// Result of preparing the HolonNode envelope carried by an operation.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HolonNodeEnvelope {
+    /// The operation does not carry a HolonNode app entry.
+    NotApplicable,
+    /// The entry passed all envelope rules and is ready for lifecycle validation.
+    Valid(HolonNodeModel),
+    /// The entry failed a deterministic PVL envelope rule.
+    Invalid(PvlViolation),
+}
+
+/// Extracts and validates a HolonNode entry before flattened-op decoding.
+pub fn prepare_holon_node_envelope(op: &Op) -> ExternResult<HolonNodeEnvelope> {
+    let Some(raw) = holon_node_entry_bytes(op) else {
+        return Ok(HolonNodeEnvelope::NotApplicable);
+    };
+
+    Ok(match run_holon_node_envelope(raw)? {
+        Ok(model) => HolonNodeEnvelope::Valid(model),
+        Err(violation) => HolonNodeEnvelope::Invalid(violation),
+    })
+}
+
+/// Locates the stored inner app-entry payload without decoding it.
+fn holon_node_entry_bytes(op: &Op) -> Option<&[u8]> {
+    let (entry_type, entry) = match op {
+        Op::StoreEntry(store_entry) => (store_entry.action.hashed.entry_type(), &store_entry.entry),
+        Op::StoreRecord(store_record) => {
+            (store_record.record.action().entry_type()?, store_record.record.entry().as_option()?)
+        }
+        Op::RegisterUpdate(register_update) => {
+            (&register_update.update.hashed.entry_type, register_update.new_entry.as_ref()?)
+        }
+        _ => return None,
+    };
+
+    // HolonNode is the sole app entry in this integrity zome and therefore entry-def index 0.
+    // The integrity callback already scopes the zome index; keep this constant aligned if another
+    // app entry is ever added or the declaration order changes.
+    match entry_type {
+        EntryType::App(app_entry_def)
+            if app_entry_def.entry_index == HOLON_NODE_ENTRY_DEF_INDEX => {}
+        _ => return None,
+    }
+
+    Some(entry.as_app_entry()?.as_ref().bytes())
+}
+
+/// Runs the consensus-ordered envelope pipeline against stored inner-entry bytes.
+///
+/// The outer result is reserved for serialization/callback failures. The inner result carries
+/// deterministic PVL violations that the integrity zome maps explicitly to `Invalid`.
+fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, PvlViolation>> {
+    // Rejecting size first bounds work even when the payload is malformed or expensive to decode.
+    if let Err(violation) = validate_holon_node_size(raw.len()) {
+        return Ok(Err(violation));
+    }
+
+    let node: HolonNode = match decode(raw) {
+        Ok(node) => node,
+        Err(_) => {
+            return Ok(Err(PvlViolation::MalformedHolonNode {
+                reason: PvlMalformedReason::DecodeFailed,
+            }))
+        }
+    };
+    let model = HolonNodeModel::from(node);
+
+    // Canonicalize the model rather than the outer EntryTypes enum: Holochain stores these inner
+    // bytes, and comparing at this boundary preserves alternate-encoding evidence lost by decode.
+    let canonical = encode(&model).map_err(|error| wasm_error!(error))?;
+    if let Err(violation) = validate_holon_node_decoded(raw, &canonical, &model) {
+        return Ok(Err(violation));
+    }
+
+    Ok(Ok(model))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use base_types::{BaseValue, MapBoolean, MapBytes, MapEnumValue, MapInteger, MapString};
+    use integrity_core_types::{LocalId, PropertyMap, PropertyName};
+    use serde::ser::{SerializeMap, SerializeStruct};
+    use serde::Serialize;
+    use shared_validation::pvl_limits_v1::{MAX_HOLON_NODE_BYTES, MAX_PROPERTY_COUNT};
+
+    use super::*;
+
+    fn property_name(value: &str) -> PropertyName {
+        PropertyName(MapString(value.to_string()))
+    }
+
+    fn canonical_node(property_map: PropertyMap) -> HolonNode {
+        HolonNode::new(None, property_map)
+    }
+
+    fn run(raw: &[u8]) -> Result<HolonNodeModel, PvlViolation> {
+        run_holon_node_envelope(raw).expect("test values should not fail canonical serialization")
+    }
+
+    #[test]
+    fn model_encoding_matches_guest_inner_entry_encoding() {
+        let empty = HolonNode::new(None, PropertyMap::new());
+        assert_eq!(encode(&empty).unwrap(), encode(&HolonNodeModel::from(empty.clone())).unwrap());
+
+        let properties = BTreeMap::from([
+            (property_name("z-bytes"), BaseValue::BytesValue(MapBytes(vec![1, 2, 3]))),
+            (property_name("a-string"), BaseValue::StringValue(MapString("value".into()))),
+            (property_name("m-bool"), BaseValue::BooleanValue(MapBoolean(true))),
+            (property_name("c-int"), BaseValue::IntegerValue(MapInteger(-42))),
+            (
+                property_name("e-enum"),
+                BaseValue::EnumValue(MapEnumValue(MapString("Active".into()))),
+            ),
+        ]);
+        let representative = HolonNode::new(Some(LocalId(vec![7; 39])), properties);
+
+        assert_eq!(
+            encode(&representative).unwrap(),
+            encode(&HolonNodeModel::from(representative)).unwrap()
+        );
+    }
+
+    #[test]
+    fn stored_app_entry_payload_matches_guest_encoding() {
+        let node = canonical_node(BTreeMap::from([(
+            property_name("name"),
+            BaseValue::StringValue(MapString("stored".into())),
+        )]));
+        let entry = Entry::app(SerializedBytes::try_from(&node).unwrap()).unwrap();
+        let stored =
+            entry.as_app_entry().expect("entry was constructed as an app entry").as_ref().bytes();
+        let encoded = encode(&node).unwrap();
+
+        assert_eq!(stored.as_slice(), encoded.as_slice());
+    }
+
+    #[test]
+    fn accepts_canonical_holon_node_bytes() {
+        let node = canonical_node(BTreeMap::from([(
+            property_name("name"),
+            BaseValue::StringValue(MapString("canonical".into())),
+        )]));
+        let raw = encode(&node).unwrap();
+
+        assert_eq!(run(&raw), Ok(HolonNodeModel::from(node)));
+    }
+
+    #[test]
+    fn maps_decode_failures_to_the_fixed_malformed_reason() {
+        assert_eq!(
+            run(&[0xc1]),
+            Err(PvlViolation::MalformedHolonNode { reason: PvlMalformedReason::DecodeFailed })
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_property_keys_as_non_canonical() {
+        let raw = encode(&NodeWithProperties(DuplicateProperties)).unwrap();
+
+        assert_non_canonical(&raw);
+    }
+
+    #[test]
+    fn rejects_reordered_property_map_as_non_canonical() {
+        let raw = encode(&NodeWithProperties(ReorderedProperties)).unwrap();
+
+        assert_non_canonical(&raw);
+    }
+
+    #[test]
+    fn rejects_non_canonical_integer_width() {
+        let node = canonical_node(BTreeMap::from([(
+            property_name("integer"),
+            BaseValue::IntegerValue(MapInteger(1)),
+        )]));
+        let mut raw = encode(&node).unwrap();
+        assert_eq!(
+            raw.pop(),
+            Some(1),
+            "canonical integer value should be the terminal positive fixint"
+        );
+        raw.extend_from_slice(&[0xd3, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+        assert_non_canonical(&raw);
+    }
+
+    #[test]
+    fn rejects_ignored_extra_field_as_non_canonical() {
+        let raw = encode(&NodeWithExtraField {
+            original_id: None,
+            property_map: PropertyMap::new(),
+            ignored: true,
+        })
+        .unwrap();
+
+        assert_non_canonical(&raw);
+    }
+
+    #[test]
+    fn rejects_oversized_bytes_before_decode() {
+        let raw = vec![0xc1; MAX_HOLON_NODE_BYTES + 1];
+
+        assert_eq!(
+            run(&raw),
+            Err(PvlViolation::HolonNodeTooLarge { actual_bytes: 262_145, max_bytes: 262_144 })
+        );
+    }
+
+    #[test]
+    fn rejects_more_than_the_property_limit() {
+        let properties = (0..=MAX_PROPERTY_COUNT)
+            .map(|index| {
+                (
+                    property_name(&format!("property-{index:03}")),
+                    BaseValue::BooleanValue(MapBoolean(true)),
+                )
+            })
+            .collect();
+        let raw = encode(&canonical_node(properties)).unwrap();
+
+        assert_eq!(
+            run(&raw),
+            Err(PvlViolation::TooManyProperties { actual_count: 257, max_count: 256 })
+        );
+    }
+
+    fn assert_non_canonical(raw: &[u8]) {
+        assert_eq!(
+            run(raw),
+            Err(PvlViolation::MalformedHolonNode {
+                reason: PvlMalformedReason::NonCanonicalEncoding,
+            })
+        );
+    }
+
+    #[derive(Debug)]
+    struct NodeWithProperties<T>(T);
+
+    impl<T: Serialize> Serialize for NodeWithProperties<T> {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut node = serializer.serialize_struct("HolonNode", 2)?;
+            node.serialize_field("original_id", &Option::<LocalId>::None)?;
+            node.serialize_field("property_map", &self.0)?;
+            node.end()
+        }
+    }
+
+    #[derive(Debug)]
+    struct DuplicateProperties;
+
+    impl Serialize for DuplicateProperties {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut map = serializer.serialize_map(Some(2))?;
+            let key = property_name("duplicate");
+            map.serialize_entry(&key, &BaseValue::BooleanValue(MapBoolean(false)))?;
+            map.serialize_entry(&key, &BaseValue::BooleanValue(MapBoolean(true)))?;
+            map.end()
+        }
+    }
+
+    #[derive(Debug)]
+    struct ReorderedProperties;
+
+    impl Serialize for ReorderedProperties {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut map = serializer.serialize_map(Some(2))?;
+            map.serialize_entry(
+                &property_name("z-last"),
+                &BaseValue::BooleanValue(MapBoolean(true)),
+            )?;
+            map.serialize_entry(
+                &property_name("a-first"),
+                &BaseValue::BooleanValue(MapBoolean(false)),
+            )?;
+            map.end()
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct NodeWithExtraField {
+        original_id: Option<LocalId>,
+        property_map: PropertyMap,
+        ignored: bool,
+    }
+}

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -92,6 +92,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use base_types::{BaseValue, MapBoolean, MapBytes, MapEnumValue, MapInteger, MapString};
+    use holochain_serialized_bytes::UnsafeBytes;
     use integrity_core_types::{LocalId, PropertyMap, PropertyName};
     use serde::ser::{SerializeMap, SerializeStruct};
     use serde::Serialize;
@@ -109,6 +110,189 @@ mod tests {
 
     fn run(raw: &[u8]) -> Result<HolonNodeModel, PvlViolation> {
         run_holon_node_envelope(raw).expect("test values should not fail canonical serialization")
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum HolonNodeOpForm {
+        StoreEntryCreate,
+        StoreEntryUpdate,
+        RegisterUpdate,
+        StoreRecordCreate,
+        StoreRecordUpdate,
+    }
+
+    const HOLON_NODE_OP_FORMS: [HolonNodeOpForm; 5] = [
+        HolonNodeOpForm::StoreEntryCreate,
+        HolonNodeOpForm::StoreEntryUpdate,
+        HolonNodeOpForm::RegisterUpdate,
+        HolonNodeOpForm::StoreRecordCreate,
+        HolonNodeOpForm::StoreRecordUpdate,
+    ];
+
+    fn app_entry(raw: Vec<u8>) -> Entry {
+        Entry::App(AppEntryBytes(SerializedBytes::from(UnsafeBytes::from(raw))))
+    }
+
+    fn app_entry_type() -> EntryType {
+        EntryType::App(AppEntryDef::new(
+            HOLON_NODE_ENTRY_DEF_INDEX,
+            ZomeIndex(0),
+            EntryVisibility::Public,
+        ))
+    }
+
+    fn create_action() -> Create {
+        Create {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(1),
+            action_seq: 1,
+            prev_action: ActionHash::from_raw_36(vec![1; 36]),
+            entry_type: app_entry_type(),
+            entry_hash: EntryHash::from_raw_36(vec![2; 36]),
+            weight: EntryRateWeight::default(),
+        }
+    }
+
+    fn update_action() -> Update {
+        Update {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(2),
+            action_seq: 2,
+            prev_action: ActionHash::from_raw_36(vec![3; 36]),
+            original_action_address: ActionHash::from_raw_36(vec![4; 36]),
+            original_entry_address: EntryHash::from_raw_36(vec![5; 36]),
+            entry_type: app_entry_type(),
+            entry_hash: EntryHash::from_raw_36(vec![6; 36]),
+            weight: EntryRateWeight::default(),
+        }
+    }
+
+    fn signed_entry_creation_action(
+        action: EntryCreationAction,
+    ) -> SignedHashed<EntryCreationAction> {
+        SignedHashed::with_presigned(
+            HoloHashed::with_pre_hashed(action, ActionHash::from_raw_36(vec![7; 36])),
+            Signature([0; SIGNATURE_BYTES]),
+        )
+    }
+
+    fn signed_update(update: Update) -> SignedHashed<Update> {
+        SignedHashed::with_presigned(
+            HoloHashed::with_pre_hashed(update, ActionHash::from_raw_36(vec![8; 36])),
+            Signature([0; SIGNATURE_BYTES]),
+        )
+    }
+
+    fn signed_action(action: Action) -> SignedActionHashed {
+        SignedHashed::with_presigned(
+            HoloHashed::with_pre_hashed(action, ActionHash::from_raw_36(vec![9; 36])),
+            Signature([0; SIGNATURE_BYTES]),
+        )
+    }
+
+    fn op_with_raw_entry(form: HolonNodeOpForm, raw: Vec<u8>) -> Op {
+        let entry = app_entry(raw);
+
+        match form {
+            HolonNodeOpForm::StoreEntryCreate => Op::StoreEntry(StoreEntry {
+                action: signed_entry_creation_action(EntryCreationAction::Create(create_action())),
+                entry,
+            }),
+            HolonNodeOpForm::StoreEntryUpdate => Op::StoreEntry(StoreEntry {
+                action: signed_entry_creation_action(EntryCreationAction::Update(update_action())),
+                entry,
+            }),
+            HolonNodeOpForm::RegisterUpdate => Op::RegisterUpdate(RegisterUpdate {
+                update: signed_update(update_action()),
+                new_entry: Some(entry),
+            }),
+            HolonNodeOpForm::StoreRecordCreate => Op::StoreRecord(StoreRecord {
+                record: Record::new(signed_action(Action::Create(create_action())), Some(entry)),
+            }),
+            HolonNodeOpForm::StoreRecordUpdate => Op::StoreRecord(StoreRecord {
+                record: Record::new(signed_action(Action::Update(update_action())), Some(entry)),
+            }),
+        }
+    }
+
+    #[test]
+    fn all_five_op_forms_select_inner_bytes_and_use_the_public_envelope_seam() {
+        for form in HOLON_NODE_OP_FORMS {
+            let node = canonical_node(BTreeMap::from([(
+                property_name("op-form"),
+                BaseValue::StringValue(MapString(format!("{form:?}"))),
+            )]));
+            let expected_model = HolonNodeModel::from(node.clone());
+            let raw = encode(&node).unwrap();
+            let op = op_with_raw_entry(form, raw.clone());
+
+            assert_eq!(
+                holon_node_entry_bytes(&op),
+                Some(raw.as_slice()),
+                "{form:?} selected the wrong inner app-entry bytes"
+            );
+            assert_eq!(
+                prepare_holon_node_envelope(&op).unwrap(),
+                HolonNodeEnvelope::Valid(expected_model),
+                "{form:?} did not complete the shared envelope pipeline"
+            );
+        }
+    }
+
+    #[test]
+    fn all_five_op_forms_reject_oversized_payloads_before_later_processing() {
+        let expected = HolonNodeEnvelope::Invalid(PvlViolation::HolonNodeTooLarge {
+            actual_bytes: 262_145,
+            max_bytes: 262_144,
+        });
+
+        for form in HOLON_NODE_OP_FORMS {
+            let raw = vec![0xc1; MAX_HOLON_NODE_BYTES + 1];
+            let op = op_with_raw_entry(form, raw);
+
+            // In particular, StoreRecordUpdate carries an arbitrary original-action address.
+            // Preparation must reject its current entry without attempting dependency resolution.
+            assert_eq!(
+                prepare_holon_node_envelope(&op).unwrap(),
+                expected,
+                "{form:?} did not apply the raw-size rule through the public seam"
+            );
+        }
+    }
+
+    #[test]
+    fn non_holon_node_and_non_entry_ops_are_not_applicable() {
+        let mut other_entry_create = create_action();
+        other_entry_create.entry_type = EntryType::App(AppEntryDef::new(
+            EntryDefIndex(1),
+            ZomeIndex(0),
+            EntryVisibility::Public,
+        ));
+        let other_entry_op = Op::StoreEntry(StoreEntry {
+            action: signed_entry_creation_action(EntryCreationAction::Create(other_entry_create)),
+            entry: app_entry(vec![0xc1]),
+        });
+
+        let delete = Delete {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(3),
+            action_seq: 3,
+            prev_action: ActionHash::from_raw_36(vec![10; 36]),
+            deletes_address: ActionHash::from_raw_36(vec![11; 36]),
+            deletes_entry_address: EntryHash::from_raw_36(vec![12; 36]),
+            weight: RateWeight::default(),
+        };
+        let non_entry_op = Op::RegisterDelete(RegisterDelete {
+            delete: SignedHashed::with_presigned(
+                HoloHashed::with_pre_hashed(delete, ActionHash::from_raw_36(vec![13; 36])),
+                Signature([0; SIGNATURE_BYTES]),
+            ),
+        });
+
+        for op in [other_entry_op, non_entry_op] {
+            assert_eq!(holon_node_entry_bytes(&op), None);
+            assert_eq!(prepare_holon_node_envelope(&op).unwrap(), HolonNodeEnvelope::NotApplicable);
+        }
     }
 
     #[test]

--- a/happ/crates/holons_guest_integrity/src/lib.rs
+++ b/happ/crates/holons_guest_integrity/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod holon_node;
+pub mod holon_node_envelope;
 pub mod type_conversions;
 
 pub use holon_node::{
     HolonNode, LOCAL_HOLON_SPACE_DESCRIPTION, LOCAL_HOLON_SPACE_NAME, LOCAL_HOLON_SPACE_PATH,
 };
+pub use holon_node_envelope::{prepare_holon_node_envelope, HolonNodeEnvelope};
 
 pub use type_conversions::*;

--- a/happ/zomes/integrity/holons_integrity/Cargo.toml
+++ b/happ/zomes/integrity/holons_integrity/Cargo.toml
@@ -28,3 +28,6 @@ path = "../../../../shared_crates/shared_validation"
 
 [dependencies.integrity_core_types]
 path = "../../../../shared_crates/type_system/integrity_core_types"
+
+[dev-dependencies]
+holochain_serialized_bytes = "*"

--- a/happ/zomes/integrity/holons_integrity/src/holon_node.rs
+++ b/happ/zomes/integrity/holons_integrity/src/holon_node.rs
@@ -1,28 +1,6 @@
 use hdi::prelude::*;
-use integrity_core_types::{
-    HolonNodeModel, PersistenceAction, PersistenceDelete, PersistenceUpdate,
-};
+use integrity_core_types::PersistenceDelete;
 use shared_validation::*;
-
-pub fn validate_create_holon_node(
-    _action: PersistenceAction,
-    holon_node_model: HolonNodeModel,
-) -> ExternResult<ValidateCallbackResult> {
-    validate_create_holon(holon_node_model)
-        .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-
-    Ok(ValidateCallbackResult::Valid)
-}
-
-pub fn validate_update_holon_node(
-    _action: PersistenceUpdate,
-    holon_node_model: HolonNodeModel,
-) -> ExternResult<ValidateCallbackResult> {
-    validate_update_holon(holon_node_model)
-        .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-
-    Ok(ValidateCallbackResult::Valid)
-}
 
 pub fn validate_delete_holon_node(
     _action: PersistenceDelete,

--- a/happ/zomes/integrity/holons_integrity/src/lib.rs
+++ b/happ/zomes/integrity/holons_integrity/src/lib.rs
@@ -24,6 +24,9 @@ pub mod smartlink;
 pub use holon_node::*;
 pub use smartlink::*;
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[hdk_entry_types]

--- a/happ/zomes/integrity/holons_integrity/src/lib.rs
+++ b/happ/zomes/integrity/holons_integrity/src/lib.rs
@@ -55,56 +55,31 @@ pub fn validate_agent_joining(
 
 #[hdk_extern]
 pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match prepare_holon_node_envelope(&op)? {
+        HolonNodeEnvelope::Invalid(violation) => {
+            return Ok(ValidateCallbackResult::Invalid(violation.to_string()));
+        }
+        HolonNodeEnvelope::Valid(_) | HolonNodeEnvelope::NotApplicable => {}
+    }
+
     #[allow(unreachable_patterns)]
     match op.flattened::<EntryTypes, LinkTypes>()? {
+        // HolonNode envelope validation already succeeded in the raw-op guard above.
         FlatOp::StoreEntry(store_entry) => match store_entry {
-            OpEntry::CreateEntry { app_entry, action } => match app_entry {
-                EntryTypes::HolonNode(holon_node) => {
-                    let persistence_create = PersistenceCreate::new(
-                        persistence_agent_id_from_agent_pub_key(action.author),
-                        PersistenceTimestamp(action.timestamp.0),
-                        action.action_seq,
-                        local_id_from_action_hash(action.prev_action),
-                    );
-                    let holon_node_model =
-                        HolonNodeModel::new(holon_node.original_id, holon_node.property_map);
-                    validate_create_holon_node(
-                        PersistenceAction::Create(persistence_create),
-                        holon_node_model,
-                    )
-                }
+            OpEntry::CreateEntry { app_entry, .. } => match app_entry {
+                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
             },
-            OpEntry::UpdateEntry { app_entry, action, .. } => match app_entry {
-                EntryTypes::HolonNode(holon_node) => {
-                    let holon_node_model =
-                        HolonNodeModel::new(holon_node.original_id, holon_node.property_map);
-                    let persistence_update = PersistenceUpdate::new(
-                        persistence_agent_id_from_agent_pub_key(action.author),
-                        PersistenceTimestamp(action.timestamp.0),
-                        action.action_seq,
-                        local_id_from_action_hash(action.prev_action),
-                    );
-                    validate_create_holon_node(
-                        PersistenceAction::Update(persistence_update),
-                        holon_node_model,
-                    )
-                }
+            OpEntry::UpdateEntry { app_entry, .. } => match app_entry {
+                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
             },
             _ => Ok(ValidateCallbackResult::Valid),
         },
         FlatOp::RegisterUpdate(update_entry) => match update_entry {
-            OpUpdate::Entry { app_entry, action } => match app_entry {
-                EntryTypes::HolonNode(holon_node) => {
-                    let holon_node_model =
-                        HolonNodeModel::new(holon_node.original_id, holon_node.property_map);
-                    let persistence_update = PersistenceUpdate::new(
-                        persistence_agent_id_from_agent_pub_key(action.author),
-                        PersistenceTimestamp(action.timestamp.0),
-                        action.action_seq,
-                        local_id_from_action_hash(action.prev_action),
-                    );
-                    validate_update_holon_node(persistence_update, holon_node_model)
-                }
+            // Storage SL2 will activate this path when version-producing writes become native,
+            // root-addressed updates targeting the lineage-root Create. That transition also
+            // removes original_id from the entry shape and requires parity-fixture review.
+            OpUpdate::Entry { app_entry, .. } => match app_entry {
+                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
                 _ => Ok(ValidateCallbackResult::Invalid(
                     "Original and updated entry types must be the same".to_string(),
                 )),
@@ -267,84 +242,41 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             ),
         },
         FlatOp::StoreRecord(store_record) => match store_record {
-            OpRecord::CreateEntry { app_entry, action } => match app_entry {
-                EntryTypes::HolonNode(holon_node) => {
-                    let holon_node_model =
-                        HolonNodeModel::new(holon_node.original_id, holon_node.property_map);
-                    let persistence_create = PersistenceCreate::new(
-                        persistence_agent_id_from_agent_pub_key(action.author),
-                        PersistenceTimestamp(action.timestamp.0),
-                        action.action_seq,
-                        local_id_from_action_hash(action.prev_action),
-                    );
-                    validate_create_holon_node(
-                        PersistenceAction::Create(persistence_create),
-                        holon_node_model,
-                    )
-                }
+            // HolonNode envelope validation already succeeded in the raw-op guard above.
+            OpRecord::CreateEntry { app_entry, .. } => match app_entry {
+                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
             },
-            OpRecord::UpdateEntry { original_action_hash, app_entry, action, .. } => {
+            // MAP writes currently emit Creates. Storage SL2 will exercise this path with native
+            // updates targeting the lineage-root Create; envelope preparation has already run.
+            OpRecord::UpdateEntry { original_action_hash, app_entry, .. } => {
                 let original_record = must_get_valid_record(original_action_hash)?;
-                let original_action = original_record.action().clone();
-                let _original_action = match original_action {
-                    Action::Create(create) => EntryCreationAction::Create(create),
-                    Action::Update(update) => EntryCreationAction::Update(update),
-                    _ => {
-                        return Ok(ValidateCallbackResult::Invalid(
-                            "Original action for an update must be a Create or Update action"
-                                .to_string(),
-                        ));
-                    }
-                };
+                if !matches!(original_record.action(), Action::Create(_) | Action::Update(_)) {
+                    return Ok(ValidateCallbackResult::Invalid(
+                        "Original action for an update must be a Create or Update action"
+                            .to_string(),
+                    ));
+                }
                 match app_entry {
-                    EntryTypes::HolonNode(holon_node) => {
-                        let holon_node_model =
-                            HolonNodeModel::new(holon_node.original_id, holon_node.property_map);
-                        let persistence_update = PersistenceUpdate::new(
-                            persistence_agent_id_from_agent_pub_key(action.author.clone()),
-                            PersistenceTimestamp(action.timestamp.0),
-                            action.action_seq,
-                            local_id_from_action_hash(action.prev_action.clone()),
-                        );
-                        let result = validate_create_holon_node(
-                            PersistenceAction::Update(persistence_update),
-                            holon_node_model.clone(),
-                        )?;
-                        if let ValidateCallbackResult::Valid = result {
-                            let original_holon_node: Option<HolonNode> = original_record
-                                .entry()
-                                .to_app_option()
-                                .map_err(|e| wasm_error!(e))?;
-                            let _original_holon_node = match original_holon_node {
-                                Some(holon_node) => holon_node,
-                                None => {
-                                    return Ok(
-                                            ValidateCallbackResult::Invalid(
-                                                "The updated entry type must be the same as the original entry type"
-                                                    .to_string(),
-                                            ),
-                                        );
-                                }
-                            };
-                            let persistence_update = PersistenceUpdate::new(
-                                persistence_agent_id_from_agent_pub_key(action.author),
-                                PersistenceTimestamp(action.timestamp.0),
-                                action.action_seq,
-                                local_id_from_action_hash(action.prev_action),
-                            );
-                            validate_update_holon_node(persistence_update, holon_node_model)
-                        } else {
-                            Ok(result)
+                    EntryTypes::HolonNode(_) => {
+                        let original_holon_node: Option<HolonNode> =
+                            original_record.entry().to_app_option().map_err(|e| wasm_error!(e))?;
+                        if original_holon_node.is_none() {
+                            return Ok(ValidateCallbackResult::Invalid(
+                                "The updated entry type must be the same as the original entry type"
+                                    .to_string(),
+                            ));
                         }
+
+                        Ok(ValidateCallbackResult::Valid)
                     }
                 }
             }
             OpRecord::DeleteEntry { original_action_hash, action, .. } => {
                 let original_record = must_get_valid_record(original_action_hash)?;
-                let original_action = original_record.action().clone();
-                let original_action = match original_action {
-                    Action::Create(create) => EntryCreationAction::Create(create),
-                    Action::Update(update) => EntryCreationAction::Update(update),
+                let original_action = original_record.action();
+                let original_entry_type = match original_action {
+                    Action::Create(create) => &create.entry_type,
+                    Action::Update(update) => &update.entry_type,
                     _ => {
                         return Ok(ValidateCallbackResult::Invalid(
                             "Original action for a delete must be a Create or Update action"
@@ -352,7 +284,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                         ));
                     }
                 };
-                let app_entry_type = match original_action.entry_type() {
+                let app_entry_type = match original_entry_type {
                     EntryType::App(app_entry_type) => app_entry_type,
                     _ => {
                         return Ok(ValidateCallbackResult::Valid);
@@ -361,7 +293,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 let entry = match original_record.entry().as_option() {
                     Some(entry) => entry,
                     None => {
-                        return if original_action.entry_type().visibility().is_public() {
+                        return if original_entry_type.visibility().is_public() {
                             Ok(
                                     ValidateCallbackResult::Invalid(
                                         "Original record for a delete of a public entry must contain an entry"

--- a/happ/zomes/integrity/holons_integrity/src/tests.rs
+++ b/happ/zomes/integrity/holons_integrity/src/tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+use holochain_serialized_bytes::{SerializedBytes, UnsafeBytes};
+use shared_validation::pvl_limits_v1::MAX_HOLON_NODE_BYTES;
+
+fn oversized_store_record_update() -> Op {
+    let entry_type =
+        EntryType::App(AppEntryDef::new(EntryDefIndex(0), ZomeIndex(0), EntryVisibility::Public));
+    let update = Update {
+        author: AgentPubKey::from_raw_36(vec![0; 36]),
+        timestamp: Timestamp::from_micros(1),
+        action_seq: 2,
+        prev_action: ActionHash::from_raw_36(vec![1; 36]),
+        // This address is intentionally not backed by a record. Reaching
+        // must_get_valid_record would therefore fail the test.
+        original_action_address: ActionHash::from_raw_36(vec![2; 36]),
+        original_entry_address: EntryHash::from_raw_36(vec![3; 36]),
+        entry_type,
+        entry_hash: EntryHash::from_raw_36(vec![4; 36]),
+        weight: EntryRateWeight::default(),
+    };
+    let signed_action = SignedHashed::with_presigned(
+        HoloHashed::with_pre_hashed(Action::Update(update), ActionHash::from_raw_36(vec![5; 36])),
+        Signature([0; SIGNATURE_BYTES]),
+    );
+    let entry = Entry::App(AppEntryBytes(SerializedBytes::from(UnsafeBytes::from(vec![
+        0xc1;
+        MAX_HOLON_NODE_BYTES
+            + 1
+    ]))));
+
+    Op::StoreRecord(StoreRecord { record: Record::new(signed_action, Some(entry)) })
+}
+
+#[test]
+fn oversized_store_record_update_is_rejected_before_dependency_lookup() {
+    match validate(oversized_store_record_update()) {
+        Ok(ValidateCallbackResult::Invalid(message)) => {
+            assert_eq!(message, "MAP-PVL-1003: HolonNode exceeds 262144-byte limit");
+        }
+        other => {
+            panic!("expected the raw-size PVL rejection before dependency lookup, got {other:?}")
+        }
+    }
+}

--- a/shared_crates/shared_validation/src/holon_node_envelope.rs
+++ b/shared_crates/shared_validation/src/holon_node_envelope.rs
@@ -1,0 +1,133 @@
+//! Descriptor-independent envelope rules for persisted HolonNode entries.
+
+use integrity_core_types::{HolonNodeModel, PvlMalformedReason, PvlViolation};
+
+use crate::pvl_limits_v1::{
+    saturating_u16, saturating_u32, MAX_HOLON_NODE_BYTES, MAX_PROPERTY_COUNT,
+};
+
+/// Validates the serialized entry length before the entry is decoded.
+pub fn validate_holon_node_size(raw_len: usize) -> Result<(), PvlViolation> {
+    if raw_len > MAX_HOLON_NODE_BYTES {
+        return Err(PvlViolation::HolonNodeTooLarge {
+            actual_bytes: saturating_u32(raw_len),
+            max_bytes: saturating_u32(MAX_HOLON_NODE_BYTES),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates that the stored payload is the canonical encoding of its decoded model.
+pub fn validate_holon_node_encoding(raw: &[u8], canonical: &[u8]) -> Result<(), PvlViolation> {
+    if raw != canonical {
+        return Err(PvlViolation::MalformedHolonNode {
+            reason: PvlMalformedReason::NonCanonicalEncoding,
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates the number of properties in a decoded HolonNode.
+pub fn validate_property_count(count: usize) -> Result<(), PvlViolation> {
+    if count > MAX_PROPERTY_COUNT {
+        return Err(PvlViolation::TooManyProperties {
+            actual_count: saturating_u16(count),
+            max_count: saturating_u16(MAX_PROPERTY_COUNT),
+        });
+    }
+
+    Ok(())
+}
+
+/// Applies decoded-model rules in consensus order: encoding, then property count.
+pub fn validate_holon_node_decoded(
+    raw: &[u8],
+    canonical: &[u8],
+    model: &HolonNodeModel,
+) -> Result<(), PvlViolation> {
+    // Check encoding first: decoding can collapse duplicate map keys and hide the malformed input.
+    validate_holon_node_encoding(raw, canonical)?;
+    validate_property_count(model.property_map.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use base_types::{BaseValue, MapString};
+    use integrity_core_types::{PropertyMap, PropertyName};
+
+    use super::*;
+
+    fn model_with_property_count(count: usize) -> HolonNodeModel {
+        let property_map: PropertyMap = (0..count)
+            .map(|index| {
+                (
+                    PropertyName(MapString(format!("property-{index:03}"))),
+                    BaseValue::StringValue(MapString("value".to_string())),
+                )
+            })
+            .collect();
+        HolonNodeModel::new(None, property_map)
+    }
+
+    #[test]
+    fn serialized_length_boundary_is_inclusive() {
+        assert_eq!(validate_holon_node_size(MAX_HOLON_NODE_BYTES), Ok(()));
+        assert_eq!(
+            validate_holon_node_size(MAX_HOLON_NODE_BYTES + 1),
+            Err(PvlViolation::HolonNodeTooLarge { actual_bytes: 262_145, max_bytes: 262_144 })
+        );
+    }
+
+    #[test]
+    fn property_count_boundary_is_inclusive() {
+        assert_eq!(validate_property_count(MAX_PROPERTY_COUNT), Ok(()));
+        assert_eq!(
+            validate_property_count(MAX_PROPERTY_COUNT + 1),
+            Err(PvlViolation::TooManyProperties { actual_count: 257, max_count: 256 })
+        );
+    }
+
+    #[test]
+    fn violation_measurements_saturate_to_contract_widths() {
+        assert_eq!(
+            validate_property_count(usize::MAX),
+            Err(PvlViolation::TooManyProperties { actual_count: u16::MAX, max_count: 256 })
+        );
+
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(
+            validate_holon_node_size(usize::MAX),
+            Err(PvlViolation::HolonNodeTooLarge { actual_bytes: u32::MAX, max_bytes: 262_144 })
+        );
+    }
+
+    #[test]
+    fn encoding_requires_an_exact_byte_match() {
+        assert_eq!(validate_holon_node_encoding(&[1, 2], &[1, 2]), Ok(()));
+        assert_eq!(
+            validate_holon_node_encoding(&[1, 2], &[2, 1]),
+            Err(PvlViolation::MalformedHolonNode {
+                reason: PvlMalformedReason::NonCanonicalEncoding,
+            })
+        );
+    }
+
+    #[test]
+    fn decoded_rules_report_encoding_before_property_count() {
+        let model = model_with_property_count(MAX_PROPERTY_COUNT + 1);
+
+        assert_eq!(
+            validate_holon_node_decoded(&[1], &[2], &model),
+            Err(PvlViolation::MalformedHolonNode {
+                reason: PvlMalformedReason::NonCanonicalEncoding,
+            })
+        );
+
+        assert_eq!(
+            validate_holon_node_decoded(&[1, 2, 3], &[1, 2, 3], &model),
+            Err(PvlViolation::TooManyProperties { actual_count: 257, max_count: 256 })
+        );
+    }
+}

--- a/shared_crates/shared_validation/src/lib.rs
+++ b/shared_crates/shared_validation/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod holon_node_envelope;
 // Public module, part of the crate's public API
 pub mod pvl_limits_v1;
 pub mod validation_helpers;
 
 // Re-exporting key functions/types for ease of use
+pub use holon_node_envelope::*;
 pub use validation_helpers::*;
 
 pub use integrity_core_types::{PvlField, PvlMalformedReason, PvlViolation};

--- a/shared_crates/shared_validation/src/validation_helpers.rs
+++ b/shared_crates/shared_validation/src/validation_helpers.rs
@@ -1,20 +1,10 @@
 use core_types::{decode_smartlink_tag, ValidationError, HOLOCHAIN_ACTION_HASH_BYTES};
-use integrity_core_types::{HolonNodeModel, LocalId, PersistenceLinkTag};
+use integrity_core_types::{LocalId, PersistenceLinkTag};
 
 /// Foundational routines for property and relationship checks
 /// applicable to both zomes
 
 // ==== Entry CUD ====
-
-pub fn validate_create_holon(_holon_node_model: HolonNodeModel) -> Result<(), ValidationError> {
-    // Deferring logic until Descriptors
-
-    Ok(())
-}
-
-pub fn validate_update_holon(_holon_node_model: HolonNodeModel) -> Result<(), ValidationError> {
-    Ok(())
-}
 
 pub fn validate_delete_holon() -> Result<(), ValidationError> {
     Ok(())

--- a/tests/sweetests/Cargo.toml
+++ b/tests/sweetests/Cargo.toml
@@ -19,6 +19,7 @@ holochain = { version = "=0.6.1", default-features = false, features = [
     "wasmer_sys",
     "transport-iroh"
 ] }
+holochain_state = "=0.6.1"
 
 
 # Workaround: iroh-base-holochain 0.95.1 hard-pins ed25519-dalek = "=3.0.0-pre.1",
@@ -103,5 +104,4 @@ pretty_assertions = "1.4"
 #futures = { version = "0.3.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 #async-std = "1"
-
 

--- a/tests/sweetests/src/harness/helpers/mod.rs
+++ b/tests/sweetests/src/harness/helpers/mod.rs
@@ -3,6 +3,7 @@ pub mod constants;
 pub mod core_schema;
 pub mod expected_test_result;
 pub mod mock_conductor;
+pub mod pvl_validation;
 pub mod test_context;
 pub mod tracing_utils;
 
@@ -11,5 +12,6 @@ pub use constants::*;
 pub use core_schema::*;
 pub use expected_test_result::*;
 pub use mock_conductor::*;
+pub use pvl_validation::*;
 pub use test_context::*;
 pub use tracing_utils::*;

--- a/tests/sweetests/src/harness/helpers/pvl_validation.rs
+++ b/tests/sweetests/src/harness/helpers/pvl_validation.rs
@@ -1,0 +1,29 @@
+use holochain::conductor::{api::error::ConductorApiError, CellError};
+use holochain::core::workflow::WorkflowError;
+use holochain_state::source_chain::SourceChainError;
+use std::fmt::Debug;
+
+const APP_VALIDATION_PREFIX: &str = "Validation failed while committing: ";
+
+/// Asserts that an authoring call was rejected with exactly the expected PVL message.
+///
+/// Holochain wraps an Integrity callback rejection in its authoring-path error types and
+/// prefixes the callback message. Keeping that substrate-specific knowledge here lets PVL
+/// sweettests assert consensus-visible messages without duplicating brittle error plumbing.
+pub fn assert_commit_rejected_with_pvl<T: Debug>(
+    result: Result<T, ConductorApiError>,
+    expected_message: &str,
+) {
+    let reason = match result {
+        Err(ConductorApiError::CellError(CellError::WorkflowError(workflow_error))) => {
+            match *workflow_error {
+                WorkflowError::SourceChainError(SourceChainError::InvalidCommit(reason)) => reason,
+                other => panic!("expected InvalidCommit, got workflow error {other:?}"),
+            }
+        }
+        Err(other) => panic!("expected InvalidCommit, got conductor error {other:?}"),
+        Ok(value) => panic!("expected the commit to be rejected, but it returned {value:?}"),
+    };
+
+    assert_eq!(reason, format!("{APP_VALIDATION_PREFIX}{expected_message}"));
+}

--- a/tests/sweetests/tests/pvl_validation_tests.rs
+++ b/tests/sweetests/tests/pvl_validation_tests.rs
@@ -1,0 +1,38 @@
+//! Conductor-level PVL tests that exercise authoring directly below the dance layer.
+//!
+//! PR 2 intentionally adds only the property-count rejection here. Size, decode, and
+//! non-canonical rejection paths remain adapter-level tests until broader conductor
+//! coverage is added in PVL PR 8.
+
+use holochain::prelude::Record;
+use holons_prelude::prelude::*;
+use holons_test::harness::helpers::{assert_commit_rejected_with_pvl, setup_test_conductor};
+use integrity_core_types::HolonNodeModel;
+
+const EXPECTED_REJECTION: &str = "MAP-PVL-1101: property count exceeds 256";
+
+/// Proves that the Integrity callback's PVL message reaches the authoring
+/// conductor path without being replaced by an implicit guest-error message.
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_holon_node_with_257_properties_using_exact_pvl_message() {
+    let backend = setup_test_conductor().await;
+    let property_map = (0..257)
+        .map(|index| {
+            (
+                format!("property-{index:03}").to_property_name(),
+                MapString("value".to_string()).to_base_value(),
+            )
+        })
+        .collect();
+
+    // HolonNodeModel has the same serialized field layout as the guest HolonNode.
+    // Passing it directly keeps this test independent of guest-only Rust types while
+    // exercising the coordinator's real create_entry authoring path.
+    let holon_node = HolonNodeModel::new(None, property_map);
+    let result = backend
+        .conductor
+        .call_fallible::<_, Record>(&backend.cell.zome("holons"), "create_holon_node", holon_node)
+        .await;
+
+    assert_commit_rejected_with_pvl(result, EXPECTED_REJECTION);
+}


### PR DESCRIPTION
## PVL PR 2 — HolonNode Envelope Validation (Vertical Slice)

Closes #600.

### Summary

First MAP-level rejection logic in the Integrity zome. Implements descriptor-independent envelope validation for the `HolonNode` entry as an end-to-end vertical slice — pure-core rules, substrate-adapter entry point, Integrity wiring for all HolonNode entry-op forms, and explicit violation→`Invalid` mapping — turning the PR 1 limit/violation contracts into enforced rules on the live write path.

Per PVL Design Spec v0.4 (§5.1–5.2, §10) and Implementation Plan v2.4 (PR 2), validation covers:

- **serialized entry size** (`MAX_HOLON_NODE_BYTES` = 262,144) → `MAP-PVL-1003`
- **typed decode** → `MAP-PVL-1001` (`DecodeFailed`)
- **canonical encoding** (raw bytes byte-match the model re-encode) → `MAP-PVL-1001` (`NonCanonicalEncoding`)
- **property count** (`MAX_PROPERTY_COUNT` = 256) → `MAP-PVL-1101`

Rules run in a deterministic, consensus-relevant order: **size → decode → canonical → count**, pinned by tests.

### Why

Before this PR, `validate_create_holon` / `validate_update_holon` were no-ops and the zome accepted every decodable `HolonNode` unconditionally — no floor on entry size, property count, or non-canonical encoding, so a coordinator defect or peer could commit oversized/incoherent entries every peer must then store, gossip, and traverse. This establishes the deterministic hygiene floor without consulting descriptors or runtime state.

### Design

Follows the PVL §3.3 layering, with the Integrity zome holding dispatch + callback mapping only:

```
holons_integrity        → validate() dispatch + violation→Invalid mapping
  holons_guest_integrity → raw-op extraction, decode, canonical re-encode, byte-compare
    shared_validation    → pure rules → Result<(), PvlViolation>  (no hdi/hdk/holo_hash)
```

- **Raw-first guard.** A `prepare_holon_node_envelope(&op)` guard runs before `op.flattened()`, extracting the inner app-entry bytes directly from the raw `Op` (`StoreEntry`, `StoreRecord`, `RegisterUpdate`). It measures and rejects oversized entries **before** typed decode and before any dependency request — in the StoreRecord-update arm, before its existing `must_get_valid_record`.
- **Canonical-encoding check.** The decoded model is re-encoded and byte-compared against the stored entry. This is what makes the "canonical shape" rule non-empty (serde `BTreeMap` decoding is last-wins for duplicate keys, so nothing is observable post-decode) and doubles as the guest/preflight serialization-parity guarantee. It catches duplicate keys, non-canonical ordering, non-canonical integer widths, and ignored extra fields.
- **Explicit rejection mapping.** `Err(PvlViolation)` → `ValidateCallbackResult::Invalid(violation.to_string())`, so the consensus-visible message is exactly the `MAP-PVL-<code>: <summary>` contract rather than a substrate-wrapped guest string.
- **Wiring cleanup.** All five HolonNode entry-op forms route through the one adapter entry point; the create-then-update double validation in the StoreRecord-update arm is removed; the superseded no-op validators and their zome wrappers are deleted.

### Storage SL2 breadcrumbs (no behavior change)

`ForUpdateNewVersion` still persists via `create_entry`. Breadcrumb comments mark the anticipated Storage SL2 switch (root-addressed native `update_entry` against the lineage-root Create, removal of `original_id` from the entry shape, parity-fixture revisit) at the guest commit path and the RegisterUpdate / StoreRecord-update arms. The update-op wiring is exercised by adapter tests but is dead for MAP writes until SL2, since writes currently emit only `Create` actions.

### Scope / impact

- **DNA hash + validation semantics change** (first real rejection logic in `validate()`) — requires fresh test state; acceptable pre-production.
- **Commit path & loader:** every entry-producing staged commit now passes envelope checks; the 379-holon core-schema corpus continues to load clean (positive coverage via existing loader fixtures).
- **No host / TS SDK / wire changes** — `HolonError::PvlViolation` and its SDK mirror landed in PR 1; violations stay inside Integrity until preflight (PR 8).

### Testing

- **Pure core:** size/count boundaries (inclusive), saturating narrowing, rule ordering.
- **Adapter:** stored-payload↔`encode` parity **and** model↔guest-entry parity (both legs of the canonical-compare pinned); decode-failure; duplicate-key / reordered / non-canonical integer-width / ignored-extra-field → `NonCanonicalEncoding`; oversized-before-decode; over-count.
- **Conductor (sweetest):** a 257-property `HolonNode` is rejected with the exact `MAP-PVL-1101: property count exceeds 256` message reaching the author, via a reusable `assert_commit_rejected_with_pvl` harness helper.
- `npm run check`, `npm run fmt:check`, `npm run test:unit`, and `npm run sweetest` all pass (corpus loads; existing dance suites green).

### Explicitly out of scope

Property-name / native-value rules (PR 3); identifier shape (PR 4); update/delete target, lineage, `original_id` immutability (PR 5 + Storage SL2); SmartLink validation (PR 6); dependency-budget + coordinator preflight (PR 8); changing how `ForUpdateNewVersion` persists (Storage SL2). Only `TooManyProperties` is exercised at the conductor level here by design; broader negative-path conductor coverage is PR 8.
