### PR TITLE
601 pvl pr 3 property name and native value validation

### DIFF
--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -383,6 +383,40 @@ mod tests {
     }
 
     #[test]
+    fn rejects_numeric_and_string_boolean_substitutes_during_typed_decode() {
+        let numeric = encode(&NodeWithProperties(BTreeMap::from([(
+            property_name("boolean"),
+            ForgedNativeValue::new(1, "BooleanValue", 1_u8),
+        )])))
+        .unwrap();
+        assert_decode_failed(&numeric);
+
+        let string = encode(&NodeWithProperties(BTreeMap::from([(
+            property_name("boolean"),
+            ForgedNativeValue::new(1, "BooleanValue", "true"),
+        )])))
+        .unwrap();
+        assert_decode_failed(&string);
+    }
+
+    #[test]
+    fn rejects_overflowing_and_wrongly_typed_integer_values_during_typed_decode() {
+        let overflowing = encode(&NodeWithProperties(BTreeMap::from([(
+            property_name("integer"),
+            ForgedNativeValue::new(2, "IntegerValue", u64::MAX),
+        )])))
+        .unwrap();
+        assert_decode_failed(&overflowing);
+
+        let wrongly_typed = encode(&NodeWithProperties(BTreeMap::from([(
+            property_name("integer"),
+            ForgedNativeValue::new(2, "IntegerValue", "1"),
+        )])))
+        .unwrap();
+        assert_decode_failed(&wrongly_typed);
+    }
+
+    #[test]
     fn rejects_ignored_extra_field_as_non_canonical() {
         let raw = encode(&NodeWithExtraField {
             original_id: None,
@@ -431,6 +465,13 @@ mod tests {
         );
     }
 
+    fn assert_decode_failed(raw: &[u8]) {
+        assert_eq!(
+            run(raw),
+            Err(PvlViolation::MalformedHolonNode { reason: PvlMalformedReason::DecodeFailed })
+        );
+    }
+
     #[derive(Debug)]
     struct NodeWithProperties<T>(T);
 
@@ -440,6 +481,30 @@ mod tests {
             node.serialize_field("original_id", &Option::<LocalId>::None)?;
             node.serialize_field("property_map", &self.0)?;
             node.end()
+        }
+    }
+
+    #[derive(Debug)]
+    struct ForgedNativeValue<T> {
+        variant_index: u32,
+        variant_name: &'static str,
+        value: T,
+    }
+
+    impl<T> ForgedNativeValue<T> {
+        fn new(variant_index: u32, variant_name: &'static str, value: T) -> Self {
+            Self { variant_index, variant_name, value }
+        }
+    }
+
+    impl<T: Serialize> Serialize for ForgedNativeValue<T> {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_newtype_variant(
+                "BaseValue",
+                self.variant_index,
+                self.variant_name,
+                &self.value,
+            )
         }
     }
 

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -7,9 +7,18 @@ use shared_validation::{validate_holon_node_decoded, validate_holon_node_size};
 
 use crate::HolonNode;
 
+/// Entry-definition index assigned to `HolonNode`.
+///
+/// `HolonNode` is currently the sole app entry declared by this integrity
+/// zome, so its index is fixed at zero. Adding or reordering app-entry
+/// definitions requires updating this constant and the associated op tests.
 const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
 
-/// Result of preparing the HolonNode envelope carried by an operation.
+/// Outcome of attempting HolonNode envelope preparation for an operation.
+///
+/// `NotApplicable` means the operation is outside this validator's domain;
+/// it is not a validation success or failure. `Invalid` represents a
+/// deterministic consensus-visible rejection.
 #[derive(Debug, PartialEq, Eq)]
 pub enum HolonNodeEnvelope {
     /// The operation does not carry a HolonNode app entry.
@@ -20,7 +29,11 @@ pub enum HolonNodeEnvelope {
     Invalid(PvlViolation),
 }
 
-/// Extracts and validates a HolonNode entry before flattened-op decoding.
+/// Extracts and validates a HolonNode's raw stored entry bytes before the
+/// operation is converted into a flattened lifecycle-validation form.
+///
+/// This preserves access to the original encoding so size and canonicality
+/// checks can run before decoding discards representation details.
 pub fn prepare_holon_node_envelope(op: &Op) -> ExternResult<HolonNodeEnvelope> {
     let Some(raw) = holon_node_entry_bytes(op) else {
         return Ok(HolonNodeEnvelope::NotApplicable);
@@ -32,7 +45,17 @@ pub fn prepare_holon_node_envelope(op: &Op) -> ExternResult<HolonNodeEnvelope> {
     })
 }
 
-/// Locates the stored inner app-entry payload without decoding it.
+/// Returns the exact stored app-entry bytes when `op` carries a `HolonNode`.
+///
+/// Supports the entry-bearing `create` and `update` operation forms used by the
+/// integrity callback. Operations that do not carry entry content, or that
+/// carry another entry type, return `None`.
+///
+/// Returning `None` does not indicate an invalid operation; it simply means
+/// that `HolonNode` envelope validation does not apply.
+///
+/// The bytes are returned without decoding so raw-size and canonical-encoding
+/// checks can inspect the original stored representation.
 fn holon_node_entry_bytes(op: &Op) -> Option<&[u8]> {
     let (entry_type, entry) = match op {
         Op::StoreEntry(store_entry) => (store_entry.action.hashed.entry_type(), &store_entry.entry),
@@ -45,9 +68,8 @@ fn holon_node_entry_bytes(op: &Op) -> Option<&[u8]> {
         _ => return None,
     };
 
-    // HolonNode is the sole app entry in this integrity zome and therefore entry-def index 0.
-    // The integrity callback already scopes the zome index; keep this constant aligned if another
-    // app entry is ever added or the declaration order changes.
+    // Since this code only runs for this zome, the entry index alone
+    // identifies whether this is a HolonNode.
     match entry_type {
         EntryType::App(app_entry_def)
             if app_entry_def.entry_index == HOLON_NODE_ENTRY_DEF_INDEX => {}
@@ -59,8 +81,13 @@ fn holon_node_entry_bytes(op: &Op) -> Option<&[u8]> {
 
 /// Runs the consensus-ordered envelope pipeline against stored inner-entry bytes.
 ///
-/// The outer result is reserved for serialization/callback failures. The inner result carries
-/// deterministic PVL violations that the integrity zome maps explicitly to `Invalid`.
+/// The outer `ExternResult` is reserved for host, serialization, or callback
+/// execution failures that prevent validation from completing. The inner
+/// `Result` represents completed validation: either a valid model or a
+/// deterministic PVL violation.
+///
+/// Keeping those channels separate prevents malformed peer-authored data from
+/// being reported as an integrity-callback execution failure.
 fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, PvlViolation>> {
     // Rejecting size first bounds work even when the payload is malformed or expensive to decode.
     if let Err(violation) = validate_holon_node_size(raw.len()) {
@@ -77,8 +104,12 @@ fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, Pv
     };
     let model = HolonNodeModel::from(node);
 
-    // Canonicalize the model rather than the outer EntryTypes enum: Holochain stores these inner
-    // bytes, and comparing at this boundary preserves alternate-encoding evidence lost by decode.
+    // Re-encode the decoded model into its canonical representation and compare it
+    // with the exact stored bytes. Decoding alone would accept multiple equivalent
+    // encodings and erase the evidence needed to reject non-canonical input.
+    //
+    // Canonicalize the model rather than the outer EntryTypes enum because
+    // Holochain stores and exposes these inner app-entry bytes at this boundary.
     let canonical = encode(&model).map_err(|error| wasm_error!(error))?;
     if let Err(violation) = validate_holon_node_decoded(raw, &canonical, &model) {
         return Ok(Err(violation));
@@ -250,8 +281,9 @@ mod tests {
             let raw = vec![0xc1; MAX_HOLON_NODE_BYTES + 1];
             let op = op_with_raw_entry(form, raw);
 
-            // In particular, StoreRecordUpdate carries an arbitrary original-action address.
-            // Preparation must reject its current entry without attempting dependency resolution.
+            // Raw-size rejection must occur before decoding or dependency resolution.
+            // This is especially important for StoreRecordUpdate, whose original-action
+            // address is untrusted peer-authored input.
             assert_eq!(
                 prepare_holon_node_envelope(&op).unwrap(),
                 expected,
@@ -295,6 +327,9 @@ mod tests {
         }
     }
 
+    // Envelope canonicality validation re-encodes `HolonNodeModel`, so this test
+    // guards the assumption that the model and guest-facing entry type have an
+    // identical serialized representation.
     #[test]
     fn model_encoding_matches_guest_inner_entry_encoding() {
         let empty = HolonNode::new(None, PropertyMap::new());
@@ -318,6 +353,9 @@ mod tests {
         );
     }
 
+    // The envelope validator reads `AppEntryBytes` directly. Guard that those
+    // stored inner bytes are exactly the bytes produced by guest serialization,
+    // with no additional wrapper encoding introduced by `Entry::app`.
     #[test]
     fn stored_app_entry_payload_matches_guest_encoding() {
         let node = canonical_node(BTreeMap::from([(
@@ -472,6 +510,11 @@ mod tests {
         );
     }
 
+    // The following serializers deliberately produce byte representations that
+    // cannot be constructed through the strongly typed HolonNode API. They let
+    // tests exercise malformed, duplicate-key, reordered, and otherwise
+    // non-canonical encodings at the raw envelope boundary.
+
     #[derive(Debug)]
     struct NodeWithProperties<T>(T);
 
@@ -483,6 +526,7 @@ mod tests {
             node.end()
         }
     }
+
 
     #[derive(Debug)]
     struct ForgedNativeValue<T> {

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -527,7 +527,6 @@ mod tests {
         }
     }
 
-
     #[derive(Debug)]
     struct ForgedNativeValue<T> {
         variant_index: u32,

--- a/shared_crates/shared_validation/src/holon_node_envelope.rs
+++ b/shared_crates/shared_validation/src/holon_node_envelope.rs
@@ -41,7 +41,7 @@ pub fn validate_property_count(count: usize) -> Result<(), PvlViolation> {
     Ok(())
 }
 
-/// Applies decoded-model rules in consensus order: encoding, then property count.
+/// Applies decoded-model rules in consensus order: encoding, property count, then properties.
 pub fn validate_holon_node_decoded(
     raw: &[u8],
     canonical: &[u8],
@@ -49,7 +49,8 @@ pub fn validate_holon_node_decoded(
 ) -> Result<(), PvlViolation> {
     // Check encoding first: decoding can collapse duplicate map keys and hide the malformed input.
     validate_holon_node_encoding(raw, canonical)?;
-    validate_property_count(model.property_map.len())
+    validate_property_count(model.property_map.len())?;
+    crate::holon_node_properties::validate_holon_node_properties(&model.property_map)
 }
 
 #[cfg(test)]
@@ -128,6 +129,35 @@ mod tests {
         assert_eq!(
             validate_holon_node_decoded(&[1, 2, 3], &[1, 2, 3], &model),
             Err(PvlViolation::TooManyProperties { actual_count: 257, max_count: 256 })
+        );
+    }
+
+    #[test]
+    fn decoded_rules_apply_property_validation_after_property_count() {
+        let mut property_map = PropertyMap::new();
+        property_map.insert(
+            PropertyName(MapString(String::new())),
+            BaseValue::StringValue(MapString("value".to_string())),
+        );
+        let model = HolonNodeModel::new(None, property_map);
+
+        assert_eq!(
+            validate_holon_node_decoded(&[1, 2, 3], &[1, 2, 3], &model),
+            Err(PvlViolation::EmptyPropertyName)
+        );
+    }
+
+    #[test]
+    fn decoded_rules_report_property_count_before_property_rules() {
+        let mut model = model_with_property_count(MAX_PROPERTY_COUNT + 1);
+        model.property_map.insert(
+            PropertyName(MapString(String::new())),
+            BaseValue::StringValue(MapString("value".to_string())),
+        );
+
+        assert_eq!(
+            validate_holon_node_decoded(&[1, 2, 3], &[1, 2, 3], &model),
+            Err(PvlViolation::TooManyProperties { actual_count: 258, max_count: 256 })
         );
     }
 }

--- a/shared_crates/shared_validation/src/holon_node_properties.rs
+++ b/shared_crates/shared_validation/src/holon_node_properties.rs
@@ -1,0 +1,286 @@
+//! Descriptor-independent property rules for persisted HolonNode entries.
+
+use integrity_core_types::{PropertyMap, PropertyName, PropertyValue, PvlViolation};
+
+use crate::pvl_limits_v1::{
+    raw_byte_len, saturating_u32, utf8_byte_len, MAX_BYTES_VALUE_BYTES, MAX_ENUM_VALUE_BYTES,
+    MAX_PROPERTY_NAME_BYTES, MAX_STRING_VALUE_BYTES,
+};
+
+/// Validates the representation of a property name.
+pub fn validate_property_name(property_name: &PropertyName) -> Result<(), PvlViolation> {
+    let name = &property_name.0 .0;
+
+    if name.is_empty() {
+        return Err(PvlViolation::EmptyPropertyName);
+    }
+
+    if name.starts_with(char::is_whitespace) || name.ends_with(char::is_whitespace) {
+        return Err(PvlViolation::InvalidPropertyName {
+            reason: "leading or trailing whitespace".into(),
+        });
+    }
+
+    if name.chars().any(char::is_control) {
+        return Err(PvlViolation::InvalidPropertyName { reason: "control character".into() });
+    }
+
+    let actual_bytes = utf8_byte_len(name);
+    if actual_bytes > MAX_PROPERTY_NAME_BYTES {
+        return Err(PvlViolation::PropertyNameTooLong {
+            actual_bytes: saturating_u32(actual_bytes),
+            max_bytes: saturating_u32(MAX_PROPERTY_NAME_BYTES),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates the native representation of a property value.
+pub fn validate_property_value(
+    property_name: &PropertyName,
+    value: &PropertyValue,
+) -> Result<(), PvlViolation> {
+    match value {
+        PropertyValue::StringValue(value) => {
+            let actual_bytes = utf8_byte_len(&value.0);
+            if actual_bytes > MAX_STRING_VALUE_BYTES {
+                return Err(PvlViolation::StringValueTooLarge {
+                    property_name: property_name.clone(),
+                    actual_bytes: saturating_u32(actual_bytes),
+                    max_bytes: saturating_u32(MAX_STRING_VALUE_BYTES),
+                });
+            }
+        }
+        PropertyValue::BooleanValue(_) => {}
+        PropertyValue::IntegerValue(_) => {}
+        PropertyValue::EnumValue(value) => {
+            let token = &value.0 .0;
+            if token.is_empty() {
+                return Err(PvlViolation::EmptyEnumValue { property_name: property_name.clone() });
+            }
+
+            let actual_bytes = utf8_byte_len(token);
+            if actual_bytes > MAX_ENUM_VALUE_BYTES {
+                return Err(PvlViolation::EnumValueTooLarge {
+                    property_name: property_name.clone(),
+                    actual_bytes: saturating_u32(actual_bytes),
+                    max_bytes: saturating_u32(MAX_ENUM_VALUE_BYTES),
+                });
+            }
+        }
+        PropertyValue::BytesValue(value) => {
+            let actual_bytes = raw_byte_len(&value.0);
+            if actual_bytes > MAX_BYTES_VALUE_BYTES {
+                return Err(PvlViolation::BytesValueTooLarge {
+                    property_name: property_name.clone(),
+                    actual_bytes: saturating_u32(actual_bytes),
+                    max_bytes: saturating_u32(MAX_BYTES_VALUE_BYTES),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates every property in deterministic map order.
+pub fn validate_holon_node_properties(property_map: &PropertyMap) -> Result<(), PvlViolation> {
+    for (property_name, value) in property_map {
+        validate_property_name(property_name)?;
+        validate_property_value(property_name, value)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use base_types::{BaseValue, MapBoolean, MapBytes, MapEnumValue, MapInteger, MapString};
+
+    use super::*;
+
+    fn property_name(value: impl Into<String>) -> PropertyName {
+        PropertyName(MapString(value.into()))
+    }
+
+    #[test]
+    fn property_name_boundaries_use_utf8_bytes() {
+        assert_eq!(validate_property_name(&property_name("a".repeat(128))), Ok(()));
+        assert_eq!(
+            validate_property_name(&property_name("a".repeat(129))),
+            Err(PvlViolation::PropertyNameTooLong { actual_bytes: 129, max_bytes: 128 })
+        );
+        assert_eq!(validate_property_name(&property_name("é".repeat(64))), Ok(()));
+        assert_eq!(
+            validate_property_name(&property_name(format!("{}a", "é".repeat(64)))),
+            Err(PvlViolation::PropertyNameTooLong { actual_bytes: 129, max_bytes: 128 })
+        );
+    }
+
+    #[test]
+    fn property_name_representation_rules_are_enforced() {
+        assert_eq!(
+            validate_property_name(&property_name("")),
+            Err(PvlViolation::EmptyPropertyName)
+        );
+
+        for name in [" leading", "trailing ", "\u{00a0}leading", "trailing\u{00a0}"] {
+            assert_eq!(
+                validate_property_name(&property_name(name)),
+                Err(PvlViolation::InvalidPropertyName {
+                    reason: "leading or trailing whitespace".into(),
+                })
+            );
+        }
+
+        for name in ["interior\tcontrol", "interior\0control"] {
+            assert_eq!(
+                validate_property_name(&property_name(name)),
+                Err(PvlViolation::InvalidPropertyName { reason: "control character".into() })
+            );
+        }
+
+        assert_eq!(validate_property_name(&property_name("ordinary interior space")), Ok(()));
+    }
+
+    #[test]
+    fn property_name_rules_have_deterministic_precedence() {
+        assert_eq!(
+            validate_property_name(&property_name("\t")),
+            Err(PvlViolation::InvalidPropertyName {
+                reason: "leading or trailing whitespace".into(),
+            })
+        );
+
+        let control_and_too_long = format!("{}\0", "a".repeat(129));
+        assert_eq!(
+            validate_property_name(&property_name(control_and_too_long)),
+            Err(PvlViolation::InvalidPropertyName { reason: "control character".into() })
+        );
+    }
+
+    #[test]
+    fn string_value_boundaries_use_utf8_bytes() {
+        let name = property_name("value");
+        assert_eq!(
+            validate_property_value(&name, &BaseValue::StringValue(MapString("a".repeat(16_384))),),
+            Ok(())
+        );
+        assert_eq!(
+            validate_property_value(&name, &BaseValue::StringValue(MapString("a".repeat(16_385))),),
+            Err(PvlViolation::StringValueTooLarge {
+                property_name: name.clone(),
+                actual_bytes: 16_385,
+                max_bytes: 16_384,
+            })
+        );
+        assert_eq!(
+            validate_property_value(&name, &BaseValue::StringValue(MapString("é".repeat(8_192))),),
+            Ok(())
+        );
+        assert_eq!(
+            validate_property_value(
+                &name,
+                &BaseValue::StringValue(MapString(format!("{}a", "é".repeat(8_192)))),
+            ),
+            Err(PvlViolation::StringValueTooLarge {
+                property_name: name,
+                actual_bytes: 16_385,
+                max_bytes: 16_384,
+            })
+        );
+    }
+
+    #[test]
+    fn enum_value_rules_are_enforced() {
+        let name = property_name("status");
+        assert_eq!(
+            validate_property_value(
+                &name,
+                &BaseValue::EnumValue(MapEnumValue(MapString(String::new()))),
+            ),
+            Err(PvlViolation::EmptyEnumValue { property_name: name.clone() })
+        );
+        assert_eq!(
+            validate_property_value(
+                &name,
+                &BaseValue::EnumValue(MapEnumValue(MapString("a".repeat(256)))),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            validate_property_value(
+                &name,
+                &BaseValue::EnumValue(MapEnumValue(MapString("a".repeat(257)))),
+            ),
+            Err(PvlViolation::EnumValueTooLarge {
+                property_name: name,
+                actual_bytes: 257,
+                max_bytes: 256,
+            })
+        );
+    }
+
+    #[test]
+    fn bytes_value_boundary_is_inclusive() {
+        let name = property_name("payload");
+        assert_eq!(
+            validate_property_value(&name, &BaseValue::BytesValue(MapBytes(vec![0; 131_072])),),
+            Ok(())
+        );
+        assert_eq!(
+            validate_property_value(&name, &BaseValue::BytesValue(MapBytes(vec![0; 131_073])),),
+            Err(PvlViolation::BytesValueTooLarge {
+                property_name: name,
+                actual_bytes: 131_073,
+                max_bytes: 131_072,
+            })
+        );
+    }
+
+    #[test]
+    fn all_five_scalar_variants_are_supported() {
+        let name = property_name("value");
+        let values: [PropertyValue; 5] = [
+            BaseValue::StringValue(MapString("text".into())),
+            BaseValue::BooleanValue(MapBoolean(true)),
+            BaseValue::IntegerValue(MapInteger(i64::MIN)),
+            BaseValue::EnumValue(MapEnumValue(MapString("member".into()))),
+            BaseValue::BytesValue(MapBytes(vec![1, 2, 3])),
+        ];
+
+        for value in &values {
+            assert_eq!(validate_property_value(&name, value), Ok(()));
+        }
+    }
+
+    #[test]
+    fn property_map_checks_names_before_values() {
+        let invalid_name = property_name("");
+        let mut property_map = PropertyMap::new();
+        property_map.insert(invalid_name, BaseValue::StringValue(MapString("a".repeat(16_385))));
+
+        assert_eq!(
+            validate_holon_node_properties(&property_map),
+            Err(PvlViolation::EmptyPropertyName)
+        );
+    }
+
+    #[test]
+    fn property_map_reports_the_first_violation_in_btree_order() {
+        let first_name = property_name("a");
+        let second_name = property_name("b");
+        let mut property_map = PropertyMap::new();
+        property_map.insert(second_name, BaseValue::BytesValue(MapBytes(vec![0; 131_073])));
+        property_map.insert(
+            first_name.clone(),
+            BaseValue::EnumValue(MapEnumValue(MapString(String::new()))),
+        );
+
+        assert_eq!(
+            validate_holon_node_properties(&property_map),
+            Err(PvlViolation::EmptyEnumValue { property_name: first_name })
+        );
+    }
+}

--- a/shared_crates/shared_validation/src/holon_node_properties.rs
+++ b/shared_crates/shared_validation/src/holon_node_properties.rs
@@ -100,6 +100,17 @@ mod tests {
 
     use super::*;
 
+    fn property_value_from_base_value(value: BaseValue) -> PropertyValue {
+        value
+    }
+
+    fn base_value_from_property_value(value: PropertyValue) -> BaseValue {
+        value
+    }
+
+    const _: fn(BaseValue) -> PropertyValue = property_value_from_base_value;
+    const _: fn(PropertyValue) -> BaseValue = base_value_from_property_value;
+
     fn property_name(value: impl Into<String>) -> PropertyName {
         PropertyName(MapString(value.into()))
     }
@@ -240,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn all_five_scalar_variants_are_supported() {
+    fn all_five_scalar_variants_are_supported_at_single_value_depth() {
         let name = property_name("value");
         let values: [PropertyValue; 5] = [
             BaseValue::StringValue(MapString("text".into())),
@@ -253,6 +264,21 @@ mod tests {
         for value in &values {
             assert_eq!(validate_property_value(&name, value), Ok(()));
         }
+    }
+
+    #[test]
+    fn property_values_are_concrete_scalar_base_values() {
+        let name = property_name("value");
+        let value: PropertyValue = BaseValue::IntegerValue(MapInteger(42));
+        let mut property_map = PropertyMap::new();
+
+        assert_eq!(property_map.get(&name), None);
+
+        property_map.insert(name.clone(), value);
+        let present_value: &BaseValue =
+            property_map.get(&name).expect("inserted property must be present");
+
+        assert_eq!(present_value, &BaseValue::IntegerValue(MapInteger(42)));
     }
 
     #[test]

--- a/shared_crates/shared_validation/src/lib.rs
+++ b/shared_crates/shared_validation/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod holon_node_envelope;
+pub mod holon_node_properties;
 // Public module, part of the crate's public API
 pub mod pvl_limits_v1;
 pub mod validation_helpers;
 
 // Re-exporting key functions/types for ease of use
 pub use holon_node_envelope::*;
+pub use holon_node_properties::*;
 pub use validation_helpers::*;
 
 pub use integrity_core_types::{PvlField, PvlMalformedReason, PvlViolation};

--- a/shared_crates/shared_validation/src/pvl_limits_v1.rs
+++ b/shared_crates/shared_validation/src/pvl_limits_v1.rs
@@ -43,12 +43,23 @@ pub fn raw_byte_len(value: &[u8]) -> usize {
     value.len()
 }
 
-/// Narrows a measured length to `u32` without wrapping.
+/// Converts a measured `usize` value to `u32` for inclusion in a bounded
+/// validation-violation report.
+///
+/// Values larger than `u32::MAX` are reported as `u32::MAX`, ensuring that
+/// constructing a violation cannot panic or wrap even for adversarially
+/// large inputs.
 pub fn saturating_u32(len: usize) -> u32 {
     u32::try_from(len).unwrap_or(u32::MAX)
 }
 
-/// Narrows a measured length to `u16` without wrapping.
+
+/// Converts a measured `usize` value to `u16` for inclusion in a bounded
+/// validation-violation report.
+///
+/// Values larger than `u16::MAX` are reported as `u16::MAX`, ensuring that
+/// constructing a violation cannot panic or wrap even for adversarially
+/// large inputs.
 pub fn saturating_u16(len: usize) -> u16 {
     u16::try_from(len).unwrap_or(u16::MAX)
 }
@@ -59,6 +70,9 @@ mod tests {
 
     #[test]
     fn limit_values_match_the_pvl_v1_contract() {
+        // These literals intentionally duplicate the published PVL v1 contract.
+        // Changing either the implementation constants or this test requires an
+        // explicit protocol-versioning decision.
         assert_eq!(MAX_HOLON_NODE_BYTES, 262_144);
         assert_eq!(MAX_PROPERTY_COUNT, 256);
         assert_eq!(MAX_PROPERTY_NAME_BYTES, 128);

--- a/shared_crates/shared_validation/src/pvl_limits_v1.rs
+++ b/shared_crates/shared_validation/src/pvl_limits_v1.rs
@@ -53,7 +53,6 @@ pub fn saturating_u32(len: usize) -> u32 {
     u32::try_from(len).unwrap_or(u32::MAX)
 }
 
-
 /// Converts a measured `usize` value to `u16` for inclusion in a bounded
 /// validation-violation report.
 ///

--- a/shared_crates/type_system/integrity_core_types/src/property.rs
+++ b/shared_crates/type_system/integrity_core_types/src/property.rs
@@ -24,5 +24,5 @@ impl fmt::Display for PropertyName {
 /// The type of a property’s value at runtime.
 pub type PropertyValue = BaseValue;
 
-/// The map from property names to optional property values.
+/// The map from property names to concrete property values.
 pub type PropertyMap = BTreeMap<PropertyName, PropertyValue>;

--- a/tests/sweetests/tests/pvl_validation_tests.rs
+++ b/tests/sweetests/tests/pvl_validation_tests.rs
@@ -9,7 +9,8 @@ use holons_prelude::prelude::*;
 use holons_test::harness::helpers::{assert_commit_rejected_with_pvl, setup_test_conductor};
 use integrity_core_types::HolonNodeModel;
 
-const EXPECTED_REJECTION: &str = "MAP-PVL-1101: property count exceeds 256";
+const EXPECTED_PROPERTY_COUNT_REJECTION: &str = "MAP-PVL-1101: property count exceeds 256";
+const EXPECTED_EMPTY_PROPERTY_NAME_REJECTION: &str = "MAP-PVL-1102: property name is empty";
 
 /// Proves that the Integrity callback's PVL message reaches the authoring
 /// conductor path without being replaced by an implicit guest-error message.
@@ -34,5 +35,21 @@ async fn rejects_holon_node_with_257_properties_using_exact_pvl_message() {
         .call_fallible::<_, Record>(&backend.cell.zome("holons"), "create_holon_node", holon_node)
         .await;
 
-    assert_commit_rejected_with_pvl(result, EXPECTED_REJECTION);
+    assert_commit_rejected_with_pvl(result, EXPECTED_PROPERTY_COUNT_REJECTION);
+}
+
+/// Proves that property-level PVL violations use the same exact authoring rejection path.
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_empty_property_name_using_exact_pvl_message() {
+    let backend = setup_test_conductor().await;
+    let property_map = [("".to_property_name(), MapString("value".to_string()).to_base_value())]
+        .into_iter()
+        .collect();
+    let holon_node = HolonNodeModel::new(None, property_map);
+    let result = backend
+        .conductor
+        .call_fallible::<_, Record>(&backend.cell.zome("holons"), "create_holon_node", holon_node)
+        .await;
+
+    assert_commit_rejected_with_pvl(result, EXPECTED_EMPTY_PROPERTY_NAME_REJECTION);
 }


### PR DESCRIPTION
## PVL PR 3 — Descriptor-Independent Property Name and Native Value Validation

Closes #601

### Summary

PR 2 bounded the serialized `HolonNode` envelope, enforced canonical msgpack encoding, and capped property count — but never looked inside individual properties. This PR adds **descriptor-independent, Class-1 native-structural** validation of each property's **name** and **native value**, so validation cost and downstream key/tag processing stay predictable without consulting descriptors or runtime/DHT state.

Implements PVL Design Spec v0.4 §§5.3 and 6.1–6.8, and PVL Impl Plan v2.4 PR 3.

This slice is almost purely additive: every `PvlViolation` variant, `MAP-PVL` code, limit constant, and measurement helper it emits already landed in PR 1. **No new error variants, no new dependencies, no guest-adapter production change** — new violations flow back through the existing `Err(violation) → HolonNodeEnvelope::Invalid` path.

### What changed

**New validator** (`shared_crates/shared_validation/src/holon_node_properties.rs`) — three lifecycle-independent helpers:

- `validate_property_name` — first-violation-wins order: empty → `EmptyPropertyName` (1102); leading/trailing whitespace → `InvalidPropertyName` (1103); control character → `InvalidPropertyName` (1103); `> 128` UTF-8 bytes → `PropertyNameTooLong` (1104). Interior non-control whitespace is permitted; names are not echoed in the violation.
- `validate_property_value` — exhaustive `match` through the `PropertyValue` alias, **no wildcard arm**: string `> 16 384 B` → 1110; empty enum token → `EmptyEnumValue` (1116); enum `> 256 B` → 1111; bytes `> 131 072 B` → 1112; integer/boolean → `Ok` (representation faults are already rejected upstream at typed decode / canonical comparison).
- `validate_holon_node_properties` — iterates the `PropertyMap` in `BTreeMap` order, name-before-value per entry.

**Pipeline wiring** (`shared_crates/shared_validation/src/holon_node_envelope.rs`) — `validate_holon_node_decoded` now runs the property stage after the count stage, preserving deterministic order: raw size → typed decode → canonical encoding → property count → per-property (name → value) in map order. Signature unchanged.

**Doc fix** (`integrity_core_types/src/property.rs`) — corrected the stale `PropertyMap` comment (`optional` → `concrete` property values).

**Tests** — pure-core unit coverage (boundaries, precedence, multibyte straddles, Unicode whitespace, NUL/control); envelope-order pins; guest-adapter representation tests proving numeric/string Boolean substitutes and overflowing/wrongly-typed integers don't survive typed decode; construction pins (`PropertyValue == BaseValue`, no present-`None`, five-variant exhaustiveness); one single-fault conductor test (empty property name → `MAP-PVL-1102`) through the real authoring path.

### Design notes

- **No wildcard match** is the primary compile-time pin: a future collection/nested/nullable `BaseValue` variant must break compilation until its PVL rule lands.
- `shared_validation` gains **no new dependency** — the validator matches through the `PropertyValue` alias (already re-exported via `integrity_core_types`); `base_types` stays a test-only dependency.
- No descriptor lookup, no validation dependencies, no new `PvlViolation ↔ SmartLink` conversions.

### Verification

- `npm run check` — pass (host + hApp `wasm32` check + web typecheck)
- `npm run fmt:check` — pass
- `npm run test:unit` — pass
- `npm run sweetest` — pass (379-holon / 12-bundle core-schema corpus still loads under the new §5.3 name rules)

`shared_validation` confirmed WASM-safe and free of `hdi`/`hdk`/`holo_hash`.

### Definition of Done

All DoD items from the issue are met — property-name rules, inclusive value boundaries, empty-enum `1116`, integer/boolean representation pinned across the raw-adapter and typed pure-core boundaries, five variants without a wildcard, deterministic test-pinned order, collection/nesting/present-`None` pins, corrected doc, no descriptor dependency, corpus loads, WASM-safety, and all four commands green.
