### PR TITLE
594 storage sl1 part 2 smartlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.0"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe639324ff99c3bf32144aaf79dc7e048305a6e82b6409644ddcbe7e0f5f5be9"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
  "pkcs8 0.11.0-rc.11",
  "serde",
@@ -1776,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.1",
- "ed25519 3.0.0-rc.0",
+ "ed25519 3.0.0-rc.4",
  "rand_core 0.9.5",
  "serde",
  "sha2 0.11.0-rc.2",
@@ -1811,15 +1811,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "enum-as-inner"
@@ -2007,15 +1998,15 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixt"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2072a540403c9f1c5520c1543820a3e96cf42bb20dbc9380efc7439bda465234"
+checksum = "bb9eece564689517be071462896acb16ebfdbadbff7c1182cfcd2d1193ab5a7b"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
  "parking_lot",
  "paste",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "strum",
  "strum_macros",
@@ -2060,21 +2051,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2464,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df74665942cd911ca26245b3a68c783eef902018d41994e3192660fd9b157e0c"
+checksum = "8fb0f48cc3fbb36f2542a9f5358024f9ac7d1b5d64582be5bd5e649b8deba358"
 dependencies = [
  "getrandom 0.3.4",
  "hdk_derive",
@@ -2484,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccd037e53cd05e518f66b839f0a57cda156a55dca0599bb1a4518ec371da801"
+checksum = "d385c2798822971e6114be5de3b53165467bfdc749e81bcec7f6eb69e1e7180b"
 dependencies = [
  "getrandom 0.3.4",
  "hdi",
@@ -2502,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21166508c997b6a767734116f05dd0b1d9511883def0f729f2cf97d12ae18839"
+checksum = "24f94a605cb41204b28013ec1d77d4c201aeede99c9043152d0f4caca5a30a44"
 dependencies = [
  "darling 0.21.3",
  "heck",
@@ -2573,7 +2549,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "rustls",
  "thiserror 2.0.18",
@@ -2597,7 +2573,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2618,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e08d69f8af5042aa369b7fda3d9bea7ffe08de680aa9f897c29e50de0e2460c"
+checksum = "17d79d5b437fb77ad4fa3ef0de5429af5da031de4486050d49d34fcd16c14f46"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -2635,7 +2611,7 @@ dependencies = [
  "must_future",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rusqlite",
  "schemars 0.9.0",
  "serde",
@@ -2646,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c36cbc0bb0df94f87dee0fae2e2669021438b6056f2166567d338c4ed3c0604"
+checksum = "e1f14229ce2a3099ca144037af76161492e72b3da99afe097c216e5a95d9a647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2707,7 +2683,7 @@ dependencies = [
  "opentelemetry 0.31.0",
  "parking_lot",
  "petgraph",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand-utf8",
  "rusqlite",
  "rustls",
@@ -2740,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d15f1403074b434eb54ac949a28c7bd4862459b72ac9e8110eca5ecbc6099b"
+checksum = "1a5e7f2cbf1e4367c7093abf394e3fefc91e5f8c5223629ea3654a0b90df0491"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2768,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_chc"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8aad951e06db15317635a7473f5586e1e07e517177c937176b45911e6f8c7d2"
+checksum = "2b1d1e6504d568805fff64e020454c65111082dc1a005cad60579054f481099f"
 dependencies = [
  "async-trait",
  "derive_more 2.1.1",
@@ -2795,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_client"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12e63a81cfa7437ab86b12296caa2e580255bc89e073c6fc0a67da6bbf13b46"
+checksum = "2e15a3b7b1e20f8eee1ad0b87447bdcd2a3386e34ba050789bc0f5b3f05fa6be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2820,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2171e5a597a95f1e8f4a69ecc84c3daa7410b9c42e421c5e6888b77260ef84"
+checksum = "06148ae3513e44f926b259d3700d16195cff671db73c7144753336111f2d95ee"
 dependencies = [
  "derive_more 2.1.1",
  "holo_hash",
@@ -2848,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_config"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1fe3854a18a5263d38f07db9cbc56fe4df407f8b0513bae3052e0db03fccbf"
+checksum = "a77607e469cd7e7347f5a15fc18c0c5d83accf167c06f7a4362cf41a336e7e8c"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2866,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fef817394dab4d006be7a24fb0e322db32b0060c949ee05a96df02b8eef508"
+checksum = "fe4f6adefd52753b0f429f135327ad271c4edb9dd65ea0b3fbaff400d3324bf8"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -2888,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e132243778f35e9bd067e61a24965b328048130ef8d1068d2e6ed1fb358f2a"
+checksum = "adf54cd12d3d05c4f98f5a8c7c50af75ecbaa4c93376dd0bf0509ff2611f9bcc"
 dependencies = [
  "base64",
  "derive_more 2.1.1",
@@ -2918,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7c318b909b9d983b5b759068e26a67486ded19f58fad2c9f10515b9ff82bc5"
+checksum = "b43ae809fcab9f770c4f15d7b155ce26cec8085008ed4f8d1233ff9a41fd5e9d"
 dependencies = [
  "digest 0.10.7",
  "dirs",
@@ -2944,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf25c0d084ff290a8650c2fc82bd4341fc25d0d5f7ffe9af63a2ca9d50d9f0f"
+checksum = "fd3f2687d00c359a32d61ef8a1bc8406ecd188c1a7a8cc07e58437a4dd812452"
 dependencies = [
  "getrandom 0.3.4",
  "holochain_secure_primitive",
@@ -2955,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36a53a8b4b2886dc1d7bac3e440dcf5fbd851c2a428d06d644955a0ba90b1ea"
+checksum = "17293bf2d18c6357dd9256c0a6aefa6b8faaa559583f3cfb7d3a8bf707449a00"
 dependencies = [
  "async-trait",
  "base64",
@@ -2983,7 +2959,7 @@ dependencies = [
  "mockall",
  "opentelemetry 0.31.0",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3022,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c794f7bd4abe9b687cc98483bbeeb83d87771073218ce52ae67c871a6d15fa4"
+checksum = "07e164e2f642890cd988684b66fb5c0d3289a1c2157e70e2fd06db0e67bfda63"
 dependencies = [
  "paste",
  "serde",
@@ -3061,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0e2ce26b0d9e14766fc7d07a55fb4b9b6df674ca2e171a2b0a1f287d7912d"
+checksum = "852834e55efd0b319dbba12579d3b48bd233cdba85da80585ade24c8c6e395b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3103,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4908a1a09cd671039083d90c4ec2670b8d1115e95ad1ace7a7433ea0fcf1d348"
+checksum = "c60c1132695905254729b7efc80d00f5c28935e5c0e55f3e8e0c22c2bb82619d"
 dependencies = [
  "async-recursion",
  "base64",
@@ -3138,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3459395b62c34bb6bd29792e637eca5375bb5278d3cde1a74765148164d688d"
+checksum = "a7dc5a9c47c823f401e1322f2614a98f8f0fe6340d0b10fe4dce931b4565341f"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3149,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e117da4f46ba37969ccc15ec877c42195eb70a47ed82eda25d561364e2421d0"
+checksum = "c69d69da70592d0be242a0fbbaa73d5b8f9c8825510604ffbf8dabb530cf334f"
 dependencies = [
  "hdk",
  "holochain_serialized_bytes",
@@ -3160,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a201a7ae0e181ac157c605f9335fdb4a0ddce5e4b6a5540ec9f77c5174feb073"
+checksum = "1d38bb99d11feebbaaecb3cb22c1aa4f3c8b368106c2a58256eb811049794a7f"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3171,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46c5fcf4d991746bc7fb232089dba407ede546d1a251c362f41713fbf970368"
+checksum = "acf81766956cdd9854328a81cab59ba171f66cf828876e3963025c6c2bc1e2be"
 dependencies = [
  "chrono",
  "derive_more 2.1.1",
@@ -3188,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad7154c407fb1fb8432ca2aa68f77ad492ce95446644b76ea1ed50982d28624"
+checksum = "3354a903d27b7398fa57481dbf9762b7a5c13d4b4d4ae9843308f6789546b0fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3221,7 +3197,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "rusqlite",
  "schemars 0.9.0",
@@ -3241,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df26e438014aa7ca3430d33893cdd9d30b252eeece880fd36222a9a4dd0bb2d3"
+checksum = "7f321976d306fbb3f43dbe9a1245d871556d880a98defb112902fcb8b8404517"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3259,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330d285c2eb2e0dc4a70473db4edeeae47bb4bf724c844a07ec28fccb5a64905"
+checksum = "d55b9b34ee36494ef270f11695397bc6070fa2f229dcef937f82a9886b8d8606"
 dependencies = [
  "holochain_types",
  "strum",
@@ -3316,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9270dd262e42361253b3bf92bf0234ab81f14ce88198266c8dcd89ada3987d60"
+checksum = "3fcc6676d88b6de875934872575f4ed6b3a9ce5966f1788e3b0c1ca9323c842f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3335,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a27bd154f022c9eabae7fde1b44bd9b0f5d68005bdb43f5553d4e840824b54"
+checksum = "dc4ea07fc84d728f584523e7b1cf16312da9cc9e26c4835384d30348b10ea032"
 dependencies = [
  "contrafact",
  "derive_builder",
@@ -3353,7 +3329,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rusqlite",
  "schemars 0.9.0",
  "serde",
@@ -3532,7 +3508,6 @@ dependencies = [
  "core_types",
  "derive-new",
  "digest 0.11.0-rc.3",
- "ed25519 3.0.0-rc.0",
  "holochain",
  "holochain_state",
  "holon_dance_builders",
@@ -3547,7 +3522,6 @@ dependencies = [
  "map_commands_runtime",
  "pkcs8 0.11.0-rc.11",
  "pretty_assertions",
- "rand 0.9.4",
  "rstest",
  "serde",
  "sha1 0.11.0-rc.2",
@@ -3688,22 +3662,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3885,7 +3843,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "tokio",
  "url",
  "xmltree",
@@ -4084,7 +4042,7 @@ dependencies = [
  "pkarr",
  "pkcs8 0.11.0-rc.11",
  "portmapper",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "rustls",
  "rustls-pki-types",
@@ -4222,7 +4180,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "postcard",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen 0.14.8",
  "reloadable-state",
  "reqwest 0.12.28",
@@ -4279,7 +4237,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "postcard",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "rustls",
  "rustls-pki-types",
@@ -5074,9 +5032,9 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54d0e8bb2a647c396b1a76bcbee7173fda0eafdaa630fe64f8f45defd00ca8e"
+checksum = "64d93dc65d29bd5fc05c0978a166048e330f56f948f46c526e1d5d8c2a4fb4af"
 dependencies = [
  "bytes",
  "dunce",
@@ -5180,23 +5138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.6",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -5584,31 +5525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5675,7 +5591,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.31.0",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
 ]
 
@@ -5905,7 +5821,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "smallvec",
  "socket2 0.6.3",
@@ -6086,7 +6002,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -6245,7 +6161,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6368,9 +6284,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6382,7 +6298,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bae41c9941c4969a9b9a054378451feff4fee65e8b8679ea3bed267ae36b9b"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -6752,21 +6668,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6777,7 +6688,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -8184,16 +8094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8294,7 +8194,7 @@ dependencies = [
  "getrandom 0.3.4",
  "http",
  "httparse",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "rustls-pki-types",
  "simdutf8",
@@ -8577,7 +8477,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
@@ -8594,7 +8494,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -8789,7 +8689,7 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde_core",
  "uuid-rng-internal",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.4",
  "rstest",
+ "serde",
  "sha1 0.11.0-rc.2",
  "sha2 0.11.0-rc.2",
  "tokio",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1778106249,
-        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
+        "lastModified": 1784564969,
+        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
+        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1778884165,
-        "narHash": "sha256-3ANE+PjAGqF5SE59L8ZWLBwD0WxEBik/nWct9c9rSvE=",
+        "lastModified": 1784725594,
+        "narHash": "sha256-V8x4UJhnVounU2YzhV848A9deMRRFbkFBIi1LGiLtP4=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "c51df16be0498bd499fd0c82445d6cadadd7ccb4",
+        "rev": "b3aa80e81c51ea7e2cec0bc55be818e448b117a9",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.601.1",
+        "ref": "v0.603.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -53,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1778596880,
-        "narHash": "sha256-uUJZkeqBAZgXtDf0juCRpKOUO3yY1gWEKWGqatWcVjY=",
+        "lastModified": 1784126313,
+        "narHash": "sha256-+aktpWs+Ljzk38qaKvgIDrSHFbplGMUlOONUReJ9kmo=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "3bdeaccd1c54fa351e76f7347601dfbc061d5bd4",
+        "rev": "448a36efe8c4a95b7f3c6ccca9858d8275ed0a71",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.1",
+        "ref": "holochain-0.6.3",
         "repo": "holochain",
         "type": "github"
       }
@@ -79,11 +79,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778884233,
-        "narHash": "sha256-qDQMAQwQm6ZBL+hYejJU0p0GO7aP/UwVwto61jC5QYc=",
+        "lastModified": 1784734039,
+        "narHash": "sha256-MnFKKM4re0PDFCOEFnhoK60WeT4KbPL4/i5p+C1mZvI=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "5e41693a5f4451e93be1c347a5dd9dafd5e216e5",
+        "rev": "21d3a9f3eb1d7a533fc816ab53825f3ef35b0007",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778430510,
-        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778728594,
-        "narHash": "sha256-+gIOsOzqWNfn+ThCXBQGcLHVEnaGQW59XjghE9JUIYk=",
+        "lastModified": 1784697913,
+        "narHash": "sha256-DK+AmC9SQ9hmOFNIMu1l05gJtsmKyYsfJnuFtt1TnAU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "83a17ebffcfacb17b49e1b5e9dc15eed07936648",
+        "rev": "47759faaddf38fadaf172151ca9df8adae9c0b2e",
         "type": "github"
       },
       "original": {

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hdi"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df74665942cd911ca26245b3a68c783eef902018d41994e3192660fd9b157e0c"
+checksum = "8fb0f48cc3fbb36f2542a9f5358024f9ac7d1b5d64582be5bd5e649b8deba358"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccd037e53cd05e518f66b839f0a57cda156a55dca0599bb1a4518ec371da801"
+checksum = "d385c2798822971e6114be5de3b53165467bfdc749e81bcec7f6eb69e1e7180b"
 dependencies = [
  "getrandom",
  "hdi",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21166508c997b6a767734116f05dd0b1d9511883def0f729f2cf97d12ae18839"
+checksum = "24f94a605cb41204b28013ec1d77d4c201aeede99c9043152d0f4caca5a30a44"
 dependencies = [
  "darling",
  "heck",
@@ -502,9 +502,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e08d69f8af5042aa369b7fda3d9bea7ffe08de680aa9f897c29e50de0e2460c"
+checksum = "17d79d5b437fb77ad4fa3ef0de5429af5da031de4486050d49d34fcd16c14f46"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fef817394dab4d006be7a24fb0e322db32b0060c949ee05a96df02b8eef508"
+checksum = "fe4f6adefd52753b0f429f135327ad271c4edb9dd65ea0b3fbaff400d3324bf8"
 dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf25c0d084ff290a8650c2fc82bd4341fc25d0d5f7ffe9af63a2ca9d50d9f0f"
+checksum = "fd3f2687d00c359a32d61ef8a1bc8406ecd188c1a7a8cc07e58437a4dd812452"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c794f7bd4abe9b687cc98483bbeeb83d87771073218ce52ae67c871a6d15fa4"
+checksum = "07e164e2f642890cd988684b66fb5c0d3289a1c2157e70e2fd06db0e67bfda63"
 dependencies = [
  "paste",
  "serde",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a201a7ae0e181ac157c605f9335fdb4a0ddce5e4b6a5540ec9f77c5174feb073"
+checksum = "1d38bb99d11feebbaaecb3cb22c1aa4f3c8b368106c2a58256eb811049794a7f"
 dependencies = [
  "chrono",
  "serde",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df26e438014aa7ca3430d33893cdd9d30b252eeece880fd36222a9a4dd0bb2d3"
+checksum = "7f321976d306fbb3f43dbe9a1245d871556d880a98defb112902fcb8b8404517"
 dependencies = [
  "cfg-if",
  "colored",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a27bd154f022c9eabae7fde1b44bd9b0f5d68005bdb43f5553d4e840824b54"
+checksum = "dc4ea07fc84d728f584523e7b1cf16312da9cc9e26c4835384d30348b10ea032"
 dependencies = [
  "derive_more",
  "holo_hash",

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -3,8 +3,9 @@ use holons_guest_integrity::type_conversions::*;
 use holons_guest_integrity::HolonNode;
 use std::sync::{Arc, RwLock};
 
-use crate::guest_shared_objects::{save_smartlink, SmartLink};
+use crate::guest_shared_objects::save_smartlink;
 use crate::persistence_layer::create_holon_node;
+use core_types::PreparedSmartLink;
 
 use holons_core::{
     core_shared_objects::{
@@ -573,30 +574,30 @@ fn save_smartlinks_for_collection(
     for (target_index, resolved_target) in resolved_targets.iter().enumerate() {
         // Persist both directions from one resolved endpoint pair so the forward
         // and inverse SmartLinks stay anchored to the same committed source.
-        let forward_smartlink = SmartLink {
-            smartlink_id: None,
-            from_address: source_id.clone(),
-            to_address: HolonId::Local(resolved_target.target_local_id.clone()),
+        let forward_smartlink = PreparedSmartLink {
+            source_id: source_id.clone(),
+            target_id: HolonId::Local(resolved_target.target_local_id.clone()),
             relationship_name: name.clone(),
             canonical_key: canonical_key_from_optional_key(resolved_target.target_key.clone())?,
+            occurrence_id: None,
             relationship_property_values: PropertyMap::new(),
-            target_property_values: PropertyMap::new(),
+            target_property_cache_candidates: Vec::new(),
         };
 
         debug!(
             "saving smartlink (idx={}): relationship={:?}, source={:?}, target={:?}",
-            target_index, name.0 .0, source_id, forward_smartlink.to_address
+            target_index, name.0 .0, source_id, forward_smartlink.target_id
         );
         save_smartlink(forward_smartlink)?;
 
-        let inverse_smartlink = SmartLink {
-            smartlink_id: None,
-            from_address: resolved_target.target_local_id.clone(),
-            to_address: HolonId::Local(source_id.clone()),
+        let inverse_smartlink = PreparedSmartLink {
+            source_id: resolved_target.target_local_id.clone(),
+            target_id: HolonId::Local(source_id.clone()),
             relationship_name: inverse_name.clone(),
             canonical_key: inverse_canonical_key.clone(),
+            occurrence_id: None,
             relationship_property_values: PropertyMap::new(),
-            target_property_values: PropertyMap::new(),
+            target_property_cache_candidates: Vec::new(),
         };
 
         debug!(

--- a/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
@@ -61,16 +61,25 @@ pub fn get_relationship_links(
 
 /// Facade shim: persists a SmartLink and returns its create-link action hash.
 ///
-/// Delegates to the storage-layer `put_smartlink`. The physical id is returned for
-/// every outcome so the pre-#594 return contract (an `ActionHash`) is preserved; a
-/// `Conflict` is surfaced as a warning rather than an error, since the commit path
-/// never produces one (stable canonical key, empty relationship properties).
+/// Delegates to the storage-layer `put_smartlink`. `Inserted` / `AlreadyPresent`
+/// return the physical id (preserving the pre-#594 `ActionHash` return contract). A
+/// `Conflict` is surfaced as a **hard error**: a live link already shares this
+/// insertion identity but differs in canonical key or authoritative relationship
+/// properties, so the requested SmartLink was *not* persisted. Returning success
+/// there would let commit Pass 2 continue as if it had been — and legacy DHT rows
+/// (the old dedup matched only exact tag bytes) can genuinely be in that state.
 pub fn save_smartlink(prepared: PreparedSmartLink) -> Result<ActionHash, HolonError> {
+    let source_id = prepared.source_id.clone();
+    let target_id = prepared.target_id.clone();
+    let relationship_name = prepared.relationship_name.clone();
     let smartlink_id = match put_smartlink(prepared)? {
         PutSmartLinkOutcome::Inserted(id) | PutSmartLinkOutcome::AlreadyPresent(id) => id,
-        PutSmartLinkOutcome::Conflict(id) => {
-            warn!("put_smartlink reported Conflict for existing SmartLink {:?}", id);
-            id
+        PutSmartLinkOutcome::Conflict(existing) => {
+            return Err(HolonError::CommitFailure(format!(
+                "SmartLink conflict: a live link {existing:?} already shares the insertion identity \
+                 (source={source_id:?}, target={target_id:?}, relationship={relationship_name:?}) \
+                 but differs in canonical key or relationship properties; requested link not persisted"
+            )));
         }
     };
     try_action_hash_from_local_id(&smartlink_id.0)

--- a/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/smartlink_adapter.rs
@@ -1,40 +1,21 @@
-use base_types::MapString;
-use core_types::{
-    decode_smartlink_tag, encode_smartlink_tag, smartlink_relationship_prefix, CanonicalKey,
-    HolonError, HolonId, SmartLinkId, SmartLinkTagInput, TargetPropertyCacheCandidate,
-};
-use hdi::prelude::*;
+//! Temporary coordinator-facing SmartLink facade.
+//!
+//! Storage SL1 Part 2 (#594) moved the real read/write/delete logic into
+//! `persistence_layer::smartlink`. These functions are thin, behavior-preserving
+//! shims kept until the facade is retired in SL4. They exist only so existing
+//! callers keep compiling against the same surface.
+
+use core_types::{HolonError, HolonId, PreparedSmartLink, PutSmartLinkOutcome};
 use hdk::prelude::*;
 use holons_guest_integrity::type_conversions::*;
 use holons_integrity::LinkTypes;
-use integrity_core_types::{LocalId, PropertyMap, RelationshipName};
+use integrity_core_types::{LocalId, RelationshipName};
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct SmartLink {
-    pub smartlink_id: Option<SmartLinkId>,
-    pub from_address: LocalId,
-    pub to_address: HolonId,
-    pub relationship_name: RelationshipName,
-    pub canonical_key: CanonicalKey,
-    pub relationship_property_values: PropertyMap,
-    pub target_property_values: PropertyMap,
-}
+use crate::persistence_layer::{expand_all_from_source, expand_from_source, put_smartlink};
 
-impl SmartLink {
-    pub fn key(&self) -> Result<Option<MapString>, HolonError> {
-        Ok((!self.canonical_key.as_str().is_empty())
-            .then(|| MapString(self.canonical_key.as_str().to_string())))
-    }
-
-    /// Returns the persisted target identity and any cached smart properties.
-    /// This is context-free and does not mint runtime references.
-    pub fn to_pointer(&self) -> (HolonId, Option<PropertyMap>) {
-        (
-            self.to_address.clone(),
-            (!self.target_property_values.is_empty()).then(|| self.target_property_values.clone()),
-        )
-    }
-}
+/// The canonical decoded SmartLink now lives in `core_types`; re-export it so the
+/// pre-#594 `guest_shared_objects::SmartLink` path keeps resolving.
+pub use core_types::SmartLink;
 
 // This link query defaults on all fields; `GetStrategy::default()` performs a network fetch.
 pub fn fetch_links_to_all_holons() -> Result<Vec<HolonId>, HolonError> {
@@ -63,150 +44,34 @@ pub fn fetch_links_to_all_holons() -> Result<Vec<HolonId>, HolonError> {
     Ok(holon_ids)
 }
 
-/// Gets all SmartLinks across all relationships from the given source.
+/// Facade shim: all SmartLinks from a source across every relationship.
+/// Delegates to the storage-layer expansion API.
 pub fn get_all_relationship_links(local_source_id: &LocalId) -> Result<Vec<SmartLink>, HolonError> {
-    let base_address = try_action_hash_from_local_id(local_source_id)?;
-    let links_query = LinkQuery::try_new(base_address, LinkTypes::SmartLink)
-        .map_err(holon_error_from_wasm_error)?;
-    let links =
-        get_links(links_query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
-    let mut smartlinks = Vec::with_capacity(links.len());
-    debug!("Got {:?} links", links.len());
-
-    for link in links {
-        smartlinks
-            .push(get_smartlink_from_link(try_action_hash_from_local_id(local_source_id)?, link)?);
-    }
-
-    Ok(smartlinks)
+    expand_all_from_source(local_source_id)
 }
 
-/// Gets links for a specific relationship from this source.
+/// Facade shim: SmartLinks for a specific relationship from this source.
+/// Delegates to the storage-layer expansion API.
 pub fn get_relationship_links(
     source_action_hash: ActionHash,
     relationship_name: &RelationshipName,
 ) -> Result<Vec<SmartLink>, HolonError> {
-    debug!("Entered get_relationship_links for: {:?}", relationship_name.0.to_string());
-    let link_tag_filter = LinkTag(
-        smartlink_relationship_prefix(relationship_name)
-            .map_err(smartlink_tag_error_to_holon_error)?,
-    );
-
-    let links_query = LinkQuery::try_new(source_action_hash.clone(), LinkTypes::SmartLink)
-        .map_err(holon_error_from_wasm_error)?
-        .tag_prefix(link_tag_filter);
-    let links =
-        get_links(links_query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
-    let mut smartlinks = Vec::with_capacity(links.len());
-    debug!("Got {:?} links", links.len());
-
-    for link in links {
-        let smartlink = get_smartlink_from_link(source_action_hash.clone(), link)?;
-        debug!("Got SmartLink {:?}", smartlink);
-        smartlinks.push(smartlink);
-    }
-
-    Ok(smartlinks)
+    expand_from_source(&local_id_from_action_hash(source_action_hash), relationship_name)
 }
 
-/// Converts a Holochain Link into a SmartLink.
-fn get_smartlink_from_link(
-    source_local_hash: ActionHash,
-    link: Link,
-) -> Result<SmartLink, HolonError> {
-    let local_target = link
-        .target
-        .into_action_hash()
-        .ok_or(wasm_error!(WasmErrorInner::Guest(String::from(
-            "No action hash associated with link"
-        ))))
-        .map_err(holon_error_from_wasm_error)?;
-    let link_tag_object =
-        decode_smartlink_tag(&link.tag.into_inner(), local_id_from_action_hash(local_target))
-            .map_err(smartlink_tag_error_to_holon_error)?;
-
-    Ok(SmartLink {
-        smartlink_id: Some(SmartLinkId(local_id_from_action_hash(link.create_link_hash))),
-        from_address: local_id_from_action_hash(source_local_hash),
-        to_address: link_tag_object.target_id,
-        relationship_name: link_tag_object.relationship_name,
-        canonical_key: link_tag_object.canonical_key,
-        relationship_property_values: link_tag_object.relationship_property_values,
-        target_property_values: link_tag_object.target_property_values,
-    })
-}
-
-/// Persists a SmartLink and returns its create action hash.
+/// Facade shim: persists a SmartLink and returns its create-link action hash.
 ///
-/// An equivalent persisted link returns its canonical existing action hash instead of writing a
-/// duplicate. Deterministic selection keeps replay behavior independent of DHT query ordering.
-pub fn save_smartlink(input: SmartLink) -> Result<ActionHash, HolonError> {
-    let target_property_cache_candidates = input
-        .target_property_values
-        .iter()
-        .map(|(property_name, value)| TargetPropertyCacheCandidate {
-            property_name: property_name.clone(),
-            value: value.clone(),
-        })
-        .collect();
-    let link_tag = LinkTag(
-        encode_smartlink_tag(&SmartLinkTagInput {
-            target_id: input.to_address.clone(),
-            relationship_name: input.relationship_name.clone(),
-            canonical_key: input.canonical_key,
-            occurrence_id: None,
-            relationship_property_values: input.relationship_property_values,
-            target_property_cache_candidates,
-        })
-        .map_err(smartlink_tag_error_to_holon_error)?,
-    );
-    let source_hash = try_action_hash_from_local_id(&input.from_address)?;
-    let target_hash = try_action_hash_from_local_id(input.to_address.local_id())?;
-
-    if let Some(existing_action_hash) =
-        equivalent_smartlink_action_hash(&source_hash, &target_hash, &link_tag)?
-    {
-        debug!(
-            "SmartLink already persisted for relationship {:?} from {:?}; skipping duplicate write",
-            input.relationship_name.0 .0, input.from_address
-        );
-        return Ok(existing_action_hash);
-    }
-
-    create_link(source_hash, target_hash, LinkTypes::SmartLink, link_tag)
-        .map_err(holon_error_from_wasm_error)
-}
-
-/// Returns the canonical existing action hash for an equivalent live SmartLink.
-///
-/// The full encoded tag serves as the narrowest possible `tag_prefix` filter. Exact bytes are
-/// compared after querying because prefix filtering alone does not establish equivalence. If old
-/// data contains multiple exact matches, select the lowest `ActionHash` so replay behavior is
-/// stable regardless of DHT query ordering.
-fn equivalent_smartlink_action_hash(
-    source_hash: &ActionHash,
-    target_hash: &ActionHash,
-    link_tag: &LinkTag,
-) -> Result<Option<ActionHash>, HolonError> {
-    let links_query = LinkQuery::try_new(source_hash.clone(), LinkTypes::SmartLink)
-        .map_err(holon_error_from_wasm_error)?
-        .tag_prefix(link_tag.clone());
-    let links =
-        get_links(links_query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
-
-    Ok(links
-        .into_iter()
-        .filter(|link| {
-            link.tag == *link_tag
-                && link.target.clone().into_action_hash().as_ref() == Some(target_hash)
-        })
-        .map(|link| link.create_link_hash)
-        .min())
-}
-
-fn smartlink_tag_error_to_holon_error(error: impl std::fmt::Display) -> HolonError {
-    HolonError::InvalidWireFormat {
-        wire_type: "SmartLinkTagV1".to_string(),
-        reason: error.to_string(),
-    }
+/// Delegates to the storage-layer `put_smartlink`. The physical id is returned for
+/// every outcome so the pre-#594 return contract (an `ActionHash`) is preserved; a
+/// `Conflict` is surfaced as a warning rather than an error, since the commit path
+/// never produces one (stable canonical key, empty relationship properties).
+pub fn save_smartlink(prepared: PreparedSmartLink) -> Result<ActionHash, HolonError> {
+    let smartlink_id = match put_smartlink(prepared)? {
+        PutSmartLinkOutcome::Inserted(id) | PutSmartLinkOutcome::AlreadyPresent(id) => id,
+        PutSmartLinkOutcome::Conflict(id) => {
+            warn!("put_smartlink reported Conflict for existing SmartLink {:?}", id);
+            id
+        }
+    };
+    try_action_hash_from_local_id(&smartlink_id.0)
 }

--- a/happ/crates/holons_guest/src/persistence_layer/mod.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/mod.rs
@@ -4,8 +4,10 @@ pub mod all_holon_nodes;
 pub mod holon_node;
 pub mod saved_holon_node;
 pub mod smartlink;
+pub mod smartlink_externs;
 
 pub use all_holon_nodes::*;
 pub use holon_node::*;
 pub use saved_holon_node::*;
 pub use smartlink::*;
+pub use smartlink_externs::*;

--- a/happ/crates/holons_guest/src/persistence_layer/mod.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/mod.rs
@@ -3,7 +3,9 @@
 pub mod all_holon_nodes;
 pub mod holon_node;
 pub mod saved_holon_node;
+pub mod smartlink;
 
 pub use all_holon_nodes::*;
 pub use holon_node::*;
 pub use saved_holon_node::*;
+pub use smartlink::*;

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -121,26 +121,40 @@ pub fn put_smartlink(prepared: PreparedSmartLink) -> Result<PutSmartLinkOutcome,
 
 /// Deletes exactly the physical link named by `smartlink_id`, idempotently.
 ///
-/// HDK `delete_link` is not self-reporting, so liveness is probed via `get_details`
-/// on the create-link action: a record with no delete actions is live.
-/// Deleting one id never affects sibling live links.
+/// HDK `delete_link` is not self-reporting (a repeat delete just commits another
+/// `DeleteLink`), and a `CreateLink` action's record details do **not** track its
+/// `DeleteLink`s. Liveness is therefore established by reading the create-link
+/// action to recover its base, then checking whether the link still appears among
+/// that base's live links (`get_links` excludes deleted links). Deleting one id
+/// never affects sibling live links.
 pub fn delete_smartlink(smartlink_id: &SmartLinkId) -> Result<DeleteSmartLinkOutcome, HolonError> {
     let create_hash = try_action_hash_from_local_id(&smartlink_id.0)?;
-    let details = get_details(create_hash.clone(), GetOptions::default())
-        .map_err(holon_error_from_wasm_error)?;
-    let live = match details {
-        Some(Details::Record(record_details)) => record_details.deletes.is_empty(),
-        Some(Details::Entry(_)) => {
+
+    // Recover the base address from the create-link action (needed to test liveness).
+    let Some(record) =
+        get(create_hash.clone(), GetOptions::default()).map_err(holon_error_from_wasm_error)?
+    else {
+        return Ok(DeleteSmartLinkOutcome::AlreadyAbsent);
+    };
+    let base_address = match record.action() {
+        Action::CreateLink(create_link) => create_link.base_address.clone(),
+        _ => {
             return Err(HolonError::InvalidParameter(format!(
                 "SmartLinkId {:?} does not reference a create-link action",
                 smartlink_id
             )));
         }
-        None => false,
     };
+
+    // A link is live iff it still appears in its base's live links.
+    let query = LinkQuery::try_new(base_address, LinkTypes::SmartLink)
+        .map_err(holon_error_from_wasm_error)?;
+    let links = get_links(query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
+    let live = links.iter().any(|link| link.create_link_hash == create_hash);
     if !live {
         return Ok(DeleteSmartLinkOutcome::AlreadyAbsent);
     }
+
     delete_link(create_hash, GetOptions::default()).map_err(holon_error_from_wasm_error)?;
     Ok(DeleteSmartLinkOutcome::Deleted)
 }

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -6,7 +6,7 @@
 //! It reuses the Tag v1 codec (`core_types::smartlink`) for all encode/decode/prefix work.
 
 use core_types::{
-    decode_smartlink_tag, encode_smartlink_tag, smartlink_exact_key_prefix, smartlink_key_prefix,
+    decode_smartlink, encode_smartlink_tag, smartlink_exact_key_prefix, smartlink_key_prefix,
     smartlink_relationship_prefix, DeleteSmartLinkOutcome, HolonError, KeyMatch, PreparedSmartLink,
     PutSmartLinkOutcome, SmartLink, SmartLinkId,
 };
@@ -174,24 +174,22 @@ fn decode_query(source_id: &LocalId, query: LinkQuery) -> Result<Vec<SmartLink>,
 }
 
 /// Decodes one Holochain `Link` into a storage `SmartLink`, preserving its physical id.
+///
+/// The tag decode (and its malformed → `InvalidWireFormat`-naming-the-id mapping) lives in
+/// `core_types::decode_smartlink`; here we only extract the physical id and endpoints from the
+/// `Link` and delegate.
 fn decode_link_to_smartlink(source_id: &LocalId, link: Link) -> Result<SmartLink, HolonError> {
     let smartlink_id = SmartLinkId(local_id_from_action_hash(link.create_link_hash));
     let target = link
         .target
         .into_action_hash()
         .ok_or_else(|| malformed_link_error(&smartlink_id, "link target is not an action hash"))?;
-    let decoded = decode_smartlink_tag(&link.tag.into_inner(), local_id_from_action_hash(target))
-        .map_err(|e| malformed_link_error(&smartlink_id, e))?;
-    Ok(SmartLink {
+    decode_smartlink(
         smartlink_id,
-        from_address: source_id.clone(),
-        target_id: decoded.target_id,
-        relationship_name: decoded.relationship_name,
-        canonical_key: decoded.canonical_key,
-        occurrence_id: decoded.occurrence_id,
-        relationship_property_values: decoded.relationship_property_values,
-        target_property_values: decoded.target_property_values,
-    })
+        source_id.clone(),
+        local_id_from_action_hash(target),
+        &link.tag.into_inner(),
+    )
 }
 
 fn malformed_link_error(id: &SmartLinkId, error: impl std::fmt::Display) -> HolonError {

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -1,0 +1,195 @@
+//! Storage-layer SmartLink persistence API (Storage SL1 Part 2, Issue #594).
+//!
+//! Descriptor-unaware read/write/delete over `LinkTypes::SmartLink`. Callers supply
+//! fully-prepared inputs; this layer never resolves relationship descriptors, computes
+//! canonical keys, pairs occurrence ids, or selects target-property cache candidates.
+//! It reuses the Tag v1 codec (`core_types::smartlink`) for all encode/decode/prefix work.
+
+use core_types::{
+    decode_smartlink_tag, encode_smartlink_tag, smartlink_exact_key_prefix, smartlink_key_prefix,
+    smartlink_relationship_prefix, DeleteSmartLinkOutcome, HolonError, KeyMatch, PreparedSmartLink,
+    PutSmartLinkOutcome, SmartLink, SmartLinkId,
+};
+use hdk::prelude::*;
+use holons_guest_integrity::type_conversions::*;
+use holons_integrity::LinkTypes;
+use integrity_core_types::{LocalId, RelationshipName};
+
+// ---------------------------------------------------------------------------
+// Read: expansion
+// ---------------------------------------------------------------------------
+
+/// Returns every live SmartLink from `source_id`, across all relationships.
+///
+/// Results are unordered, unhydrated, and each preserves its physical `SmartLinkId`.
+/// If any matching live link is malformed, the whole expansion fails with
+/// `HolonError::InvalidWireFormat` naming the offending `SmartLinkId`.
+pub fn expand_all_from_source(source_id: &LocalId) -> Result<Vec<SmartLink>, HolonError> {
+    let base = try_action_hash_from_local_id(source_id)?;
+    let query =
+        LinkQuery::try_new(base, LinkTypes::SmartLink).map_err(holon_error_from_wasm_error)?;
+    decode_query(source_id, query)
+}
+
+/// Returns live SmartLinks from `source_id` filtered to a single relationship.
+pub fn expand_from_source(
+    source_id: &LocalId,
+    relationship_name: &RelationshipName,
+) -> Result<Vec<SmartLink>, HolonError> {
+    let prefix = LinkTag(smartlink_relationship_prefix(relationship_name).map_err(tag_error)?);
+    let base = try_action_hash_from_local_id(source_id)?;
+    let query = LinkQuery::try_new(base, LinkTypes::SmartLink)
+        .map_err(holon_error_from_wasm_error)?
+        .tag_prefix(prefix);
+    decode_query(source_id, query)
+}
+
+/// Returns live SmartLinks from `source_id` for a relationship, filtered by canonical
+/// key: exact match, or a non-empty starts-with prefix.
+///
+/// `StartsWith("")` is rejected with `HolonError::InvalidParameter` — an empty prefix
+/// would match every key and is never a meaningful key query.
+pub fn expand_from_source_by_key(
+    source_id: &LocalId,
+    relationship_name: &RelationshipName,
+    key_match: KeyMatch,
+) -> Result<Vec<SmartLink>, HolonError> {
+    let prefix_bytes = match &key_match {
+        KeyMatch::Exact(key) => {
+            smartlink_exact_key_prefix(relationship_name, key).map_err(tag_error)?
+        }
+        KeyMatch::StartsWith(prefix) => {
+            if prefix.as_str().is_empty() {
+                return Err(HolonError::InvalidParameter(
+                    "expand_from_source_by_key: StartsWith(\"\") is not a valid key prefix"
+                        .to_string(),
+                ));
+            }
+            smartlink_key_prefix(relationship_name, prefix).map_err(tag_error)?
+        }
+    };
+    let base = try_action_hash_from_local_id(source_id)?;
+    let query = LinkQuery::try_new(base, LinkTypes::SmartLink)
+        .map_err(holon_error_from_wasm_error)?
+        .tag_prefix(LinkTag(prefix_bytes));
+    decode_query(source_id, query)
+}
+
+// ---------------------------------------------------------------------------
+// Write: idempotent insert with conflict detection
+// ---------------------------------------------------------------------------
+
+/// Idempotently persists `prepared`, detecting semantic conflicts.
+///
+/// Insertion identity is `source + target + relationship + occurrence`. The decision
+/// compares decoded candidate fields (never raw tag bytes):
+/// - no live link shares the identity            -> create link, `Inserted`
+/// - identity + canonical key + rel props match  -> `AlreadyPresent` (target cache ignored)
+/// - identity matches but key or rel props differ -> `Conflict` (no write)
+///
+/// Never creates a second live link with an identity that already exists.
+pub fn put_smartlink(prepared: PreparedSmartLink) -> Result<PutSmartLinkOutcome, HolonError> {
+    // Candidates are filtered by relationship only — key is not part of identity, so
+    // filtering by key would hide conflicts on a differing key.
+    let candidates = expand_from_source(&prepared.source_id, &prepared.relationship_name)?;
+
+    // Among identity matches, choose the lowest SmartLinkId for replay-stable behavior
+    // independent of DHT query ordering.
+    let identity_match = candidates
+        .iter()
+        .filter(|c| c.same_identity(&prepared))
+        .min_by(|a, b| a.smartlink_id.0 .0.cmp(&b.smartlink_id.0 .0));
+
+    if let Some(existing) = identity_match {
+        if existing.is_already_present(&prepared) {
+            return Ok(PutSmartLinkOutcome::AlreadyPresent(existing.smartlink_id.clone()));
+        }
+        return Ok(PutSmartLinkOutcome::Conflict(existing.smartlink_id.clone()));
+    }
+
+    let tag = LinkTag(encode_smartlink_tag(&prepared.to_tag_input()).map_err(tag_error)?);
+    let source_hash = try_action_hash_from_local_id(&prepared.source_id)?;
+    let target_hash = try_action_hash_from_local_id(prepared.target_id.local_id())?;
+    let create_hash = create_link(source_hash, target_hash, LinkTypes::SmartLink, tag)
+        .map_err(holon_error_from_wasm_error)?;
+    Ok(PutSmartLinkOutcome::Inserted(SmartLinkId(local_id_from_action_hash(create_hash))))
+}
+
+// ---------------------------------------------------------------------------
+// Delete: exact, idempotent
+// ---------------------------------------------------------------------------
+
+/// Deletes exactly the physical link named by `smartlink_id`, idempotently.
+///
+/// HDK `delete_link` is not self-reporting, so liveness is probed via `get_details`
+/// on the create-link action: a record with no delete actions is live.
+/// Deleting one id never affects sibling live links.
+pub fn delete_smartlink(smartlink_id: &SmartLinkId) -> Result<DeleteSmartLinkOutcome, HolonError> {
+    let create_hash = try_action_hash_from_local_id(&smartlink_id.0)?;
+    let details = get_details(create_hash.clone(), GetOptions::default())
+        .map_err(holon_error_from_wasm_error)?;
+    let live = match details {
+        Some(Details::Record(record_details)) => record_details.deletes.is_empty(),
+        Some(Details::Entry(_)) => {
+            return Err(HolonError::InvalidParameter(format!(
+                "SmartLinkId {:?} does not reference a create-link action",
+                smartlink_id
+            )));
+        }
+        None => false,
+    };
+    if !live {
+        return Ok(DeleteSmartLinkOutcome::AlreadyAbsent);
+    }
+    delete_link(create_hash, GetOptions::default()).map_err(holon_error_from_wasm_error)?;
+    Ok(DeleteSmartLinkOutcome::Deleted)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Runs a prepared `LinkQuery` and decodes every live match into a `SmartLink`.
+fn decode_query(source_id: &LocalId, query: LinkQuery) -> Result<Vec<SmartLink>, HolonError> {
+    let links = get_links(query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
+    let mut out = Vec::with_capacity(links.len());
+    for link in links {
+        out.push(decode_link_to_smartlink(source_id, link)?);
+    }
+    Ok(out)
+}
+
+/// Decodes one Holochain `Link` into a storage `SmartLink`, preserving its physical id.
+fn decode_link_to_smartlink(source_id: &LocalId, link: Link) -> Result<SmartLink, HolonError> {
+    let smartlink_id = SmartLinkId(local_id_from_action_hash(link.create_link_hash));
+    let target = link
+        .target
+        .into_action_hash()
+        .ok_or_else(|| malformed_link_error(&smartlink_id, "link target is not an action hash"))?;
+    let decoded = decode_smartlink_tag(&link.tag.into_inner(), local_id_from_action_hash(target))
+        .map_err(|e| malformed_link_error(&smartlink_id, e))?;
+    Ok(SmartLink {
+        smartlink_id,
+        from_address: source_id.clone(),
+        target_id: decoded.target_id,
+        relationship_name: decoded.relationship_name,
+        canonical_key: decoded.canonical_key,
+        occurrence_id: decoded.occurrence_id,
+        relationship_property_values: decoded.relationship_property_values,
+        target_property_values: decoded.target_property_values,
+    })
+}
+
+fn malformed_link_error(id: &SmartLinkId, error: impl std::fmt::Display) -> HolonError {
+    HolonError::InvalidWireFormat {
+        wire_type: "SmartLinkTagV1".to_string(),
+        reason: format!("malformed SmartLink {:?}: {}", id, error),
+    }
+}
+
+fn tag_error(error: impl std::fmt::Display) -> HolonError {
+    HolonError::InvalidWireFormat {
+        wire_type: "SmartLinkTagV1".to_string(),
+        reason: error.to_string(),
+    }
+}

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink_externs.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink_externs.rs
@@ -1,0 +1,52 @@
+//! Zome-extern wrappers over the SmartLink storage API (Issue #594).
+//!
+//! These thin `#[hdk_extern]` shims expose the descriptor-unaware storage functions in
+//! `persistence_layer::smartlink` so they can be driven directly from a live-conductor
+//! sweettest (bypassing the dance surface). They mirror the always-present raw persistence
+//! externs in `holon_node.rs`: owned arguments, `ExternResult` returns, `HolonError` folded
+//! into `WasmError` at the boundary. Multi-argument calls take a tuple to avoid introducing
+//! a shared transport DTO — the sweettest constructs inputs from already-shared crates only.
+
+use crate::persistence_layer::smartlink::{
+    delete_smartlink, expand_all_from_source, expand_from_source, expand_from_source_by_key,
+    put_smartlink,
+};
+use core_types::{
+    DeleteSmartLinkOutcome, HolonError, KeyMatch, PreparedSmartLink, PutSmartLinkOutcome,
+    SmartLink, SmartLinkId,
+};
+use hdk::prelude::*;
+use integrity_core_types::{LocalId, RelationshipName};
+
+fn to_wasm(error: HolonError) -> WasmError {
+    wasm_error!(WasmErrorInner::Guest(error.to_string()))
+}
+
+#[hdk_extern]
+pub fn smartlink_put(prepared: PreparedSmartLink) -> ExternResult<PutSmartLinkOutcome> {
+    put_smartlink(prepared).map_err(to_wasm)
+}
+
+#[hdk_extern]
+pub fn smartlink_expand_all(source_id: LocalId) -> ExternResult<Vec<SmartLink>> {
+    expand_all_from_source(&source_id).map_err(to_wasm)
+}
+
+#[hdk_extern]
+pub fn smartlink_expand(input: (LocalId, RelationshipName)) -> ExternResult<Vec<SmartLink>> {
+    let (source_id, relationship_name) = input;
+    expand_from_source(&source_id, &relationship_name).map_err(to_wasm)
+}
+
+#[hdk_extern]
+pub fn smartlink_expand_by_key(
+    input: (LocalId, RelationshipName, KeyMatch),
+) -> ExternResult<Vec<SmartLink>> {
+    let (source_id, relationship_name, key_match) = input;
+    expand_from_source_by_key(&source_id, &relationship_name, key_match).map_err(to_wasm)
+}
+
+#[hdk_extern]
+pub fn smartlink_delete(smartlink_id: SmartLinkId) -> ExternResult<DeleteSmartLinkOutcome> {
+    delete_smartlink(&smartlink_id).map_err(to_wasm)
+}

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2175,15 +2175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if 1.0.4",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,9 +2410,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixt"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2072a540403c9f1c5520c1543820a3e96cf42bb20dbc9380efc7439bda465234"
+checksum = "bb9eece564689517be071462896acb16ebfdbadbff7c1182cfcd2d1193ab5a7b"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -2475,21 +2466,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2502,12 +2484,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -3139,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df74665942cd911ca26245b3a68c783eef902018d41994e3192660fd9b157e0c"
+checksum = "8fb0f48cc3fbb36f2542a9f5358024f9ac7d1b5d64582be5bd5e649b8deba358"
 dependencies = [
  "getrandom 0.3.4",
  "hdk_derive",
@@ -3159,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccd037e53cd05e518f66b839f0a57cda156a55dca0599bb1a4518ec371da801"
+checksum = "d385c2798822971e6114be5de3b53165467bfdc749e81bcec7f6eb69e1e7180b"
 dependencies = [
  "getrandom 0.3.4",
  "hdi",
@@ -3177,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21166508c997b6a767734116f05dd0b1d9511883def0f729f2cf97d12ae18839"
+checksum = "24f94a605cb41204b28013ec1d77d4c201aeede99c9043152d0f4caca5a30a44"
 dependencies = [
  "darling 0.21.3",
  "heck 0.5.0",
@@ -3299,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e08d69f8af5042aa369b7fda3d9bea7ffe08de680aa9f897c29e50de0e2460c"
+checksum = "17d79d5b437fb77ad4fa3ef0de5429af5da031de4486050d49d34fcd16c14f46"
 dependencies = [
  "base64 0.22.1",
  "blake2b_simd",
@@ -3325,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c36cbc0bb0df94f87dee0fae2e2669021438b6056f2166567d338c4ed3c0604"
+checksum = "e1f14229ce2a3099ca144037af76161492e72b3da99afe097c216e5a95d9a647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3409,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d15f1403074b434eb54ac949a28c7bd4862459b72ac9e8110eca5ecbc6099b"
+checksum = "1a5e7f2cbf1e4367c7093abf394e3fefc91e5f8c5223629ea3654a0b90df0491"
 dependencies = [
  "async-trait",
  "fixt",
@@ -3436,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_chc"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8aad951e06db15317635a7473f5586e1e07e517177c937176b45911e6f8c7d2"
+checksum = "2b1d1e6504d568805fff64e020454c65111082dc1a005cad60579054f481099f"
 dependencies = [
  "async-trait",
  "derive_more 2.1.1",
@@ -3462,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_client"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12e63a81cfa7437ab86b12296caa2e580255bc89e073c6fc0a67da6bbf13b46"
+checksum = "2e15a3b7b1e20f8eee1ad0b87447bdcd2a3386e34ba050789bc0f5b3f05fa6be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2171e5a597a95f1e8f4a69ecc84c3daa7410b9c42e421c5e6888b77260ef84"
+checksum = "06148ae3513e44f926b259d3700d16195cff671db73c7144753336111f2d95ee"
 dependencies = [
  "derive_more 2.1.1",
  "holo_hash",
@@ -3518,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_config"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1fe3854a18a5263d38f07db9cbc56fe4df407f8b0513bae3052e0db03fccbf"
+checksum = "a77607e469cd7e7347f5a15fc18c0c5d83accf167c06f7a4362cf41a336e7e8c"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3536,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fef817394dab4d006be7a24fb0e322db32b0060c949ee05a96df02b8eef508"
+checksum = "fe4f6adefd52753b0f429f135327ad271c4edb9dd65ea0b3fbaff400d3324bf8"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -3556,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e132243778f35e9bd067e61a24965b328048130ef8d1068d2e6ed1fb358f2a"
+checksum = "adf54cd12d3d05c4f98f5a8c7c50af75ecbaa4c93376dd0bf0509ff2611f9bcc"
 dependencies = [
  "base64 0.22.1",
  "derive_more 2.1.1",
@@ -3586,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7c318b909b9d983b5b759068e26a67486ded19f58fad2c9f10515b9ff82bc5"
+checksum = "b43ae809fcab9f770c4f15d7b155ce26cec8085008ed4f8d1233ff9a41fd5e9d"
 dependencies = [
  "digest 0.10.7",
  "dirs",
@@ -3612,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf25c0d084ff290a8650c2fc82bd4341fc25d0d5f7ffe9af63a2ca9d50d9f0f"
+checksum = "fd3f2687d00c359a32d61ef8a1bc8406ecd188c1a7a8cc07e58437a4dd812452"
 dependencies = [
  "getrandom 0.3.4",
  "holochain_secure_primitive",
@@ -3623,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36a53a8b4b2886dc1d7bac3e440dcf5fbd851c2a428d06d644955a0ba90b1ea"
+checksum = "17293bf2d18c6357dd9256c0a6aefa6b8faaa559583f3cfb7d3a8bf707449a00"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3729,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c794f7bd4abe9b687cc98483bbeeb83d87771073218ce52ae67c871a6d15fa4"
+checksum = "07e164e2f642890cd988684b66fb5c0d3289a1c2157e70e2fd06db0e67bfda63"
 dependencies = [
  "paste",
  "serde",
@@ -3765,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0e2ce26b0d9e14766fc7d07a55fb4b9b6df674ca2e171a2b0a1f287d7912d"
+checksum = "852834e55efd0b319dbba12579d3b48bd233cdba85da80585ade24c8c6e395b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4908a1a09cd671039083d90c4ec2670b8d1115e95ad1ace7a7433ea0fcf1d348"
+checksum = "c60c1132695905254729b7efc80d00f5c28935e5c0e55f3e8e0c22c2bb82619d"
 dependencies = [
  "async-recursion",
  "chrono",
@@ -3837,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3459395b62c34bb6bd29792e637eca5375bb5278d3cde1a74765148164d688d"
+checksum = "a7dc5a9c47c823f401e1322f2614a98f8f0fe6340d0b10fe4dce931b4565341f"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3848,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a201a7ae0e181ac157c605f9335fdb4a0ddce5e4b6a5540ec9f77c5174feb073"
+checksum = "1d38bb99d11feebbaaecb3cb22c1aa4f3c8b368106c2a58256eb811049794a7f"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3859,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46c5fcf4d991746bc7fb232089dba407ede546d1a251c362f41713fbf970368"
+checksum = "acf81766956cdd9854328a81cab59ba171f66cf828876e3963025c6c2bc1e2be"
 dependencies = [
  "chrono",
  "derive_more 2.1.1",
@@ -3876,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad7154c407fb1fb8432ca2aa68f77ad492ce95446644b76ea1ed50982d28624"
+checksum = "3354a903d27b7398fa57481dbf9762b7a5c13d4b4d4ae9843308f6789546b0fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3924,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df26e438014aa7ca3430d33893cdd9d30b252eeece880fd36222a9a4dd0bb2d3"
+checksum = "7f321976d306fbb3f43dbe9a1245d871556d880a98defb112902fcb8b8404517"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.4",
@@ -3984,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9270dd262e42361253b3bf92bf0234ab81f14ce88198266c8dcd89ada3987d60"
+checksum = "3fcc6676d88b6de875934872575f4ed6b3a9ce5966f1788e3b0c1ca9323c842f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4003,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a27bd154f022c9eabae7fde1b44bd9b0f5d68005bdb43f5553d4e840824b54"
+checksum = "dc4ea07fc84d728f584523e7b1cf16312da9cc9e26c4835384d30348b10ea032"
 dependencies = [
  "derive_builder",
  "derive_more 2.1.1",
@@ -4269,22 +4245,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -5826,9 +5786,9 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54d0e8bb2a647c396b1a76bcbee7173fda0eafdaa630fe64f8f45defd00ca8e"
+checksum = "64d93dc65d29bd5fc05c0978a166048e330f56f948f46c526e1d5d8c2a4fb4af"
 dependencies = [
  "bytes",
  "dunce",
@@ -5962,23 +5922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -6347,7 +6290,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -6624,32 +6567,6 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if 1.0.4",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -7323,15 +7240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.4",
 ]
 
 [[package]]
@@ -8057,21 +7965,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -8082,7 +7985,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -10008,16 +9910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10167,18 +10059,6 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
-dependencies = [
- "indexmap 2.11.1",
- "toml_datetime 0.7.0",
- "toml_parser",
  "winnow 0.7.14",
 ]
 
@@ -10394,7 +10274,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/host/conductora/plugins/tauri-plugin-holochain/holochain_runtime/Cargo.toml
+++ b/host/conductora/plugins/tauri-plugin-holochain/holochain_runtime/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 # Holochain dependencies
-holochain = { version = "0.6.1", default-features = false, features = [ "wasmer_sys", "transport-iroh", "schema" ] }
-mr_bundle = {version = "0.6.1", default-features = false }
-holochain_types = {version = "0.6.1", default-features = false }
-holochain_keystore = {version = "0.6.1", default-features = false }
-holochain_conductor_api = {version = "0.6.1", default-features = false }
-holochain_util = {version = "0.6.1", default-features = false }
+holochain = { version = "0.6", default-features = false, features = [ "wasmer_sys", "transport-iroh", "schema" ] }
+mr_bundle = {version = "0.6", default-features = false }
+holochain_types = {version = "0.6", default-features = false }
+holochain_keystore = {version = "0.6", default-features = false }
+holochain_conductor_api = {version = "0.6", default-features = false }
+holochain_util = {version = "0.6", default-features = false }
 
 #kitsune_p2p_mdns = { path = "../mdns" }
 kitsune_p2p_mdns = "*"

--- a/host/patches/README.md
+++ b/host/patches/README.md
@@ -5,6 +5,53 @@ in `host/Cargo.toml`. Each subdirectory is a full crate copy with a targeted fix
 
 ---
 
+## Status — STILL REQUIRED (re-verified 2026-07-27 against Holochain 0.6.3)
+
+**Upstream issue:** https://github.com/holochain/holochain-wasmer/issues/192 (open)
+
+| Check | Result |
+|---|---|
+| `holochain` 0.6.1 / 0.6.2 / **0.6.3** dep on `holochain_wasmer_host` | **`=0.0.102` in all three** — the exact version patched here, so this patch applies unchanged |
+| `holochain` 0.6.x dep on `wasmer` | `^6.0.1` throughout — unchanged |
+| `holochain_wasmer_host` 0.0.103 (latest) `get_from_filesystem` | **still buggy** — byte-identical to 0.0.102 |
+| `holochain/holochain-wasmer` `develop` branch | **still buggy** (`crates/host/src/module.rs:319`) |
+
+No manifest change was needed for the 0.6.3 bump. After updating, confirm the patch is still wired:
+cargo must **not** warn `Patch 'holochain_wasmer_host …' was not used in the crate graph`, and the
+`host/Cargo.lock` entry for `holochain_wasmer_host` must have **no `source = "registry+…"` line**
+(patched crates are listed with `dependencies` only).
+
+Runtime check on 2026-07-27: a cold start on Apple Silicon at 0.6.3 compiled and wrote two fresh
+entries to `/tmp/conductora_dev/<key>/wasm-cache/` with no crash — i.e. the `NotFound` → `Ok(None)`
+path executed successfully. Note this confirms the patch **works**; it is not evidence the patch is
+unnecessary. To test whether it is still load-bearing, comment out the `[patch.crates-io]` block,
+`rm -rf /tmp/conductora_dev/*/wasm-cache`, and start the app — expect a silent SIGSEGV.
+
+### Looking ahead to Holochain 0.7
+
+`holochain` 0.7.0-rc.* moves to **`holochain_wasmer_host =0.0.103`** and **`wasmer =7.1.0`**. Both
+halves of the bug survive that bump:
+
+- 0.0.103's `get_from_filesystem` is unchanged from 0.0.102.
+- `wasmer-compiler` 7.1.0 still captures a backtrace unconditionally on the user-error arm —
+  `Trap::User(_err) => (wasm_trace(&info, None, &Backtrace::new_unresolved()), None)` in
+  `src/engine/trap/stack.rs`. Its only new escape hatch is an `EXIT_CALLED` early return
+  (wasmer #5877), which does not cover this path.
+
+The patch directory must therefore be **re-vendored from 0.0.103, not edited in place** — the crate
+was restructured:
+
+| 0.0.102 | 0.0.103 |
+|---|---|
+| `src/module/wasmer_sys.rs`, `src/module/wasmer_wamr.rs` | `src/module/sys.rs`, `src/module/wasmi.rs` |
+| `wasmer_sys`, `wasmer_sys_dev`, `wasmer_sys_prod`, `wasmer_wamr`, `error_as_host`, `debug_memory` | `wasmer-sys`, `wasmer-sys-cranelift`, `wasmer-sys-llvm`, `wasmer-wasmi`, `error-as-host`, `debug-memory` (underscores → hyphens; `wasmer_sys_dev` split into `wasmer-sys-cranelift`) |
+| default = `["error_as_host", "wasmer_sys_dev"]` | default = `["error-as-host", "wasmer-sys", "wasmer-sys-cranelift"]` |
+
+Re-apply the same `get_from_filesystem` rewrite to the vendored 0.0.103 source; the
+`[patch.crates-io]` line itself needs no change once the vendored `version` reads `0.0.103`.
+
+---
+
 ## `holochain_wasmer_host` (v0.0.102)
 
 ### Patched file
@@ -95,13 +142,17 @@ opts for the broader approach.
 
 ### Upstream report
 
-This should be filed against the Holochain repository:
-`https://github.com/holochain/holochain`
+Filed 2026-07-27 as **https://github.com/holochain/holochain-wasmer/issues/192** (open):
 
-Include:
-- The crash stack from `~/Library/Logs/DiagnosticReports/Conductora-*.ips`
-- Repro: Apple Silicon, fresh/empty wasm-cache, any WASM install
-- The one-line fix as suggested patch
+> `ModuleCache::get_from_filesystem` turns a cache miss into a `RuntimeError`, causing a SIGSEGV on
+> Apple Silicon. [BUG, MACOS]
+
+Note it belongs to `holochain/holochain-wasmer`, not `holochain/holochain` — that is where
+`module.rs` lives. The submitted text is kept at
+[`.notes/holochain-wasmer-sigsegv-issue.md`](../../.notes/holochain-wasmer-sigsegv-issue.md).
+
+**Remove this patch once that issue is fixed and a release carrying the fix is pinned by the
+`holochain` version we depend on.**
 
 ### How the patch is wired
 

--- a/shared_crates/type_system/core_types/src/smartlink/types.rs
+++ b/shared_crates/type_system/core_types/src/smartlink/types.rs
@@ -180,7 +180,7 @@ impl PreparedSmartLink {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmartLink {
     pub smartlink_id: SmartLinkId,
-    pub from_address: LocalId,
+    pub source_id: LocalId,
     pub target_id: HolonId,
     pub relationship_name: RelationshipName,
     pub canonical_key: CanonicalKey,
@@ -209,7 +209,7 @@ impl SmartLink {
     /// source + target + relationship + occurrence. Canonical key and property
     /// caches are deliberately excluded.
     pub fn same_identity(&self, prepared: &PreparedSmartLink) -> bool {
-        self.from_address == prepared.source_id
+        self.source_id == prepared.source_id
             && self.target_id == prepared.target_id
             && self.relationship_name == prepared.relationship_name
             && self.occurrence_id == prepared.occurrence_id
@@ -223,6 +223,38 @@ impl SmartLink {
             && self.canonical_key == prepared.canonical_key
             && self.relationship_property_values == prepared.relationship_property_values
     }
+}
+
+/// Decodes one persisted SmartLink's Tag v1 `tag_bytes` into a storage `SmartLink`,
+/// pairing it with its physical identity and link endpoints.
+///
+/// On a malformed tag, fails with `HolonError::InvalidWireFormat` whose `reason` names
+/// the offending `SmartLinkId` — the storage layer's "fail the whole expansion and
+/// identify the bad link" contract. A malformed *live* link is unreachable through the
+/// DHT (SmartLink integrity validation decodes the tag with this same codec at create
+/// time), so this failure path is exercised by unit tests rather than a conductor.
+pub fn decode_smartlink(
+    smartlink_id: SmartLinkId,
+    source_id: LocalId,
+    link_target: LocalId,
+    tag_bytes: &[u8],
+) -> Result<SmartLink, HolonError> {
+    let decoded = super::decode_smartlink_tag(tag_bytes, link_target).map_err(|error| {
+        HolonError::InvalidWireFormat {
+            wire_type: "SmartLinkTagV1".to_string(),
+            reason: format!("malformed SmartLink {smartlink_id:?}: {error}"),
+        }
+    })?;
+    Ok(SmartLink {
+        smartlink_id,
+        source_id,
+        target_id: decoded.target_id,
+        relationship_name: decoded.relationship_name,
+        canonical_key: decoded.canonical_key,
+        occurrence_id: decoded.occurrence_id,
+        relationship_property_values: decoded.relationship_property_values,
+        target_property_values: decoded.target_property_values,
+    })
 }
 
 /// Outcome of `put_smartlink`. Each variant carries the physical id of the
@@ -309,7 +341,7 @@ mod tests {
     fn live_from(p: &PreparedSmartLink, id: u8) -> SmartLink {
         SmartLink {
             smartlink_id: SmartLinkId(local(id)),
-            from_address: p.source_id.clone(),
+            source_id: p.source_id.clone(),
             target_id: p.target_id.clone(),
             relationship_name: p.relationship_name.clone(),
             canonical_key: p.canonical_key.clone(),
@@ -368,5 +400,50 @@ mod tests {
         live.relationship_property_values = prop("weight", "heavy");
         assert!(live.same_identity(&p));
         assert!(!live.is_already_present(&p)); // -> Conflict
+    }
+
+    /// 39-byte action-hash-shaped id, required by the codec's hash validation.
+    fn hash39(seed: u8) -> LocalId {
+        let mut bytes = vec![seed; 39];
+        bytes[7] = 0;
+        LocalId(bytes)
+    }
+
+    #[test]
+    fn decode_smartlink_round_trips_valid_tag() {
+        let input = SmartLinkTagInput {
+            target_id: HolonId::Local(hash39(2)),
+            relationship_name: rel("Likes"),
+            canonical_key: CanonicalKey::new("apple").unwrap(),
+            occurrence_id: None,
+            relationship_property_values: PropertyMap::new(),
+            target_property_cache_candidates: Vec::new(),
+        };
+        let bytes = super::super::encode_smartlink_tag(&input).unwrap();
+
+        let sl = decode_smartlink(SmartLinkId(hash39(9)), hash39(1), hash39(2), &bytes).unwrap();
+        assert_eq!(sl.smartlink_id, SmartLinkId(hash39(9)));
+        assert_eq!(sl.source_id, hash39(1));
+        assert_eq!(sl.target_id, HolonId::Local(hash39(2)));
+        assert_eq!(sl.relationship_name, rel("Likes"));
+        assert_eq!(sl.canonical_key, CanonicalKey::new("apple").unwrap());
+    }
+
+    #[test]
+    fn decode_smartlink_malformed_names_offending_id() {
+        let id = SmartLinkId(hash39(9));
+        // Junk bytes are not a valid Tag v1 payload; the link target is valid so the
+        // failure is attributed to the tag.
+        let err = decode_smartlink(id.clone(), hash39(1), hash39(2), &[0u8, 1, 2, 3]).unwrap_err();
+        match err {
+            HolonError::InvalidWireFormat { wire_type, reason } => {
+                assert_eq!(wire_type, "SmartLinkTagV1");
+                assert!(
+                    reason.contains(&format!("{id:?}")),
+                    "reason must name the offending SmartLinkId, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidWireFormat, got {other:?}"),
+        }
     }
 }

--- a/shared_crates/type_system/core_types/src/smartlink/types.rs
+++ b/shared_crates/type_system/core_types/src/smartlink/types.rs
@@ -1,5 +1,5 @@
 use crate::{HolonError, HolonId, LocalId, PropertyMap, PropertyName, RelationshipName};
-use base_types::BaseValue;
+use base_types::{BaseValue, MapString};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -143,6 +143,110 @@ pub struct DecodedSmartLinkTag {
     pub target_property_values: PropertyMap,
 }
 
+/// Fully-prepared, descriptor-unaware input to `put_smartlink`.
+///
+/// Coordination supplies every field; the storage layer never infers or derives
+/// a missing one. `occurrence_id` is always `None` in SL1 Part 2.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedSmartLink {
+    pub source_id: LocalId,
+    pub target_id: HolonId,
+    pub relationship_name: RelationshipName,
+    pub canonical_key: CanonicalKey,
+    pub occurrence_id: Option<OccurrenceId>,
+    pub relationship_property_values: PropertyMap,
+    pub target_property_cache_candidates: Vec<TargetPropertyCacheCandidate>,
+}
+
+impl PreparedSmartLink {
+    /// Builds the codec input for Tag v1 packing, reusing the shared encoder.
+    pub fn to_tag_input(&self) -> SmartLinkTagInput {
+        SmartLinkTagInput {
+            target_id: self.target_id.clone(),
+            relationship_name: self.relationship_name.clone(),
+            canonical_key: self.canonical_key.clone(),
+            occurrence_id: self.occurrence_id,
+            relationship_property_values: self.relationship_property_values.clone(),
+            target_property_cache_candidates: self.target_property_cache_candidates.clone(),
+        }
+    }
+}
+
+/// One decoded, unhydrated SmartLink returned by the storage expansion APIs.
+///
+/// Preserves the physical `SmartLinkId`, keeps the relationship-property and
+/// target-property caches as separate maps, and round-trips the optional
+/// `OccurrenceId` (always absent in SL1 Part 2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartLink {
+    pub smartlink_id: SmartLinkId,
+    pub from_address: LocalId,
+    pub target_id: HolonId,
+    pub relationship_name: RelationshipName,
+    pub canonical_key: CanonicalKey,
+    pub occurrence_id: Option<OccurrenceId>,
+    pub relationship_property_values: PropertyMap,
+    pub target_property_values: PropertyMap,
+}
+
+impl SmartLink {
+    /// Returns the tag's canonical key as a `MapString`, or `None` when keyless.
+    pub fn key(&self) -> Result<Option<MapString>, HolonError> {
+        Ok((!self.canonical_key.as_str().is_empty())
+            .then(|| MapString(self.canonical_key.as_str().to_string())))
+    }
+
+    /// Returns the persisted target identity and any cached smart properties.
+    /// This is context-free and does not mint runtime references.
+    pub fn to_pointer(&self) -> (HolonId, Option<PropertyMap>) {
+        (
+            self.target_id.clone(),
+            (!self.target_property_values.is_empty()).then(|| self.target_property_values.clone()),
+        )
+    }
+
+    /// True when this live link shares `prepared`'s insertion identity:
+    /// source + target + relationship + occurrence. Canonical key and property
+    /// caches are deliberately excluded.
+    pub fn same_identity(&self, prepared: &PreparedSmartLink) -> bool {
+        self.from_address == prepared.source_id
+            && self.target_id == prepared.target_id
+            && self.relationship_name == prepared.relationship_name
+            && self.occurrence_id == prepared.occurrence_id
+    }
+
+    /// True when this live link is authoritatively equal to `prepared`: identity
+    /// matches AND canonical key and relationship-property values match. Optional
+    /// target-property cache differences are ignored (idempotency requirement).
+    pub fn is_already_present(&self, prepared: &PreparedSmartLink) -> bool {
+        self.same_identity(prepared)
+            && self.canonical_key == prepared.canonical_key
+            && self.relationship_property_values == prepared.relationship_property_values
+    }
+}
+
+/// Outcome of `put_smartlink`. Each variant carries the physical id of the
+/// live link the decision concerns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PutSmartLinkOutcome {
+    /// A new physical link was created.
+    Inserted(SmartLinkId),
+    /// An authoritatively-identical live link already existed; no write.
+    AlreadyPresent(SmartLinkId),
+    /// A live link shares the insertion identity but differs in canonical key or
+    /// authoritative relationship properties; no write.
+    Conflict(SmartLinkId),
+}
+
+/// Outcome of `delete_smartlink`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeleteSmartLinkOutcome {
+    /// A live link existed and was deleted by this call.
+    Deleted,
+    /// No live link existed for the id (already deleted or never present).
+    AlreadyAbsent,
+}
+
 fn validate_nul_free(wire_type: &str, value: &str) -> Result<(), HolonError> {
     if value.as_bytes().contains(&0) {
         return Err(HolonError::InvalidWireFormat {
@@ -172,5 +276,97 @@ mod tests {
             CanonicalKeyPrefix::new("prefix\0"),
             Err(HolonError::InvalidWireFormat { .. })
         ));
+    }
+
+    fn local(seed: u8) -> LocalId {
+        LocalId(vec![seed; 4])
+    }
+
+    fn rel(name: &str) -> RelationshipName {
+        RelationshipName(MapString(name.to_string()))
+    }
+
+    fn prop(name: &str, value: &str) -> PropertyMap {
+        std::collections::BTreeMap::from([(
+            PropertyName(MapString(name.to_string())),
+            BaseValue::StringValue(MapString(value.to_string())),
+        )])
+    }
+
+    fn prepared() -> PreparedSmartLink {
+        PreparedSmartLink {
+            source_id: local(1),
+            target_id: HolonId::Local(local(2)),
+            relationship_name: rel("RelatedTo"),
+            canonical_key: CanonicalKey::new("target-key").unwrap(),
+            occurrence_id: None,
+            relationship_property_values: PropertyMap::new(),
+            target_property_cache_candidates: Vec::new(),
+        }
+    }
+
+    /// Builds a live decoded link that authoritatively matches `p` by default.
+    fn live_from(p: &PreparedSmartLink, id: u8) -> SmartLink {
+        SmartLink {
+            smartlink_id: SmartLinkId(local(id)),
+            from_address: p.source_id.clone(),
+            target_id: p.target_id.clone(),
+            relationship_name: p.relationship_name.clone(),
+            canonical_key: p.canonical_key.clone(),
+            occurrence_id: p.occurrence_id,
+            relationship_property_values: p.relationship_property_values.clone(),
+            target_property_values: PropertyMap::new(),
+        }
+    }
+
+    #[test]
+    fn same_identity_ignores_key_and_props() {
+        let p = prepared();
+        let mut live = live_from(&p, 9);
+        live.canonical_key = CanonicalKey::new("different-key").unwrap();
+        live.relationship_property_values = prop("weight", "heavy");
+        assert!(live.same_identity(&p));
+    }
+
+    #[test]
+    fn same_identity_false_on_different_target() {
+        let p = prepared();
+        let mut live = live_from(&p, 9);
+        live.target_id = HolonId::Local(local(7));
+        assert!(!live.same_identity(&p));
+    }
+
+    #[test]
+    fn already_present_when_identity_key_and_props_match() {
+        let p = prepared();
+        let live = live_from(&p, 9);
+        assert!(live.is_already_present(&p));
+    }
+
+    #[test]
+    fn already_present_ignores_target_property_cache() {
+        let p = prepared();
+        let mut live = live_from(&p, 9);
+        live.target_property_values = prop("title", "cached"); // cache-only difference
+        assert!(live.is_already_present(&p));
+    }
+
+    #[test]
+    fn conflict_when_canonical_key_differs() {
+        let p = prepared();
+        let mut live = live_from(&p, 9);
+        live.canonical_key = CanonicalKey::new("other-key").unwrap();
+        assert!(live.same_identity(&p));
+        assert!(!live.is_already_present(&p)); // -> Conflict
+    }
+
+    #[test]
+    fn conflict_when_relationship_props_differ() {
+        let mut p = prepared();
+        p.relationship_property_values = prop("weight", "light");
+        let mut live = live_from(&p, 9);
+        live.relationship_property_values = prop("weight", "heavy");
+        assert!(live.same_identity(&p));
+        assert!(!live.is_already_present(&p)); // -> Conflict
     }
 }

--- a/tests/sweetests/Cargo.toml
+++ b/tests/sweetests/Cargo.toml
@@ -11,24 +11,25 @@ publish = false
 
 # General deps
 async-trait = "0.1.51"
-#base64ct = "=1.7.3"
 derive-new = "0.7"
 serde = { version = "1", features = ["derive"] }
 # Holochain sweettest stack (pin as you already do)
-holochain = { version = "=0.6.1", default-features = false, features = [
+holochain = { version = "0.6", default-features = false, features = [
     "sweettest",
     "wasmer_sys",
     "transport-iroh"
 ] }
-holochain_state = "=0.6.1"
+holochain_state = "0.6"
 
 
-# Workaround: iroh-base-holochain 0.95.1 hard-pins ed25519-dalek = "=3.0.0-pre.1",
-# which fails to compile against released RustCrypto crates. Pin pkcs8 to the
-# same version Holochain's scaffolded zomes pin to, so consumers that mix this
-# plugin with Holochain zomes get a consistent resolution. Remove once
-# iroh-base-holochain publishes a release that unpins ed25519-dalek.
-ed25519 = "=3.0.0-rc.0"
+# Workaround: iroh-base-holochain (latest is 0.95.2) still hard-pins
+# ed25519-dalek = "=3.0.0-pre.1" and curve25519-dalek = "=5.0.0-pre.1", which fail
+# to compile against released RustCrypto crates. pkcs8 0.11.0 breaks ed25519
+# 3.0.0-rc.x (`?` can't convert Error::KeyMalformed), so pkcs8 must stay on the RC.
+# Re-verified against holochain 0.6.3 on 2026-07-27 — still required.
+# Remove once iroh-base-holochain publishes a release that unpins ed25519-dalek.
+# (An `ed25519 = "=3.0.0-rc.0"` pin used to live here too; it is no longer needed —
+# resolution lands on ed25519 3.0.0-rc.4, which compiles fine against the -pre.1 dalek.)
 pkcs8 = "=0.11.0-rc.11"
 
 
@@ -43,15 +44,11 @@ tracing-subscriber = "0.3"
 sha2 = "=0.11.0-rc.2"
 sha1 = "=0.11.0-rc.2"
 digest = "=0.11.0-rc.3"
-# holochain_client 0.8.1 uses kitsune2_api 0.4.1 (matching holochain 0.6.1);
-# 0.8.0 used kitsune2_api 0.3.2 which caused a two-version conflict.
-# holochain_client = "=0.8.1"
-
-# Holochain 0.6 upgrade guide recommends pinning rand = "0.9". Without this,
-# uuid v4 (pulled in by holochain) resolves rand → 0.10.1 → chacha20 0.10.0,
-# conflicting with iroh-holochain's exact pin chacha20 =0.10.0-rc.2.
-# rand 0.9.x → chacha20 0.9.x (different compat group, coexists cleanly).
-rand = "0.9"
+# Guards against uuid v4 resolving rand → 0.10 → chacha20 0.10.0, which would
+# conflict with iroh-holochain's exact pin chacha20 =0.10.0-rc.2.
+# The companion `rand = "0.9"` pin was dropped on 2026-07-27: holochain 0.6.3
+# declares `rand ^0.9` itself, and a from-scratch resolve without the pin lands
+# on rand 0.9.5 / chacha20 0.10.0-rc.2 cleanly.
 uuid = { version = "=1.21.0", features = ["serde"] }
 
 [dependencies.holons_prelude]

--- a/tests/sweetests/Cargo.toml
+++ b/tests/sweetests/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 async-trait = "0.1.51"
 #base64ct = "=1.7.3"
 derive-new = "0.7"
+serde = { version = "1", features = ["derive"] }
 # Holochain sweettest stack (pin as you already do)
 holochain = { version = "=0.6.1", default-features = false, features = [
     "sweettest",

--- a/tests/sweetests/tests/smartlink_tests.rs
+++ b/tests/sweetests/tests/smartlink_tests.rs
@@ -235,3 +235,34 @@ async fn delete_idempotent_and_leaves_siblings() {
     assert_ne!(remaining[0].smartlink_id, id_a);
     assert_eq!(remaining[0].canonical_key, key("b"));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expand_by_key_keyless_exact() {
+    let backend = setup_test_conductor().await;
+    let zome = backend.cell.zome(ZOME);
+    let source = new_endpoint(&backend).await;
+    let target = new_endpoint(&backend).await;
+
+    // A keyless SmartLink: empty canonical key is valid.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target, "Likes", ""))
+        .await;
+    let id = match out {
+        PutSmartLinkOutcome::Inserted(id) => id,
+        other => panic!("expected Inserted, got {other:?}"),
+    };
+
+    // Exact match on the empty (keyless) key returns exactly that link.
+    let exact: Vec<SmartLink> = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_expand_by_key",
+            (source.clone(), rel("Likes"), KeyMatch::Exact(key(""))),
+        )
+        .await;
+    assert_eq!(exact.len(), 1);
+    assert_eq!(exact[0].smartlink_id, id);
+    assert_eq!(exact[0].canonical_key, key(""));
+}

--- a/tests/sweetests/tests/smartlink_tests.rs
+++ b/tests/sweetests/tests/smartlink_tests.rs
@@ -1,0 +1,237 @@
+//! Live-conductor sweettests for the SmartLink storage API (Issue #594).
+//!
+//! These bypass the dance DSL: they spin up a conductor with `setup_test_conductor()`
+//! and call the `smartlink_*` zome externs directly, asserting the real DHT outcomes
+//! (`Inserted` / `AlreadyPresent` / `Conflict` / `Deleted` / `AlreadyAbsent`, plus the
+//! `StartsWith("")` guard) that the pure comparator unit tests cannot exercise.
+//!
+//! Endpoints are real committed holon nodes (created via the `create_holon_node` extern),
+//! because SmartLink integrity validation requires 39-byte action-hash source/target ids.
+
+use base_types::{BaseValue, MapString};
+use core_types::{
+    CanonicalKey, CanonicalKeyPrefix, DeleteSmartLinkOutcome, HolonId, KeyMatch, PreparedSmartLink,
+    PropertyName, PutSmartLinkOutcome, SmartLink, TargetPropertyCacheCandidate,
+};
+use holochain::prelude::Record;
+use holons_test::setup_test_conductor;
+use integrity_core_types::{LocalId, PropertyMap, RelationshipName};
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Mirrors `holons_guest_integrity::HolonNode` for the `create_holon_node` extern input,
+/// so this test needs no dependency on the (hdi-based) integrity crate.
+#[derive(Serialize, Debug)]
+struct HolonNodeInput {
+    original_id: Option<LocalId>,
+    property_map: PropertyMap,
+}
+
+const ZOME: &str = "holons";
+
+fn rel(name: &str) -> RelationshipName {
+    RelationshipName(MapString(name.to_string()))
+}
+
+fn key(value: &str) -> CanonicalKey {
+    CanonicalKey::new(value).unwrap()
+}
+
+fn string_props(name: &str, value: &str) -> PropertyMap {
+    BTreeMap::from([(
+        PropertyName(MapString(name.to_string())),
+        BaseValue::StringValue(MapString(value.to_string())),
+    )])
+}
+
+fn prepared(source: &LocalId, target: &LocalId, relationship: &str, k: &str) -> PreparedSmartLink {
+    PreparedSmartLink {
+        source_id: source.clone(),
+        target_id: HolonId::Local(target.clone()),
+        relationship_name: rel(relationship),
+        canonical_key: key(k),
+        occurrence_id: None,
+        relationship_property_values: PropertyMap::new(),
+        target_property_cache_candidates: Vec::new(),
+    }
+}
+
+/// Commits an empty holon node and returns its physical id (a valid 39-byte action hash).
+async fn new_endpoint(backend: &holons_test::MockConductorConfig) -> LocalId {
+    let record: Record = backend
+        .conductor
+        .call(
+            &backend.cell.zome(ZOME),
+            "create_holon_node",
+            HolonNodeInput { original_id: None, property_map: PropertyMap::new() },
+        )
+        .await;
+    LocalId(record.action_address().get_raw_39().to_vec())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_insert_present_conflict() {
+    let backend = setup_test_conductor().await;
+    let zome = backend.cell.zome(ZOME);
+    let source = new_endpoint(&backend).await;
+    let target = new_endpoint(&backend).await;
+
+    // First put => Inserted.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target, "Likes", "target-key"))
+        .await;
+    let id = match out {
+        PutSmartLinkOutcome::Inserted(id) => id,
+        other => panic!("expected Inserted, got {other:?}"),
+    };
+
+    // Identical put => AlreadyPresent with the same physical id.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target, "Likes", "target-key"))
+        .await;
+    assert_eq!(out, PutSmartLinkOutcome::AlreadyPresent(id.clone()));
+
+    // Same identity + key + rel props, but a different target-property cache => still AlreadyPresent.
+    let mut cached = prepared(&source, &target, "Likes", "target-key");
+    cached.target_property_cache_candidates = vec![TargetPropertyCacheCandidate {
+        property_name: PropertyName(MapString("title".to_string())),
+        value: BaseValue::StringValue(MapString("cached".to_string())),
+    }];
+    let out: PutSmartLinkOutcome = backend.conductor.call(&zome, "smartlink_put", cached).await;
+    assert_eq!(out, PutSmartLinkOutcome::AlreadyPresent(id.clone()));
+
+    // Same identity, different canonical key => Conflict, and no second link is written.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target, "Likes", "different-key"))
+        .await;
+    assert_eq!(out, PutSmartLinkOutcome::Conflict(id.clone()));
+
+    // Same identity, different authoritative relationship props => Conflict.
+    let mut diff_props = prepared(&source, &target, "Likes", "target-key");
+    diff_props.relationship_property_values = string_props("weight", "heavy");
+    let out: PutSmartLinkOutcome = backend.conductor.call(&zome, "smartlink_put", diff_props).await;
+    assert_eq!(out, PutSmartLinkOutcome::Conflict(id.clone()));
+
+    // Exactly one live link exists despite the conflicting puts.
+    let links: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].smartlink_id, id);
+    assert_eq!(links[0].canonical_key, key("target-key"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expand_modes() {
+    let backend = setup_test_conductor().await;
+    let zome = backend.cell.zome(ZOME);
+    let source = new_endpoint(&backend).await;
+    let target_a = new_endpoint(&backend).await;
+    let target_b = new_endpoint(&backend).await;
+
+    // Two "Likes" links with different keys, one "Owns" link.
+    for (target, k) in [(&target_a, "apple"), (&target_b, "apricot")] {
+        let _: PutSmartLinkOutcome = backend
+            .conductor
+            .call(&zome, "smartlink_put", prepared(&source, target, "Likes", k))
+            .await;
+    }
+    let _: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target_a, "Owns", "apple"))
+        .await;
+
+    // expand_all => all three.
+    let all: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    assert_eq!(all.len(), 3);
+
+    // expand by relationship => only the two "Likes".
+    let likes: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand", (source.clone(), rel("Likes"))).await;
+    assert_eq!(likes.len(), 2);
+    assert!(likes.iter().all(|l| l.relationship_name == rel("Likes")));
+
+    // expand by exact key => only the "apple" Likes link.
+    let exact: Vec<SmartLink> = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_expand_by_key",
+            (source.clone(), rel("Likes"), KeyMatch::Exact(key("apple"))),
+        )
+        .await;
+    assert_eq!(exact.len(), 1);
+    assert_eq!(exact[0].canonical_key, key("apple"));
+
+    // expand by "ap" prefix => both apple + apricot.
+    let prefix: Vec<SmartLink> = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_expand_by_key",
+            (
+                source.clone(),
+                rel("Likes"),
+                KeyMatch::StartsWith(CanonicalKeyPrefix::new("ap").unwrap()),
+            ),
+        )
+        .await;
+    assert_eq!(prefix.len(), 2);
+
+    // Empty starts-with prefix is rejected.
+    let empty = backend
+        .conductor
+        .call_fallible::<(LocalId, RelationshipName, KeyMatch), Vec<SmartLink>>(
+            &zome,
+            "smartlink_expand_by_key",
+            (
+                source.clone(),
+                rel("Likes"),
+                KeyMatch::StartsWith(CanonicalKeyPrefix::new("").unwrap()),
+            ),
+        )
+        .await;
+    assert!(empty.is_err(), "StartsWith(\"\") must be rejected");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_idempotent_and_leaves_siblings() {
+    let backend = setup_test_conductor().await;
+    let zome = backend.cell.zome(ZOME);
+    let source = new_endpoint(&backend).await;
+    let target_a = new_endpoint(&backend).await;
+    let target_b = new_endpoint(&backend).await;
+
+    let a: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target_a, "Likes", "a"))
+        .await;
+    let id_a = match a {
+        PutSmartLinkOutcome::Inserted(id) => id,
+        other => panic!("expected Inserted, got {other:?}"),
+    };
+    let _: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target_b, "Likes", "b"))
+        .await;
+
+    // First delete of id_a => Deleted.
+    let out: DeleteSmartLinkOutcome =
+        backend.conductor.call(&zome, "smartlink_delete", id_a.clone()).await;
+    assert_eq!(out, DeleteSmartLinkOutcome::Deleted);
+
+    // Repeat delete => AlreadyAbsent (idempotent).
+    let out: DeleteSmartLinkOutcome =
+        backend.conductor.call(&zome, "smartlink_delete", id_a.clone()).await;
+    assert_eq!(out, DeleteSmartLinkOutcome::AlreadyAbsent);
+
+    // The sibling link survived.
+    let remaining: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    assert_eq!(remaining.len(), 1);
+    assert_ne!(remaining[0].smartlink_id, id_a);
+    assert_eq!(remaining[0].canonical_key, key("b"));
+}


### PR DESCRIPTION

Adds a storage-layer SmartLink API (`persistence_layer::smartlink`) with idempotent, conflict-aware writes,
three expansion reads, and an idempotent exact delete — sitting below and separate from the temporary
coordinator facade. The facade is consolidated onto the shared `SmartLink` type and now delegates to the new
API. Most primitives (Tag v1 codec, prefix helpers, `SmartLinkId`, `HolonError::InvalidWireFormat`) already
existed; this promotes/extends them and adds the genuinely new pieces below.

## Changes

**New storage types** (`core_types::smartlink`)
- `PreparedSmartLink` (write input; `to_tag_input()` reuses the codec).
- `SmartLink` promoted from the facade to `core_types` (canonical), now with non-optional `smartlink_id`,
  `occurrence_id`, and separate relationship/target property maps.
- `PutSmartLinkOutcome { Inserted, AlreadyPresent, Conflict }`, `DeleteSmartLinkOutcome { Deleted, AlreadyAbsent }`.
- Pure comparators `SmartLink::same_identity` / `is_already_present`.

**New storage module** (`persistence_layer::smartlink`)
- `expand_all_from_source`, `expand_from_source`, `expand_from_source_by_key`
  (exact + non-empty starts-with; `StartsWith("")` → `InvalidParameter`).
- `put_smartlink` — insertion identity = source + target + relationship + occurrence; **decode-and-compare**
  candidates (not byte-equality); Inserted / AlreadyPresent (target-cache ignored) / Conflict.
- `delete_smartlink` — recovers the base from the `CreateLink` action, tests liveness via `get_links`;
  `Deleted` / `AlreadyAbsent`; idempotent; leaves sibling links intact.
- Any malformed live link fails the whole expansion with `InvalidWireFormat` naming the offending `SmartLinkId`.

**Facade consolidation** (kept working; retirement deferred to SL4)
- `smartlink_adapter.rs` re-exports `core_types::SmartLink`, delegates reads to `expand_*`, and routes
  `save_smartlink` through `put_smartlink`. Removed the old `equivalent_smartlink_action_hash` dedup.
- `commit_functions.rs` builds `PreparedSmartLink` at the two commit-Pass-2 sites.

**Test surface**
- `persistence_layer::smartlink_externs` — five `#[hdk_extern]` shims exposing the storage API for
  live-conductor tests (auto-registered into `holons.wasm`; no manifest change).
- `tests/sweetests/tests/smartlink_tests.rs` — 3 conductor tests (put/insert/present/conflict, expand modes,
  delete idempotency + siblings), bypassing the dance DSL. `serde` added to the sweettest Cargo.toml.

## Notable decisions

- **Decode-and-compare** is required for the AlreadyPresent/Conflict semantics — full-tag byte equality
  cannot ignore the target-property cache or detect a key/props conflict.
- **Delete liveness** uses `get_links` (live-only), not `get_details(...).deletes` — the latter does not
  track a link's `DeleteLink`s (this was caught by the delete sweettest and fixed).
- **Malformed-tag expansion** is defensive only: integrity validation rejects malformed tags at write time,
  so the path is unreachable via the DHT and is covered by codec unit tests rather than a sweettest.
- `occurrence_id` stays `None` (SL3 scope). Test externs ship always-present, matching the existing raw
  persistence externs (no cfg-gating precedent in the codebase).

## Testing

- `cargo test -p core_types smartlink` — 23 pass (6 new comparator tests).
- `smartlink_tests` on an in-process `SweetConductor` (`put_insert_present_conflict`, `expand_modes`, `delete_idempotent_and_leaves_siblings`). 

## Scope / follow-ups

Out of scope: SL3 occurrence semantics, SL4 facade retirement, descriptor policy / hydration / sorting /
filtering, and cfg-gating the test externs.
