### PR TITLE
604 pvl pr 4 integrity visible identifier validation

### DIFF
--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -15,6 +15,12 @@ use crate::HolonNode;
 /// zome, so its index is fixed at zero. Adding or reordering app-entry
 /// definitions requires updating this constant and the associated op tests.
 const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
+
+/// Fixed structured-diagnostic reason used when exact `ActionHash` parsing fails.
+///
+/// The underlying parser error is intentionally discarded so peer-authored
+/// identifier bytes and substrate-specific error text cannot enter the
+/// consensus-visible validation message.
 const INVALID_ACTION_HASH_ENCODING: &str = "invalid ActionHash encoding";
 
 /// Outcome of attempting HolonNode envelope preparation for an operation.
@@ -117,6 +123,9 @@ fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, Pv
     if let Err(violation) = validate_holon_node_decoded(raw, &canonical, &model) {
         return Ok(Err(violation));
     }
+
+    // Exact substrate parsing follows every pure decoded-model rule so this new
+    // check cannot change the precedence of established envelope or property failures.
     if let Err(violation) = validate_holon_node_identifiers_exact(&model) {
         return Ok(Err(violation));
     }
@@ -124,7 +133,16 @@ fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, Pv
     Ok(Ok(model))
 }
 
-/// Applies substrate-specific parsing after the pure decoded-model rules have passed.
+/// Parses persisted identifier bytes as their exact Holochain hash roles.
+///
+/// The pure layer has already established that a present `original_id` has the
+/// 39-byte ActionHash shape. This adapter completes validation with
+/// [`ActionHash::try_from_raw_39`], which rejects a correctly sized value whose
+/// Holochain prefix or hash type is not valid for the `ActionHash` role.
+///
+/// `None` remains valid under the current entry model. Parse failures become a
+/// fixed [`PvlViolation::InvalidIdentifier`] rather than a `HolonError` or raw
+/// substrate error.
 fn validate_holon_node_identifiers_exact(model: &HolonNodeModel) -> Result<(), PvlViolation> {
     let Some(original_id) = &model.original_id else {
         return Ok(());

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -13,6 +13,8 @@ use crate::HolonNode;
 /// zome, so its index is fixed at zero. Adding or reordering app-entry
 /// definitions requires updating this constant and the associated op tests.
 const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
+const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
+const INVALID_ACTION_HASH_ENCODING: &str = "invalid ActionHash encoding";
 
 /// Outcome of attempting HolonNode envelope preparation for an operation.
 ///
@@ -114,8 +116,28 @@ fn run_holon_node_envelope(raw: &[u8]) -> ExternResult<Result<HolonNodeModel, Pv
     if let Err(violation) = validate_holon_node_decoded(raw, &canonical, &model) {
         return Ok(Err(violation));
     }
+    if let Err(violation) = validate_holon_node_identifiers_exact(&model) {
+        return Ok(Err(violation));
+    }
 
     Ok(Ok(model))
+}
+
+/// Applies substrate-specific parsing after the pure decoded-model rules have passed.
+fn validate_holon_node_identifiers_exact(model: &HolonNodeModel) -> Result<(), PvlViolation> {
+    let Some(original_id) = &model.original_id else {
+        return Ok(());
+    };
+
+    ActionHash::try_from_raw_39(original_id.as_bytes().to_vec()).map_err(|_| {
+        PvlViolation::InvalidIdentifier {
+            field_name: "original_id".into(),
+            identifier_kind: ACTION_HASH_LOCAL_ID_KIND.into(),
+            reason: INVALID_ACTION_HASH_ENCODING.into(),
+        }
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -137,6 +159,10 @@ mod tests {
 
     fn canonical_node(property_map: PropertyMap) -> HolonNode {
         HolonNode::new(None, property_map)
+    }
+
+    fn valid_action_hash_local_id(seed: u8) -> LocalId {
+        LocalId(ActionHash::from_raw_36(vec![seed; 36]).get_raw_39().to_vec())
     }
 
     fn run(raw: &[u8]) -> Result<HolonNodeModel, PvlViolation> {
@@ -345,7 +371,7 @@ mod tests {
                 BaseValue::EnumValue(MapEnumValue(MapString("Active".into()))),
             ),
         ]);
-        let representative = HolonNode::new(Some(LocalId(vec![7; 39])), properties);
+        let representative = HolonNode::new(Some(valid_action_hash_local_id(7)), properties);
 
         assert_eq!(
             encode(&representative).unwrap(),
@@ -379,6 +405,74 @@ mod tests {
         let raw = encode(&node).unwrap();
 
         assert_eq!(run(&raw), Ok(HolonNodeModel::from(node)));
+    }
+
+    #[test]
+    fn accepts_an_original_id_derived_from_a_real_action_hash() {
+        let node = HolonNode::new(Some(valid_action_hash_local_id(17)), PropertyMap::new());
+        let raw = encode(&node).unwrap();
+
+        assert_eq!(run(&raw), Ok(HolonNodeModel::from(node)));
+    }
+
+    #[test]
+    fn rejects_an_exact_width_original_id_with_invalid_action_hash_encoding() {
+        let node = HolonNode::new(Some(LocalId(vec![0; 39])), PropertyMap::new());
+        let model = HolonNodeModel::from(node.clone());
+        let raw = encode(&node).unwrap();
+
+        assert_eq!(
+            shared_validation::validate_holon_node_decoded(&raw, &raw, &model),
+            Ok(()),
+            "the pure layer must not interpret Holochain hash prefixes"
+        );
+        assert_eq!(
+            run(&raw),
+            Err(PvlViolation::InvalidIdentifier {
+                field_name: "original_id".into(),
+                identifier_kind: "ActionHash-shaped LocalId".into(),
+                reason: "invalid ActionHash encoding".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_width_original_ids_in_the_pure_stage() {
+        for length in [38, 40] {
+            let node = HolonNode::new(Some(LocalId(vec![0; length])), PropertyMap::new());
+            let raw = encode(&node).unwrap();
+
+            assert_eq!(
+                run(&raw),
+                Err(PvlViolation::InvalidIdentifier {
+                    field_name: "original_id".into(),
+                    identifier_kind: "ActionHash-shaped LocalId".into(),
+                    reason: "incorrect byte length".into(),
+                }),
+                "unexpected classification for {length} bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn public_envelope_maps_exact_parse_failures_for_all_five_op_forms() {
+        let node = HolonNode::new(Some(LocalId(vec![0; 39])), PropertyMap::new());
+        let raw = encode(&node).unwrap();
+        let expected = HolonNodeEnvelope::Invalid(PvlViolation::InvalidIdentifier {
+            field_name: "original_id".into(),
+            identifier_kind: "ActionHash-shaped LocalId".into(),
+            reason: "invalid ActionHash encoding".into(),
+        });
+
+        for form in HOLON_NODE_OP_FORMS {
+            let op = op_with_raw_entry(form, raw.clone());
+
+            assert_eq!(
+                prepare_holon_node_envelope(&op).unwrap(),
+                expected,
+                "{form:?} did not apply exact identifier parsing through the public seam"
+            );
+        }
     }
 
     #[test]

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -3,7 +3,9 @@
 use hdi::prelude::*;
 use holochain_serialized_bytes::{decode, encode};
 use integrity_core_types::{HolonNodeModel, PvlMalformedReason, PvlViolation};
-use shared_validation::{validate_holon_node_decoded, validate_holon_node_size};
+use shared_validation::{
+    validate_holon_node_decoded, validate_holon_node_size, ACTION_HASH_LOCAL_ID_KIND,
+};
 
 use crate::HolonNode;
 
@@ -13,7 +15,6 @@ use crate::HolonNode;
 /// zome, so its index is fixed at zero. Adding or reordering app-entry
 /// definitions requires updating this constant and the associated op tests.
 const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
-const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
 const INVALID_ACTION_HASH_ENCODING: &str = "invalid ActionHash encoding";
 
 /// Outcome of attempting HolonNode envelope preparation for an operation.

--- a/shared_crates/shared_validation/src/holon_node_envelope.rs
+++ b/shared_crates/shared_validation/src/holon_node_envelope.rs
@@ -41,8 +41,15 @@ pub fn validate_property_count(count: usize) -> Result<(), PvlViolation> {
     Ok(())
 }
 
-/// Applies decoded-model rules in consensus order: encoding, property count, properties, then
-/// identifier shape.
+/// Applies pure decoded-model rules in consensus order.
+///
+/// Validation proceeds through canonical encoding, property count, properties
+/// in `BTreeMap` order, and finally identifier byte shape. The first violation
+/// is returned, so appending identifier validation preserves the precedence of
+/// all previously established envelope and property rules.
+///
+/// Exact Holochain hash parsing is intentionally absent from this function and
+/// runs afterward in the substrate adapter.
 pub fn validate_holon_node_decoded(
     raw: &[u8],
     canonical: &[u8],
@@ -53,7 +60,6 @@ pub fn validate_holon_node_decoded(
     validate_property_count(model.property_map.len())?;
     crate::holon_node_properties::validate_holon_node_properties(&model.property_map)?;
 
-    // Storage SL2 must revisit this rule when `original_id` leaves the persisted entry shape.
     crate::identifier_validation::validate_holon_node_identifiers(model)
 }
 

--- a/shared_crates/shared_validation/src/holon_node_envelope.rs
+++ b/shared_crates/shared_validation/src/holon_node_envelope.rs
@@ -41,7 +41,8 @@ pub fn validate_property_count(count: usize) -> Result<(), PvlViolation> {
     Ok(())
 }
 
-/// Applies decoded-model rules in consensus order: encoding, property count, then properties.
+/// Applies decoded-model rules in consensus order: encoding, property count, properties, then
+/// identifier shape.
 pub fn validate_holon_node_decoded(
     raw: &[u8],
     canonical: &[u8],
@@ -50,13 +51,16 @@ pub fn validate_holon_node_decoded(
     // Check encoding first: decoding can collapse duplicate map keys and hide the malformed input.
     validate_holon_node_encoding(raw, canonical)?;
     validate_property_count(model.property_map.len())?;
-    crate::holon_node_properties::validate_holon_node_properties(&model.property_map)
+    crate::holon_node_properties::validate_holon_node_properties(&model.property_map)?;
+
+    // Storage SL2 must revisit this rule when `original_id` leaves the persisted entry shape.
+    crate::identifier_validation::validate_holon_node_identifiers(model)
 }
 
 #[cfg(test)]
 mod tests {
     use base_types::{BaseValue, MapString};
-    use integrity_core_types::{PropertyMap, PropertyName};
+    use integrity_core_types::{LocalId, PropertyMap, PropertyName};
 
     use super::*;
 
@@ -158,6 +162,54 @@ mod tests {
         assert_eq!(
             validate_holon_node_decoded(&[1, 2, 3], &[1, 2, 3], &model),
             Err(PvlViolation::TooManyProperties { actual_count: 258, max_count: 256 })
+        );
+    }
+
+    #[test]
+    fn decoded_rules_accept_an_absent_original_id() {
+        let model = HolonNodeModel::new(None, PropertyMap::new());
+
+        assert_eq!(validate_holon_node_decoded(&[1], &[1], &model), Ok(()));
+    }
+
+    #[test]
+    fn decoded_rules_apply_identifier_validation_after_existing_rules() {
+        let invalid_identifier = Some(LocalId(Vec::new()));
+        let expected_identifier_violation = PvlViolation::InvalidIdentifier {
+            field_name: "original_id".into(),
+            identifier_kind: "ActionHash-shaped LocalId".into(),
+            reason: "incorrect byte length".into(),
+        };
+
+        let empty_properties = HolonNodeModel::new(invalid_identifier.clone(), PropertyMap::new());
+        assert_eq!(
+            validate_holon_node_decoded(&[1], &[2], &empty_properties),
+            Err(PvlViolation::MalformedHolonNode {
+                reason: PvlMalformedReason::NonCanonicalEncoding,
+            })
+        );
+        assert_eq!(
+            validate_holon_node_decoded(&[1], &[1], &empty_properties),
+            Err(expected_identifier_violation.clone())
+        );
+
+        let mut too_many_properties = model_with_property_count(MAX_PROPERTY_COUNT + 1);
+        too_many_properties.original_id = invalid_identifier.clone();
+        assert_eq!(
+            validate_holon_node_decoded(&[1], &[1], &too_many_properties),
+            Err(PvlViolation::TooManyProperties { actual_count: 257, max_count: 256 })
+        );
+
+        let invalid_property = HolonNodeModel::new(
+            invalid_identifier,
+            PropertyMap::from([(
+                PropertyName(MapString(String::new())),
+                BaseValue::StringValue(MapString("value".into())),
+            )]),
+        );
+        assert_eq!(
+            validate_holon_node_decoded(&[1], &[1], &invalid_property),
+            Err(PvlViolation::EmptyPropertyName)
         );
     }
 }

--- a/shared_crates/shared_validation/src/identifier_validation.rs
+++ b/shared_crates/shared_validation/src/identifier_validation.rs
@@ -3,7 +3,9 @@
 use core_types::HOLOCHAIN_ACTION_HASH_BYTES;
 use integrity_core_types::{HolonNodeModel, LocalId, PvlViolation};
 
-const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
+/// Consensus-pinned `identifier_kind` shared by the pure shape rule and the substrate adapter's
+/// exact-parse rule for the same field.
+pub const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
 const INCORRECT_BYTE_LENGTH: &str = "incorrect byte length";
 
 /// Validates the pure, substrate-independent shape of an ActionHash-shaped `LocalId`.

--- a/shared_crates/shared_validation/src/identifier_validation.rs
+++ b/shared_crates/shared_validation/src/identifier_validation.rs
@@ -1,14 +1,36 @@
-//! Descriptor-independent validation for Integrity-visible native identifiers.
+//! Pure, descriptor-independent validation for Integrity-visible native identifiers.
+//!
+//! This module owns the role and byte-shape checks that can be expressed over
+//! `integrity_core_types` without importing Holochain. For hash-shaped identifiers,
+//! the pure layer verifies the expected native width; `holons_guest_integrity`
+//! completes the contract by parsing the bytes as the exact Holochain hash type.
+//!
+//! Keeping those responsibilities separate makes these helpers reusable by
+//! coordinator preflight while preserving `shared_validation` as a WASM-safe,
+//! substrate-independent crate.
 
 use core_types::HOLOCHAIN_ACTION_HASH_BYTES;
 use integrity_core_types::{HolonNodeModel, LocalId, PvlViolation};
 
-/// Consensus-pinned `identifier_kind` shared by the pure shape rule and the substrate adapter's
-/// exact-parse rule for the same field.
+/// Fixed structured-diagnostic token for an ActionHash-shaped `LocalId`.
+///
+/// The pure shape rule and Holochain substrate adapter share this value so both
+/// layers classify failures as the same identifier role.
 pub const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
+
+/// Fixed structured-diagnostic reason for a value with the wrong native width.
 const INCORRECT_BYTE_LENGTH: &str = "incorrect byte length";
 
-/// Validates the pure, substrate-independent shape of an ActionHash-shaped `LocalId`.
+/// Validates the native byte shape required of an ActionHash-shaped `LocalId`.
+///
+/// This pure rule requires exactly [`HOLOCHAIN_ACTION_HASH_BYTES`] bytes but
+/// deliberately does not interpret Holochain prefixes or hash types. Exact
+/// `ActionHash` parsing belongs to the substrate adapter.
+///
+/// Every width mismatch, including an empty or oversized value, is classified
+/// as [`PvlViolation::InvalidIdentifier`]. `EmptyIdentifier` and
+/// `IdentifierTooLong` apply to opaque bounded identifiers, not to a
+/// role-specific hash with one exact native shape.
 pub fn validate_action_hash_local_id(
     field_name: &str,
     local_id: &LocalId,
@@ -24,7 +46,12 @@ pub fn validate_action_hash_local_id(
     Ok(())
 }
 
-/// Validates the identifier fields currently persisted in a `HolonNodeModel`.
+/// Validates identifier fields currently persisted in a [`HolonNodeModel`].
+///
+/// The current entry model permits an absent `original_id`. When present, the
+/// field is an ActionHash-shaped `LocalId` and must pass the pure byte-shape
+/// rule. Storage SL2 must revisit this orchestration when `original_id` leaves
+/// the persisted entry shape.
 pub fn validate_holon_node_identifiers(model: &HolonNodeModel) -> Result<(), PvlViolation> {
     if let Some(original_id) = &model.original_id {
         validate_action_hash_local_id("original_id", original_id)?;

--- a/shared_crates/shared_validation/src/identifier_validation.rs
+++ b/shared_crates/shared_validation/src/identifier_validation.rs
@@ -1,0 +1,83 @@
+//! Descriptor-independent validation for Integrity-visible native identifiers.
+
+use core_types::HOLOCHAIN_ACTION_HASH_BYTES;
+use integrity_core_types::{HolonNodeModel, LocalId, PvlViolation};
+
+const ACTION_HASH_LOCAL_ID_KIND: &str = "ActionHash-shaped LocalId";
+const INCORRECT_BYTE_LENGTH: &str = "incorrect byte length";
+
+/// Validates the pure, substrate-independent shape of an ActionHash-shaped `LocalId`.
+pub fn validate_action_hash_local_id(
+    field_name: &str,
+    local_id: &LocalId,
+) -> Result<(), PvlViolation> {
+    if local_id.as_bytes().len() != HOLOCHAIN_ACTION_HASH_BYTES {
+        return Err(PvlViolation::InvalidIdentifier {
+            field_name: field_name.into(),
+            identifier_kind: ACTION_HASH_LOCAL_ID_KIND.into(),
+            reason: INCORRECT_BYTE_LENGTH.into(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates the identifier fields currently persisted in a `HolonNodeModel`.
+pub fn validate_holon_node_identifiers(model: &HolonNodeModel) -> Result<(), PvlViolation> {
+    if let Some(original_id) = &model.original_id {
+        validate_action_hash_local_id("original_id", original_id)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use integrity_core_types::PropertyMap;
+
+    use super::*;
+
+    fn expected_invalid_original_id() -> PvlViolation {
+        PvlViolation::InvalidIdentifier {
+            field_name: "original_id".into(),
+            identifier_kind: "ActionHash-shaped LocalId".into(),
+            reason: "incorrect byte length".into(),
+        }
+    }
+
+    #[test]
+    fn absent_original_id_is_valid() {
+        let model = HolonNodeModel::new(None, PropertyMap::new());
+
+        assert_eq!(validate_holon_node_identifiers(&model), Ok(()));
+    }
+
+    #[test]
+    fn exact_action_hash_width_is_accepted_without_interpreting_the_bytes() {
+        let local_id = LocalId(vec![0; HOLOCHAIN_ACTION_HASH_BYTES]);
+
+        assert_eq!(validate_action_hash_local_id("original_id", &local_id), Ok(()));
+    }
+
+    #[test]
+    fn every_action_hash_length_mismatch_is_an_invalid_identifier() {
+        for length in [0, 38, 40, 4_096] {
+            let local_id = LocalId(vec![0; length]);
+
+            assert_eq!(
+                validate_action_hash_local_id("original_id", &local_id),
+                Err(expected_invalid_original_id()),
+                "unexpected classification for {length} bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_identifier_uses_the_stable_consensus_code_and_message() {
+        let violation = validate_action_hash_local_id("original_id", &LocalId(Vec::new()))
+            .expect_err("an empty ActionHash-shaped LocalId must be rejected");
+
+        assert_eq!(violation.code(), "MAP-PVL-1201");
+        assert_eq!(violation.to_string(), "MAP-PVL-1201: identifier is invalid");
+    }
+}

--- a/shared_crates/shared_validation/src/lib.rs
+++ b/shared_crates/shared_validation/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod holon_node_envelope;
 pub mod holon_node_properties;
+pub mod identifier_validation;
 // Public module, part of the crate's public API
 pub mod pvl_limits_v1;
 pub mod validation_helpers;
@@ -7,6 +8,7 @@ pub mod validation_helpers;
 // Re-exporting key functions/types for ease of use
 pub use holon_node_envelope::*;
 pub use holon_node_properties::*;
+pub use identifier_validation::*;
 pub use validation_helpers::*;
 
 pub use integrity_core_types::{PvlField, PvlMalformedReason, PvlViolation};


### PR DESCRIPTION
## Summary

Closes #604.

Adds two-layer validation for the Integrity-visible, ActionHash-shaped `HolonNode.original_id`:

- Pure validation requires exactly 39 bytes without depending on Holochain.
- The guest adapter performs exact `ActionHash::try_from_raw_39` parsing.
- All malformed values are reported as `InvalidIdentifier` (`MAP-PVL-1201`).
- Existing envelope and property violation precedence is preserved.

## Changes

- Added reusable identifier validation to `shared_validation`.
- Extended decoded `HolonNode` validation after existing property rules.
- Added exact Holochain parsing in `holons_guest_integrity`.
- Updated success fixtures to use bytes from typed `ActionHash` values.
- Added coverage for:
  - absent identifiers
  - empty, short, long, and substantially oversized identifiers
  - valid typed ActionHash bytes
  - exact-width values with invalid Holochain encoding
  - stable diagnostic fields and error code
  - existing first-violation ordering
  - all five HolonNode operation forms
- Expanded documentation around the pure-core/substrate-adapter boundary, validation ordering, diagnostic classification, and the future Storage SL2 transition.

## Architecture

`shared_validation` remains substrate-independent and free of `hdi`, `hdk`, and `holo_hash`. It validates only the role-specific byte shape.

Exact Holochain parsing remains in `holons_guest_integrity`. Low-level parser errors and rejected identifier bytes are not exposed in consensus-visible messages.

This PR does not introduce `RemoteObjectId`, SmartLink endpoint validation, lifecycle validation, descriptor lookup, or Storage SL2 entry-shape changes.

## Validation

Passed:

- `npm run check`
- `npm run fmt:check`
- `npm run test:unit`
- `npm run sweetest`
- Focused shared-validation and guest-adapter tests
- Rustdoc generation

The existing 379-holon, 12-bundle core-schema corpus continues to load successfully.

## Integrity impact

This tightens peer acceptance for persisted `HolonNode.original_id` values and therefore changes Integrity semantics and the DNA hash. Fresh test state is required.