### PR TITLE
609 pvl pr 5   holon update and delete validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holons_guest_integrity",
  "integrity_core_types",
+ "mockall",
  "serde",
  "shared_validation",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_serialized_bytes_derive",
  "holochain_wasmer_guest",
+ "mockall",
  "paste",
  "serde",
  "serde_bytes",
@@ -3471,6 +3472,7 @@ dependencies = [
  "hdi",
  "holochain_serialized_bytes",
  "integrity_core_types",
+ "mockall",
  "serde",
  "shared_validation",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,7 +2475,6 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_serialized_bytes_derive",
  "holochain_wasmer_guest",
- "mockall",
  "paste",
  "serde",
  "serde_bytes",

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -468,7 +468,6 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_serialized_bytes_derive",
  "holochain_wasmer_guest",
- "mockall",
  "paste",
  "serde",
  "serde_bytes",

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holons_guest_integrity",
  "integrity_core_types",
+ "mockall",
  "serde",
  "shared_validation",
 ]

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +328,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures"
@@ -447,6 +468,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_serialized_bytes_derive",
  "holochain_wasmer_guest",
+ "mockall",
  "paste",
  "serde",
  "serde_bytes",
@@ -735,6 +757,7 @@ dependencies = [
  "hdi",
  "holochain_serialized_bytes",
  "integrity_core_types",
+ "mockall",
  "serde",
  "shared_validation",
 ]
@@ -865,6 +888,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "must_future"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +964,32 @@ checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1202,6 +1277,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/happ/crates/holons_guest_integrity/Cargo.toml
+++ b/happ/crates/holons_guest_integrity/Cargo.toml
@@ -28,5 +28,9 @@ path = "../../../shared_crates/type_system/integrity_core_types"
 [dependencies.shared_validation]
 path = "../../../shared_crates/shared_validation"
 
+[dev-dependencies]
+hdi = { version = "0.7", features = ["mock"] }
+mockall = "0.13"
+
 [dev-dependencies.base_types]
 path = "../../../shared_crates/type_system/base_types"

--- a/happ/crates/holons_guest_integrity/Cargo.toml
+++ b/happ/crates/holons_guest_integrity/Cargo.toml
@@ -29,7 +29,6 @@ path = "../../../shared_crates/type_system/integrity_core_types"
 path = "../../../shared_crates/shared_validation"
 
 [dev-dependencies]
-hdi = { version = "0.7", features = ["mock"] }
 mockall = "0.13"
 
 [dev-dependencies.base_types]

--- a/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_envelope.rs
@@ -14,7 +14,7 @@ use crate::HolonNode;
 /// `HolonNode` is currently the sole app entry declared by this integrity
 /// zome, so its index is fixed at zero. Adding or reordering app-entry
 /// definitions requires updating this constant and the associated op tests.
-const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
+pub(crate) const HOLON_NODE_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
 
 /// Fixed structured-diagnostic reason used when exact `ActionHash` parsing fails.
 ///
@@ -77,8 +77,10 @@ fn holon_node_entry_bytes(op: &Op) -> Option<&[u8]> {
         _ => return None,
     };
 
-    // Since this code only runs for this zome, the entry index alone
-    // identifies whether this is a HolonNode.
+    // The op envelope is interpreted through this zome's declared EntryTypes, so
+    // its entry index selects HolonNode without another host call. Lifecycle
+    // targets are resolved actions that may belong to another integrity-zome
+    // scope and therefore require the stricter full AppEntryDef comparison.
     match entry_type {
         EntryType::App(app_entry_def)
             if app_entry_def.entry_index == HOLON_NODE_ENTRY_DEF_INDEX => {}

--- a/happ/crates/holons_guest_integrity/src/holon_node_lifecycle.rs
+++ b/happ/crates/holons_guest_integrity/src/holon_node_lifecycle.rs
@@ -1,0 +1,380 @@
+//! Holochain adapter for descriptor-independent `HolonNode` lifecycle validation.
+//!
+//! This module resolves the action named by an update or delete and projects
+//! only the facts needed by `shared_validation`. Target entry content is never
+//! requested or decoded: the action already carries both its lifecycle kind and
+//! its entry type.
+//!
+//! Host and dependency-resolution failures remain in the outer
+//! [`ExternResult`]. The inner result represents a completed PVL verdict, which
+//! prevents temporarily unavailable dependencies from becoming deterministic
+//! validation failures.
+
+use hdi::prelude::*;
+use integrity_core_types::PvlViolation;
+use shared_validation::{
+    validate_delete_target, validate_update_target, LifecycleTarget, TargetActionKind,
+    TargetEntryKind,
+};
+
+use crate::holon_node_envelope::HOLON_NODE_ENTRY_DEF_INDEX;
+
+/// Resolves and validates the lineage root named by a `HolonNode` update.
+///
+/// [`must_get_valid_record`] provides inductive validity for the structural
+/// lineage root. MAP's root-addressed topology bounds this resolution at one
+/// hop: the target must itself be a `Create`, never another `Update`.
+///
+/// `new_entry_def` comes from the already envelope-validated operation. Comparing
+/// the complete [`AppEntryDef`] gives scoped entry identity without another host
+/// call and prevents an equal entry-definition index in another integrity zome
+/// from being mistaken for `HolonNode`.
+pub fn validate_holon_node_update_target(
+    original_action_hash: &ActionHash,
+    new_entry_def: &AppEntryDef,
+) -> ExternResult<Result<(), PvlViolation>> {
+    let target_record = must_get_valid_record(original_action_hash.clone())?;
+    let target = classify_target(target_record.action(), |target_entry_def| {
+        target_entry_def == new_entry_def
+    });
+
+    Ok(validate_update_target(&target))
+}
+
+/// Resolves and validates the exact persisted version named by a `HolonNode` delete.
+///
+/// A delete carries no lineage structure forward, so [`must_get_action`] supplies
+/// every fact the rule needs without fetching the target record or entry.
+/// [`zome_info`] is a local host call used only to establish the defining
+/// integrity-zome scope for `HolonNode`; it is not a DHT dependency lookup.
+pub fn validate_holon_node_delete_target(
+    deletes_address: &ActionHash,
+) -> ExternResult<Result<(), PvlViolation>> {
+    let target_action = must_get_action(deletes_address.clone())?;
+    let holon_node_entry_def =
+        AppEntryDef::new(HOLON_NODE_ENTRY_DEF_INDEX, zome_info()?.id, EntryVisibility::Public);
+    let target = classify_target(target_action.action(), |target_entry_def| {
+        target_entry_def == &holon_node_entry_def
+    });
+
+    Ok(validate_delete_target(&target))
+}
+
+/// Projects a resolved Holochain action into the closed pure lifecycle model.
+///
+/// The caller supplies scoped app-entry classification because the update path
+/// derives scope from the new entry while the delete path derives it from
+/// `zome_info`. Keeping resolution outside this helper makes it impossible for
+/// pure validation to trigger additional host calls.
+fn classify_target(
+    action: &Action,
+    is_holon_node: impl FnOnce(&AppEntryDef) -> bool,
+) -> LifecycleTarget {
+    let action_kind = match action {
+        Action::Create(_) => TargetActionKind::Create,
+        Action::Update(_) => TargetActionKind::Update,
+        _ => TargetActionKind::Other,
+    };
+    let entry_kind = match action.entry_type() {
+        Some(EntryType::App(entry_def)) if is_holon_node(entry_def) => TargetEntryKind::HolonNode,
+        Some(EntryType::App(_)) => TargetEntryKind::OtherAppEntry,
+        Some(_) => TargetEntryKind::NonAppEntry,
+        None => TargetEntryKind::Absent,
+    };
+
+    LifecycleTarget { action_kind, entry_kind }
+}
+
+#[cfg(test)]
+mod tests {
+    use integrity_core_types::PvlViolation;
+    use mockall::mock;
+    use shared_validation::{
+        CREATE_ACTION_KIND, CREATE_OR_UPDATE_ACTION_KIND, HOLON_NODE_ENTRY_KIND, OTHER_ACTION_KIND,
+        OTHER_APP_ENTRY_KIND, UPDATE_ACTION_KIND,
+    };
+
+    use super::*;
+
+    const HOLON_ZOME_INDEX: ZomeIndex = ZomeIndex(0);
+
+    // HDI 0.7.1 exposes mockall behind its `mock` feature but does not generate
+    // the documented `MockHdiT` type. Define the test double locally and install
+    // it through the same thread-local `set_hdi` seam used by the host wrappers.
+    mock! {
+        Hdi {}
+
+        impl HdiT for Hdi {
+            fn verify_signature(&self, input: VerifySignature) -> ExternResult<bool>;
+            fn must_get_entry(&self, input: MustGetEntryInput) -> ExternResult<EntryHashed>;
+            fn must_get_action(
+                &self,
+                input: MustGetActionInput,
+            ) -> ExternResult<SignedActionHashed>;
+            fn must_get_valid_record(
+                &self,
+                input: MustGetValidRecordInput,
+            ) -> ExternResult<Record>;
+            fn must_get_agent_activity(
+                &self,
+                input: MustGetAgentActivityInput,
+            ) -> ExternResult<Vec<RegisterAgentActivity>>;
+            fn dna_info(&self, input: ()) -> ExternResult<DnaInfo>;
+            fn zome_info(&self, input: ()) -> ExternResult<ZomeInfo>;
+            fn trace(&self, input: TraceMsg) -> ExternResult<()>;
+            fn x_salsa20_poly1305_decrypt(
+                &self,
+                input: XSalsa20Poly1305Decrypt,
+            ) -> ExternResult<Option<XSalsa20Poly1305Data>>;
+            fn x_25519_x_salsa20_poly1305_decrypt(
+                &self,
+                input: X25519XSalsa20Poly1305Decrypt,
+            ) -> ExternResult<Option<XSalsa20Poly1305Data>>;
+            fn ed_25519_x_salsa20_poly1305_decrypt(
+                &self,
+                input: Ed25519XSalsa20Poly1305Decrypt,
+            ) -> ExternResult<XSalsa20Poly1305Data>;
+        }
+    }
+
+    fn action_hash(seed: u8) -> ActionHash {
+        ActionHash::from_raw_36(vec![seed; 36])
+    }
+
+    fn app_entry_def(zome_index: ZomeIndex, entry_index: EntryDefIndex) -> AppEntryDef {
+        AppEntryDef::new(entry_index, zome_index, EntryVisibility::Public)
+    }
+
+    fn holon_node_entry_def() -> AppEntryDef {
+        app_entry_def(HOLON_ZOME_INDEX, HOLON_NODE_ENTRY_DEF_INDEX)
+    }
+
+    fn create_action(entry_type: EntryType) -> Create {
+        Create {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(1),
+            action_seq: 1,
+            prev_action: action_hash(1),
+            entry_type,
+            entry_hash: EntryHash::from_raw_36(vec![2; 36]),
+            weight: EntryRateWeight::default(),
+        }
+    }
+
+    fn update_action(entry_type: EntryType) -> Update {
+        Update {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(2),
+            action_seq: 2,
+            prev_action: action_hash(3),
+            original_action_address: action_hash(4),
+            original_entry_address: EntryHash::from_raw_36(vec![5; 36]),
+            entry_type,
+            entry_hash: EntryHash::from_raw_36(vec![6; 36]),
+            weight: EntryRateWeight::default(),
+        }
+    }
+
+    fn delete_action() -> Delete {
+        Delete {
+            author: AgentPubKey::from_raw_36(vec![0; 36]),
+            timestamp: Timestamp::from_micros(3),
+            action_seq: 3,
+            prev_action: action_hash(7),
+            deletes_address: action_hash(8),
+            deletes_entry_address: EntryHash::from_raw_36(vec![9; 36]),
+            weight: RateWeight::default(),
+        }
+    }
+
+    fn signed_action(action: Action) -> SignedActionHashed {
+        SignedHashed::with_presigned(
+            HoloHashed::with_pre_hashed(action, action_hash(10)),
+            Signature([0; SIGNATURE_BYTES]),
+        )
+    }
+
+    fn record(action: Action) -> Record {
+        Record::new(signed_action(action), None)
+    }
+
+    fn zome_info_for(zome_index: ZomeIndex) -> ZomeInfo {
+        ZomeInfo::new(
+            "holons_integrity".into(),
+            zome_index,
+            SerializedBytes::default(),
+            EntryDefs(Vec::new()),
+            Vec::new(),
+            ScopedZomeTypesSet::default(),
+        )
+    }
+
+    fn install_update_target(target_action: Action) {
+        let target_record = record(target_action);
+        let mut mock_hdi = MockHdi::new();
+        mock_hdi.expect_must_get_valid_record().times(1).return_once(move |_| Ok(target_record));
+        set_hdi(mock_hdi);
+    }
+
+    fn install_delete_target(target_action: Action) {
+        let target_action = signed_action(target_action);
+        let mut mock_hdi = MockHdi::new();
+        mock_hdi.expect_must_get_action().times(1).return_once(move |_| Ok(target_action));
+        mock_hdi.expect_zome_info().times(1).return_once(|_| Ok(zome_info_for(HOLON_ZOME_INDEX)));
+        set_hdi(mock_hdi);
+    }
+
+    #[test]
+    fn update_accepts_a_holon_node_create_root() {
+        let entry_def = holon_node_entry_def();
+        install_update_target(Action::Create(create_action(EntryType::App(entry_def.clone()))));
+
+        assert_eq!(validate_holon_node_update_target(&action_hash(20), &entry_def), Ok(Ok(())));
+    }
+
+    #[test]
+    fn update_rejects_an_update_target_even_when_it_carries_a_holon_node() {
+        let entry_def = holon_node_entry_def();
+        install_update_target(Action::Update(update_action(EntryType::App(entry_def.clone()))));
+
+        assert_eq!(
+            validate_holon_node_update_target(&action_hash(20), &entry_def),
+            Ok(Err(PvlViolation::InvalidUpdateTarget {
+                expected_target_kind: CREATE_ACTION_KIND.into(),
+                actual_target_kind: UPDATE_ACTION_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn update_rejects_other_action_kinds_before_entry_classification() {
+        let entry_def = holon_node_entry_def();
+        install_update_target(Action::Delete(delete_action()));
+
+        assert_eq!(
+            validate_holon_node_update_target(&action_hash(20), &entry_def),
+            Ok(Err(PvlViolation::InvalidUpdateTarget {
+                expected_target_kind: CREATE_ACTION_KIND.into(),
+                actual_target_kind: OTHER_ACTION_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn update_rejects_a_create_carrying_another_app_entry() {
+        let entry_def = holon_node_entry_def();
+        let other_entry_def =
+            app_entry_def(HOLON_ZOME_INDEX, EntryDefIndex(HOLON_NODE_ENTRY_DEF_INDEX.0 + 1));
+        install_update_target(Action::Create(create_action(EntryType::App(other_entry_def))));
+
+        assert_eq!(
+            validate_holon_node_update_target(&action_hash(20), &entry_def),
+            Ok(Err(PvlViolation::InvalidUpdateTarget {
+                expected_target_kind: HOLON_NODE_ENTRY_KIND.into(),
+                actual_target_kind: OTHER_APP_ENTRY_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn update_classification_includes_the_integrity_zome_scope() {
+        let entry_def = holon_node_entry_def();
+        let same_index_other_scope =
+            app_entry_def(ZomeIndex(HOLON_ZOME_INDEX.0 + 1), HOLON_NODE_ENTRY_DEF_INDEX);
+        install_update_target(Action::Create(create_action(EntryType::App(
+            same_index_other_scope,
+        ))));
+
+        assert_eq!(
+            validate_holon_node_update_target(&action_hash(20), &entry_def),
+            Ok(Err(PvlViolation::InvalidUpdateTarget {
+                expected_target_kind: HOLON_NODE_ENTRY_KIND.into(),
+                actual_target_kind: OTHER_APP_ENTRY_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn target_classification_distinguishes_non_app_and_absent_entries() {
+        let non_app_target =
+            classify_target(&Action::Create(create_action(EntryType::AgentPubKey)), |_| false);
+        let absent_target = classify_target(&Action::Delete(delete_action()), |_| false);
+
+        assert_eq!(non_app_target.entry_kind, TargetEntryKind::NonAppEntry);
+        assert_eq!(absent_target.entry_kind, TargetEntryKind::Absent);
+    }
+
+    #[test]
+    fn delete_accepts_create_and_update_holon_node_versions() {
+        for target_action in [
+            Action::Create(create_action(EntryType::App(holon_node_entry_def()))),
+            Action::Update(update_action(EntryType::App(holon_node_entry_def()))),
+        ] {
+            install_delete_target(target_action);
+
+            assert_eq!(validate_holon_node_delete_target(&action_hash(21)), Ok(Ok(())));
+        }
+    }
+
+    #[test]
+    fn delete_rejects_other_action_kinds() {
+        install_delete_target(Action::Delete(delete_action()));
+
+        assert_eq!(
+            validate_holon_node_delete_target(&action_hash(21)),
+            Ok(Err(PvlViolation::InvalidDeleteTarget {
+                expected_target_kind: CREATE_OR_UPDATE_ACTION_KIND.into(),
+                actual_target_kind: OTHER_ACTION_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn delete_rejects_an_entry_outside_the_scoped_holon_node_identity() {
+        let same_index_other_scope =
+            app_entry_def(ZomeIndex(HOLON_ZOME_INDEX.0 + 1), HOLON_NODE_ENTRY_DEF_INDEX);
+        install_delete_target(Action::Create(create_action(EntryType::App(
+            same_index_other_scope,
+        ))));
+
+        assert_eq!(
+            validate_holon_node_delete_target(&action_hash(21)),
+            Ok(Err(PvlViolation::InvalidDeleteTarget {
+                expected_target_kind: HOLON_NODE_ENTRY_KIND.into(),
+                actual_target_kind: OTHER_APP_ENTRY_KIND.into(),
+            }))
+        );
+    }
+
+    #[test]
+    fn update_dependency_failures_propagate_through_the_outer_result() {
+        let mut mock_hdi = MockHdi::new();
+        mock_hdi
+            .expect_must_get_valid_record()
+            .times(1)
+            .return_once(|_| Err(wasm_error!(WasmErrorInner::Guest("update dependency".into()))));
+        set_hdi(mock_hdi);
+
+        let error = validate_holon_node_update_target(&action_hash(20), &holon_node_entry_def())
+            .expect_err("dependency failure must remain an outer error");
+
+        assert!(error.to_string().contains("update dependency"));
+    }
+
+    #[test]
+    fn delete_dependency_failures_propagate_before_zome_classification() {
+        let mut mock_hdi = MockHdi::new();
+        mock_hdi
+            .expect_must_get_action()
+            .times(1)
+            .return_once(|_| Err(wasm_error!(WasmErrorInner::Guest("delete dependency".into()))));
+        // A failed dependency lookup must return before the local zome-info call.
+        mock_hdi.expect_zome_info().times(0);
+        set_hdi(mock_hdi);
+
+        let error = validate_holon_node_delete_target(&action_hash(21))
+            .expect_err("dependency failure must remain an outer error");
+
+        assert!(error.to_string().contains("delete dependency"));
+    }
+}

--- a/happ/crates/holons_guest_integrity/src/lib.rs
+++ b/happ/crates/holons_guest_integrity/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod holon_node;
 pub mod holon_node_envelope;
+pub mod holon_node_lifecycle;
 pub mod type_conversions;
 
 pub use holon_node::{
     HolonNode, LOCAL_HOLON_SPACE_DESCRIPTION, LOCAL_HOLON_SPACE_NAME, LOCAL_HOLON_SPACE_PATH,
 };
 pub use holon_node_envelope::{prepare_holon_node_envelope, HolonNodeEnvelope};
+pub use holon_node_lifecycle::{
+    validate_holon_node_delete_target, validate_holon_node_update_target,
+};
 
 pub use type_conversions::*;

--- a/happ/crates/holons_guest_integrity/src/lib.rs
+++ b/happ/crates/holons_guest_integrity/src/lib.rs
@@ -1,3 +1,15 @@
+//! Holochain substrate adapter for MAP Integrity validation.
+//!
+//! This crate forms the boundary between substrate-independent MAP domain rules
+//! and the underlying Holochain platform. It resolves Holochain-specific inputs
+//! and dependencies, projects them into the narrow domain models consumed by
+//! shared validation, and preserves the distinction between platform execution
+//! failures and completed consensus validation verdicts.
+//!
+//! Normative validation policy belongs in substrate-free shared crates. This
+//! adapter owns only the Holochain-aware extraction, classification, and error
+//! propagation required to execute that policy inside an Integrity zome.
+
 pub mod holon_node;
 pub mod holon_node_envelope;
 pub mod holon_node_lifecycle;

--- a/happ/zomes/integrity/holons_integrity/Cargo.toml
+++ b/happ/zomes/integrity/holons_integrity/Cargo.toml
@@ -31,3 +31,5 @@ path = "../../../../shared_crates/type_system/integrity_core_types"
 
 [dev-dependencies]
 holochain_serialized_bytes = "*"
+hdi = { version = "0.7", features = ["mock"] }
+mockall = "0.13"

--- a/happ/zomes/integrity/holons_integrity/Cargo.toml
+++ b/happ/zomes/integrity/holons_integrity/Cargo.toml
@@ -31,5 +31,4 @@ path = "../../../../shared_crates/type_system/integrity_core_types"
 
 [dev-dependencies]
 holochain_serialized_bytes = "*"
-hdi = { version = "0.7", features = ["mock"] }
 mockall = "0.13"

--- a/happ/zomes/integrity/holons_integrity/src/holon_node.rs
+++ b/happ/zomes/integrity/holons_integrity/src/holon_node.rs
@@ -1,14 +1,4 @@
 use hdi::prelude::*;
-use integrity_core_types::PersistenceDelete;
-use shared_validation::*;
-
-pub fn validate_delete_holon_node(
-    _action: PersistenceDelete,
-) -> ExternResult<ValidateCallbackResult> {
-    validate_delete_holon().map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-
-    Ok(ValidateCallbackResult::Valid)
-}
 
 pub fn validate_create_link_holon_node_updates(
     _action: CreateLink,

--- a/happ/zomes/integrity/holons_integrity/src/lib.rs
+++ b/happ/zomes/integrity/holons_integrity/src/lib.rs
@@ -56,6 +56,38 @@ pub fn validate_agent_joining(
     Ok(ValidateCallbackResult::Valid)
 }
 
+/// Maps a completed lifecycle verdict onto the Integrity callback contract.
+///
+/// Host and dependency-resolution failures are propagated before this helper is
+/// called. Only deterministic PVL violations become consensus-visible
+/// `Invalid` results.
+fn lifecycle_callback_result(result: Result<(), PvlViolation>) -> ValidateCallbackResult {
+    match result {
+        Ok(()) => ValidateCallbackResult::Valid,
+        Err(violation) => ValidateCallbackResult::Invalid(violation.to_string()),
+    }
+}
+
+/// Validates one flattened `HolonNode` update through the shared adapter path.
+///
+/// All three update op arms delegate here so target extraction, scoped
+/// app-entry classification, and violation mapping cannot drift independently.
+fn validate_holon_node_update_arm(
+    original_action_hash: &ActionHash,
+    update: &Update,
+) -> ExternResult<ValidateCallbackResult> {
+    let EntryType::App(new_entry_def) = &update.entry_type else {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "flattened app-entry update did not carry an App entry type".into()
+        )));
+    };
+
+    Ok(lifecycle_callback_result(validate_holon_node_update_target(
+        original_action_hash,
+        new_entry_def,
+    )?))
+}
+
 #[hdk_extern]
 pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     match prepare_holon_node_envelope(&op)? {
@@ -72,8 +104,11 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             OpEntry::CreateEntry { app_entry, .. } => match app_entry {
                 EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
             },
-            OpEntry::UpdateEntry { app_entry, .. } => match app_entry {
-                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
+            OpEntry::UpdateEntry { app_entry, original_action_hash, action, .. } => match app_entry
+            {
+                EntryTypes::HolonNode(_) => {
+                    validate_holon_node_update_arm(&original_action_hash, &action)
+                }
             },
             _ => Ok(ValidateCallbackResult::Valid),
         },
@@ -81,8 +116,10 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             // Storage SL2 will activate this path when version-producing writes become native,
             // root-addressed updates targeting the lineage-root Create. That transition also
             // removes original_id from the entry shape and requires parity-fixture review.
-            OpUpdate::Entry { app_entry, .. } => match app_entry {
-                EntryTypes::HolonNode(_) => Ok(ValidateCallbackResult::Valid),
+            OpUpdate::Entry { app_entry, action } => match app_entry {
+                EntryTypes::HolonNode(_) => {
+                    validate_holon_node_update_arm(&action.original_action_address, &action)
+                }
                 _ => Ok(ValidateCallbackResult::Invalid(
                     "Original and updated entry types must be the same".to_string(),
                 )),
@@ -90,15 +127,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             _ => Ok(ValidateCallbackResult::Valid),
         },
         FlatOp::RegisterDelete(delete_entry) => match delete_entry {
-            OpDelete { action } => {
-                let persistence_delete = PersistenceDelete::new(
-                    persistence_agent_id_from_agent_pub_key(action.author),
-                    PersistenceTimestamp(action.timestamp.0),
-                    action.action_seq,
-                    local_id_from_action_hash(action.prev_action),
-                );
-                validate_delete_holon_node(persistence_delete)
-            }
+            OpDelete { action } => Ok(lifecycle_callback_result(
+                validate_holon_node_delete_target(&action.deletes_address)?,
+            )),
         },
         FlatOp::RegisterCreateLink { link_type, base_address, target_address, tag, action } => {
             match link_type {
@@ -251,90 +282,16 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             },
             // MAP writes currently emit Creates. Storage SL2 will exercise this path with native
             // updates targeting the lineage-root Create; envelope preparation has already run.
-            OpRecord::UpdateEntry { original_action_hash, app_entry, .. } => {
-                let original_record = must_get_valid_record(original_action_hash)?;
-                if !matches!(original_record.action(), Action::Create(_) | Action::Update(_)) {
-                    return Ok(ValidateCallbackResult::Invalid(
-                        "Original action for an update must be a Create or Update action"
-                            .to_string(),
-                    ));
-                }
+            OpRecord::UpdateEntry { original_action_hash, app_entry, action, .. } => {
                 match app_entry {
                     EntryTypes::HolonNode(_) => {
-                        let original_holon_node: Option<HolonNode> =
-                            original_record.entry().to_app_option().map_err(|e| wasm_error!(e))?;
-                        if original_holon_node.is_none() {
-                            return Ok(ValidateCallbackResult::Invalid(
-                                "The updated entry type must be the same as the original entry type"
-                                    .to_string(),
-                            ));
-                        }
-
-                        Ok(ValidateCallbackResult::Valid)
+                        validate_holon_node_update_arm(&original_action_hash, &action)
                     }
                 }
             }
-            OpRecord::DeleteEntry { original_action_hash, action, .. } => {
-                let original_record = must_get_valid_record(original_action_hash)?;
-                let original_action = original_record.action();
-                let original_entry_type = match original_action {
-                    Action::Create(create) => &create.entry_type,
-                    Action::Update(update) => &update.entry_type,
-                    _ => {
-                        return Ok(ValidateCallbackResult::Invalid(
-                            "Original action for a delete must be a Create or Update action"
-                                .to_string(),
-                        ));
-                    }
-                };
-                let app_entry_type = match original_entry_type {
-                    EntryType::App(app_entry_type) => app_entry_type,
-                    _ => {
-                        return Ok(ValidateCallbackResult::Valid);
-                    }
-                };
-                let entry = match original_record.entry().as_option() {
-                    Some(entry) => entry,
-                    None => {
-                        return if original_entry_type.visibility().is_public() {
-                            Ok(
-                                    ValidateCallbackResult::Invalid(
-                                        "Original record for a delete of a public entry must contain an entry"
-                                            .to_string(),
-                                    ),
-                                )
-                        } else {
-                            Ok(ValidateCallbackResult::Valid)
-                        };
-                    }
-                };
-                let original_app_entry = match EntryTypes::deserialize_from_type(
-                    app_entry_type.zome_index.clone(),
-                    app_entry_type.entry_index.clone(),
-                    &entry,
-                )? {
-                    Some(app_entry) => app_entry,
-                    None => {
-                        return Ok(
-                                ValidateCallbackResult::Invalid(
-                                    "Original app entry must be one of the defined entry types for this zome"
-                                        .to_string(),
-                                ),
-                            );
-                    }
-                };
-                match original_app_entry {
-                    EntryTypes::HolonNode(_original_holon_node) => {
-                        let persistence_delete = PersistenceDelete::new(
-                            persistence_agent_id_from_agent_pub_key(action.author),
-                            PersistenceTimestamp(action.timestamp.0),
-                            action.action_seq,
-                            local_id_from_action_hash(action.prev_action),
-                        );
-                        validate_delete_holon_node(persistence_delete)
-                    }
-                }
-            }
+            OpRecord::DeleteEntry { action, .. } => Ok(lifecycle_callback_result(
+                validate_holon_node_delete_target(&action.deletes_address)?,
+            )),
             OpRecord::CreateLink { base_address, target_address, tag, link_type, action } => {
                 match link_type {
                     LinkTypes::HolonNodeUpdates => validate_create_link_holon_node_updates(

--- a/happ/zomes/integrity/holons_integrity/src/tests.rs
+++ b/happ/zomes/integrity/holons_integrity/src/tests.rs
@@ -1,27 +1,276 @@
 use super::*;
-use holochain_serialized_bytes::{SerializedBytes, UnsafeBytes};
+use holochain_serialized_bytes::{encode, SerializedBytes, UnsafeBytes};
+use mockall::mock;
 use shared_validation::pvl_limits_v1::MAX_HOLON_NODE_BYTES;
 
-fn oversized_store_record_update() -> Op {
-    let entry_type =
-        EntryType::App(AppEntryDef::new(EntryDefIndex(0), ZomeIndex(0), EntryVisibility::Public));
-    let update = Update {
+const HOLON_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
+const HOLON_ZOME_INDEX: ZomeIndex = ZomeIndex(0);
+
+// HDI 0.7.1 exposes mockall behind its `mock` feature but does not generate
+// the documented `MockHdiT` type. Keep this callback-level test double local
+// and install it through the same thread-local seam used by the guest adapter.
+mock! {
+    Hdi {}
+
+    impl HdiT for Hdi {
+        fn verify_signature(&self, input: VerifySignature) -> ExternResult<bool>;
+        fn must_get_entry(&self, input: MustGetEntryInput) -> ExternResult<EntryHashed>;
+        fn must_get_action(
+            &self,
+            input: MustGetActionInput,
+        ) -> ExternResult<SignedActionHashed>;
+        fn must_get_valid_record(
+            &self,
+            input: MustGetValidRecordInput,
+        ) -> ExternResult<Record>;
+        fn must_get_agent_activity(
+            &self,
+            input: MustGetAgentActivityInput,
+        ) -> ExternResult<Vec<RegisterAgentActivity>>;
+        fn dna_info(&self, input: ()) -> ExternResult<DnaInfo>;
+        fn zome_info(&self, input: ()) -> ExternResult<ZomeInfo>;
+        fn trace(&self, input: TraceMsg) -> ExternResult<()>;
+        fn x_salsa20_poly1305_decrypt(
+            &self,
+            input: XSalsa20Poly1305Decrypt,
+        ) -> ExternResult<Option<XSalsa20Poly1305Data>>;
+        fn x_25519_x_salsa20_poly1305_decrypt(
+            &self,
+            input: X25519XSalsa20Poly1305Decrypt,
+        ) -> ExternResult<Option<XSalsa20Poly1305Data>>;
+        fn ed_25519_x_salsa20_poly1305_decrypt(
+            &self,
+            input: Ed25519XSalsa20Poly1305Decrypt,
+        ) -> ExternResult<XSalsa20Poly1305Data>;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum UpdateOpForm {
+    StoreEntry,
+    RegisterUpdate,
+    StoreRecord,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DeleteOpForm {
+    RegisterDelete,
+    StoreRecord,
+}
+
+fn action_hash(seed: u8) -> ActionHash {
+    ActionHash::from_raw_36(vec![seed; 36])
+}
+
+fn holon_entry_type() -> EntryType {
+    EntryType::App(AppEntryDef::new(
+        HOLON_ENTRY_DEF_INDEX,
+        HOLON_ZOME_INDEX,
+        EntryVisibility::Public,
+    ))
+}
+
+fn create_action() -> Create {
+    Create {
         author: AgentPubKey::from_raw_36(vec![0; 36]),
         timestamp: Timestamp::from_micros(1),
-        action_seq: 2,
-        prev_action: ActionHash::from_raw_36(vec![1; 36]),
-        // This address is intentionally not backed by a record. Reaching
-        // must_get_valid_record would therefore fail the test.
-        original_action_address: ActionHash::from_raw_36(vec![2; 36]),
-        original_entry_address: EntryHash::from_raw_36(vec![3; 36]),
-        entry_type,
-        entry_hash: EntryHash::from_raw_36(vec![4; 36]),
+        action_seq: 1,
+        prev_action: action_hash(1),
+        entry_type: holon_entry_type(),
+        entry_hash: EntryHash::from_raw_36(vec![2; 36]),
         weight: EntryRateWeight::default(),
-    };
-    let signed_action = SignedHashed::with_presigned(
-        HoloHashed::with_pre_hashed(Action::Update(update), ActionHash::from_raw_36(vec![5; 36])),
+    }
+}
+
+fn update_action() -> Update {
+    Update {
+        author: AgentPubKey::from_raw_36(vec![0; 36]),
+        timestamp: Timestamp::from_micros(2),
+        action_seq: 2,
+        prev_action: action_hash(3),
+        original_action_address: action_hash(4),
+        original_entry_address: EntryHash::from_raw_36(vec![5; 36]),
+        entry_type: holon_entry_type(),
+        entry_hash: EntryHash::from_raw_36(vec![6; 36]),
+        weight: EntryRateWeight::default(),
+    }
+}
+
+fn delete_action() -> Delete {
+    Delete {
+        author: AgentPubKey::from_raw_36(vec![0; 36]),
+        timestamp: Timestamp::from_micros(3),
+        action_seq: 3,
+        prev_action: action_hash(7),
+        deletes_address: action_hash(8),
+        deletes_entry_address: EntryHash::from_raw_36(vec![9; 36]),
+        weight: RateWeight::default(),
+    }
+}
+
+fn signed_entry_creation_action(action: EntryCreationAction) -> SignedHashed<EntryCreationAction> {
+    SignedHashed::with_presigned(
+        HoloHashed::with_pre_hashed(action, action_hash(10)),
         Signature([0; SIGNATURE_BYTES]),
-    );
+    )
+}
+
+fn signed_update(action: Update) -> SignedHashed<Update> {
+    SignedHashed::with_presigned(
+        HoloHashed::with_pre_hashed(action, action_hash(11)),
+        Signature([0; SIGNATURE_BYTES]),
+    )
+}
+
+fn signed_delete(action: Delete) -> SignedHashed<Delete> {
+    SignedHashed::with_presigned(
+        HoloHashed::with_pre_hashed(action, action_hash(12)),
+        Signature([0; SIGNATURE_BYTES]),
+    )
+}
+
+fn signed_action(action: Action) -> SignedActionHashed {
+    SignedHashed::with_presigned(
+        HoloHashed::with_pre_hashed(action, action_hash(13)),
+        Signature([0; SIGNATURE_BYTES]),
+    )
+}
+
+fn holon_entry() -> Entry {
+    let node = HolonNode::new(None, PropertyMap::new());
+    let raw = encode(&node).expect("test HolonNode must encode canonically");
+    Entry::App(AppEntryBytes(SerializedBytes::from(UnsafeBytes::from(raw))))
+}
+
+fn update_op(form: UpdateOpForm) -> Op {
+    let action = update_action();
+    let entry = holon_entry();
+
+    match form {
+        UpdateOpForm::StoreEntry => Op::StoreEntry(StoreEntry {
+            action: signed_entry_creation_action(EntryCreationAction::Update(action)),
+            entry,
+        }),
+        UpdateOpForm::RegisterUpdate => Op::RegisterUpdate(RegisterUpdate {
+            update: signed_update(action),
+            new_entry: Some(entry),
+        }),
+        UpdateOpForm::StoreRecord => Op::StoreRecord(StoreRecord {
+            record: Record::new(signed_action(Action::Update(action)), Some(entry)),
+        }),
+    }
+}
+
+fn delete_op(form: DeleteOpForm) -> Op {
+    let action = delete_action();
+
+    match form {
+        DeleteOpForm::RegisterDelete => {
+            Op::RegisterDelete(RegisterDelete { delete: signed_delete(action) })
+        }
+        DeleteOpForm::StoreRecord => Op::StoreRecord(StoreRecord {
+            record: Record::new(signed_action(Action::Delete(action)), None),
+        }),
+    }
+}
+
+fn zome_info() -> ZomeInfo {
+    ZomeInfo::new(
+        "holons_integrity".into(),
+        HOLON_ZOME_INDEX,
+        SerializedBytes::default(),
+        EntryDefs(Vec::new()),
+        Vec::new(),
+        ScopedZomeTypesSet {
+            entries: ScopedZomeTypes(vec![(HOLON_ZOME_INDEX, vec![HOLON_ENTRY_DEF_INDEX])]),
+            links: ScopedZomeTypes(Vec::new()),
+        },
+    )
+}
+
+fn install_update_target(target_action: Action) {
+    let target_record = Record::new(signed_action(target_action), None);
+    let mut mock_hdi = MockHdi::new();
+    mock_hdi
+        .expect_must_get_valid_record()
+        .withf(|input| input.0 == action_hash(4))
+        .times(0..=1)
+        .return_once(move |_| Ok(target_record));
+    // Op flattening resolves this zome's generated EntryTypes before the
+    // lifecycle adapter runs. The update adapter itself makes no zome-info call.
+    mock_hdi.expect_zome_info().times(0..=1).return_once(|_| Ok(zome_info()));
+    set_hdi(mock_hdi);
+}
+
+fn install_delete_target(target_action: Action) {
+    let target_action = signed_action(target_action);
+    let mut mock_hdi = MockHdi::new();
+    mock_hdi
+        .expect_must_get_action()
+        .withf(|input| input.0 == action_hash(8))
+        .times(0..=1)
+        .return_once(move |_| Ok(target_action));
+    mock_hdi.expect_zome_info().times(0..=1).return_once(|_| Ok(zome_info()));
+    set_hdi(mock_hdi);
+}
+
+#[test]
+fn all_three_update_arms_route_to_the_root_addressed_lifecycle_rule() {
+    for form in [UpdateOpForm::StoreEntry, UpdateOpForm::RegisterUpdate, UpdateOpForm::StoreRecord]
+    {
+        install_update_target(Action::Update(update_action()));
+
+        assert_eq!(
+            validate(update_op(form)),
+            Ok(ValidateCallbackResult::Invalid("MAP-PVL-1301: update target is invalid".into())),
+            "{form:?} did not route through update lifecycle validation"
+        );
+    }
+}
+
+#[test]
+fn all_three_update_arms_accept_a_holon_node_create_root() {
+    for form in [UpdateOpForm::StoreEntry, UpdateOpForm::RegisterUpdate, UpdateOpForm::StoreRecord]
+    {
+        install_update_target(Action::Create(create_action()));
+
+        assert_eq!(
+            validate(update_op(form)),
+            Ok(ValidateCallbackResult::Valid),
+            "{form:?} rejected a valid HolonNode Create root"
+        );
+    }
+}
+
+#[test]
+fn both_delete_arms_route_to_the_exact_version_lifecycle_rule() {
+    for form in [DeleteOpForm::RegisterDelete, DeleteOpForm::StoreRecord] {
+        install_delete_target(Action::Delete(delete_action()));
+
+        assert_eq!(
+            validate(delete_op(form)),
+            Ok(ValidateCallbackResult::Invalid("MAP-PVL-1303: delete target is invalid".into())),
+            "{form:?} did not route through delete lifecycle validation"
+        );
+    }
+}
+
+#[test]
+fn both_delete_arms_accept_a_holon_node_create_version() {
+    for form in [DeleteOpForm::RegisterDelete, DeleteOpForm::StoreRecord] {
+        install_delete_target(Action::Create(create_action()));
+
+        assert_eq!(
+            validate(delete_op(form)),
+            Ok(ValidateCallbackResult::Valid),
+            "{form:?} rejected a valid HolonNode Create version"
+        );
+    }
+}
+
+fn oversized_store_record_update() -> Op {
+    let update = update_action();
+    let signed_action = signed_action(Action::Update(update));
     let entry = Entry::App(AppEntryBytes(SerializedBytes::from(UnsafeBytes::from(vec![
         0xc1;
         MAX_HOLON_NODE_BYTES
@@ -33,6 +282,12 @@ fn oversized_store_record_update() -> Op {
 
 #[test]
 fn oversized_store_record_update_is_rejected_before_dependency_lookup() {
+    let mut mock_hdi = MockHdi::new();
+    // Any dependency request would be an ordering regression: the raw envelope
+    // guard must reject oversized bytes before lifecycle resolution begins.
+    mock_hdi.expect_must_get_valid_record().times(0);
+    set_hdi(mock_hdi);
+
     match validate(oversized_store_record_update()) {
         Ok(ValidateCallbackResult::Invalid(message)) => {
             assert_eq!(message, "MAP-PVL-1003: HolonNode exceeds 262144-byte limit");

--- a/host/map-sdk/src/internal/wire-types/references.ts
+++ b/host/map-sdk/src/internal/wire-types/references.ts
@@ -393,8 +393,8 @@ export type PvlViolationWire =
     }
   | {
       InvalidUpdateTarget: {
-        expected_entry_kind: string;
-        actual_entry_kind: string;
+        expected_target_kind: string;
+        actual_target_kind: string;
       };
     }
   | { ImmutableNativeFieldChanged: { field_name: string } }
@@ -1007,12 +1007,12 @@ export function isPvlViolationWire(value: unknown): value is PvlViolationWire {
       (
         candidate,
       ): candidate is {
-        expected_entry_kind: string;
-        actual_entry_kind: string;
+        expected_target_kind: string;
+        actual_target_kind: string;
       } =>
         isRecord(candidate) &&
-        isString(candidate['expected_entry_kind']) &&
-        isString(candidate['actual_entry_kind']),
+        isString(candidate['expected_target_kind']) &&
+        isString(candidate['actual_target_kind']),
     ) ||
     isTaggedValue(
       value,

--- a/host/map-sdk/tests/wire-types.test.ts
+++ b/host/map-sdk/tests/wire-types.test.ts
@@ -88,9 +88,37 @@ describe('PVL wire type guards', () => {
           max_bytes: 256,
         },
       },
+      {
+        InvalidUpdateTarget: {
+          expected_target_kind: 'Create',
+          actual_target_kind: 'Update',
+        },
+      },
+      {
+        ImmutableNativeFieldChanged: {
+          field_name: 'original_id',
+        },
+      },
+      {
+        InvalidDeleteTarget: {
+          expected_target_kind: 'CreateOrUpdate',
+          actual_target_kind: 'Delete',
+        },
+      },
     ];
 
     expect(violations.every(isPvlViolationWire)).toBe(true);
+  });
+
+  it('rejects the obsolete update-target field names', () => {
+    expect(
+      isPvlViolationWire({
+        InvalidUpdateTarget: {
+          expected_entry_kind: 'HolonNode',
+          actual_entry_kind: 'Other',
+        },
+      }),
+    ).toBe(false);
   });
 
   it('accepts the exhaustive malformed-reason forms', () => {

--- a/shared_crates/shared_validation/src/holon_node_lifecycle.rs
+++ b/shared_crates/shared_validation/src/holon_node_lifecycle.rs
@@ -1,0 +1,300 @@
+//! Pure, descriptor-independent validation for `HolonNode` lifecycle targets.
+//!
+//! Holochain resolves the action named by an update or delete, but the lifecycle
+//! rule needs only two facts about that target: which lifecycle action created it
+//! and which entry kind it carries. This module owns that narrow, substrate-free
+//! model so Integrity and future coordinator preflight can execute the same rule
+//! without importing Holochain actions, records, or hashes.
+//!
+//! The substrate adapter is responsible for resolving the target and classifying
+//! it into [`LifecycleTarget`]. These pure rules deliberately cannot inspect entry
+//! content: lifecycle validity is determined entirely by action metadata.
+
+use integrity_core_types::PvlViolation;
+
+/// Fixed structured-diagnostic token for a `Create` target action.
+pub const CREATE_ACTION_KIND: &str = "Create";
+
+/// Fixed structured-diagnostic token for an `Update` target action.
+pub const UPDATE_ACTION_KIND: &str = "Update";
+
+/// Fixed structured-diagnostic token for every unsupported target action.
+pub const OTHER_ACTION_KIND: &str = "Other";
+
+/// Fixed structured-diagnostic token for a scoped `HolonNode` app entry.
+pub const HOLON_NODE_ENTRY_KIND: &str = "HolonNode";
+
+/// Fixed structured-diagnostic token for an app entry outside the `HolonNode` scope.
+pub const OTHER_APP_ENTRY_KIND: &str = "OtherAppEntry";
+
+/// Fixed structured-diagnostic token for an entry that is not an app entry.
+pub const NON_APP_ENTRY_KIND: &str = "NonAppEntry";
+
+/// Fixed structured-diagnostic token for a target action with no entry type.
+pub const ABSENT_ENTRY_KIND: &str = "Absent";
+
+/// Fixed structured-diagnostic token for the action kinds accepted by a delete.
+pub const CREATE_OR_UPDATE_ACTION_KIND: &str = "CreateOrUpdate";
+
+/// Lifecycle-relevant classification of the action that a write targets.
+///
+/// This is intentionally closed and narrower than Holochain's `Action`: PVL needs
+/// to distinguish the two entry-creation actions and treats every other action
+/// identically for lifecycle validation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TargetActionKind {
+    /// A Holochain `Create` action.
+    Create,
+    /// A Holochain `Update` action.
+    Update,
+    /// Any action kind that does not create an entry version.
+    Other,
+}
+
+impl TargetActionKind {
+    /// Returns the stable token recorded in structured PVL diagnostics.
+    pub const fn diagnostic_token(self) -> &'static str {
+        match self {
+            Self::Create => CREATE_ACTION_KIND,
+            Self::Update => UPDATE_ACTION_KIND,
+            Self::Other => OTHER_ACTION_KIND,
+        }
+    }
+}
+
+/// Lifecycle-relevant classification of the entry type carried by a target action.
+///
+/// `HolonNode` identity includes its defining integrity-zome scope. The substrate
+/// adapter must therefore classify the complete scoped app-entry identity rather
+/// than relying on an entry-definition index alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TargetEntryKind {
+    /// The scoped app-entry identity for `HolonNode`.
+    HolonNode,
+    /// An app entry whose scoped identity is not `HolonNode`.
+    OtherAppEntry,
+    /// A non-app entry type, such as an agent or capability entry.
+    NonAppEntry,
+    /// An action that carries no entry type.
+    Absent,
+}
+
+impl TargetEntryKind {
+    /// Returns the stable token recorded in structured PVL diagnostics.
+    pub const fn diagnostic_token(self) -> &'static str {
+        match self {
+            Self::HolonNode => HOLON_NODE_ENTRY_KIND,
+            Self::OtherAppEntry => OTHER_APP_ENTRY_KIND,
+            Self::NonAppEntry => NON_APP_ENTRY_KIND,
+            Self::Absent => ABSENT_ENTRY_KIND,
+        }
+    }
+}
+
+/// Substrate-free facts about the resolved target of an update or delete.
+///
+/// Resolution failures are not represented here. The substrate adapter must
+/// propagate those failures before constructing this value so temporarily
+/// unavailable dependencies cannot become permanent PVL violations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LifecycleTarget {
+    /// The lifecycle-relevant kind of the resolved target action.
+    pub action_kind: TargetActionKind,
+    /// The lifecycle-relevant kind of entry carried by the target action.
+    pub entry_kind: TargetEntryKind,
+}
+
+/// Validates that an update is rooted directly at a `HolonNode` `Create`.
+///
+/// MAP uses `original_action_address` as a lineage-root pointer, not as an
+/// immediate-predecessor pointer. An `Update` target is therefore invalid even
+/// when it carries a `HolonNode`.
+///
+/// Action kind is checked before entry kind so the structured diagnostic reports
+/// the first failing lifecycle axis.
+pub fn validate_update_target(target: &LifecycleTarget) -> Result<(), PvlViolation> {
+    if target.action_kind != TargetActionKind::Create {
+        return Err(PvlViolation::InvalidUpdateTarget {
+            expected_target_kind: CREATE_ACTION_KIND.into(),
+            actual_target_kind: target.action_kind.diagnostic_token().into(),
+        });
+    }
+
+    if target.entry_kind != TargetEntryKind::HolonNode {
+        return Err(PvlViolation::InvalidUpdateTarget {
+            expected_target_kind: HOLON_NODE_ENTRY_KIND.into(),
+            actual_target_kind: target.entry_kind.diagnostic_token().into(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates that a delete names an exact persisted `HolonNode` version.
+///
+/// Both `Create` and `Update` actions identify exact entry versions and are valid
+/// delete targets. Other action kinds, absent entries, non-app entries, and app
+/// entries outside the scoped `HolonNode` identity are rejected.
+///
+/// Action kind is checked before entry kind so the structured diagnostic reports
+/// the first failing lifecycle axis.
+pub fn validate_delete_target(target: &LifecycleTarget) -> Result<(), PvlViolation> {
+    if !matches!(target.action_kind, TargetActionKind::Create | TargetActionKind::Update) {
+        return Err(PvlViolation::InvalidDeleteTarget {
+            expected_target_kind: CREATE_OR_UPDATE_ACTION_KIND.into(),
+            actual_target_kind: target.action_kind.diagnostic_token().into(),
+        });
+    }
+
+    if target.entry_kind != TargetEntryKind::HolonNode {
+        return Err(PvlViolation::InvalidDeleteTarget {
+            expected_target_kind: HOLON_NODE_ENTRY_KIND.into(),
+            actual_target_kind: target.entry_kind.diagnostic_token().into(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACTION_KINDS: [TargetActionKind; 3] =
+        [TargetActionKind::Create, TargetActionKind::Update, TargetActionKind::Other];
+    const ENTRY_KINDS: [TargetEntryKind; 4] = [
+        TargetEntryKind::HolonNode,
+        TargetEntryKind::OtherAppEntry,
+        TargetEntryKind::NonAppEntry,
+        TargetEntryKind::Absent,
+    ];
+
+    fn expected_update_violation(target: &LifecycleTarget) -> PvlViolation {
+        let (expected_target_kind, actual_target_kind) =
+            if target.action_kind != TargetActionKind::Create {
+                (CREATE_ACTION_KIND, target.action_kind.diagnostic_token())
+            } else {
+                (HOLON_NODE_ENTRY_KIND, target.entry_kind.diagnostic_token())
+            };
+
+        PvlViolation::InvalidUpdateTarget {
+            expected_target_kind: expected_target_kind.into(),
+            actual_target_kind: actual_target_kind.into(),
+        }
+    }
+
+    fn expected_delete_violation(target: &LifecycleTarget) -> PvlViolation {
+        let (expected_target_kind, actual_target_kind) =
+            if !matches!(target.action_kind, TargetActionKind::Create | TargetActionKind::Update) {
+                (CREATE_OR_UPDATE_ACTION_KIND, target.action_kind.diagnostic_token())
+            } else {
+                (HOLON_NODE_ENTRY_KIND, target.entry_kind.diagnostic_token())
+            };
+
+        PvlViolation::InvalidDeleteTarget {
+            expected_target_kind: expected_target_kind.into(),
+            actual_target_kind: actual_target_kind.into(),
+        }
+    }
+
+    #[test]
+    fn update_rule_exhausts_every_action_and_entry_kind_pair() {
+        let mut case_count = 0;
+
+        for action_kind in ACTION_KINDS {
+            for entry_kind in ENTRY_KINDS {
+                case_count += 1;
+                let target = LifecycleTarget { action_kind, entry_kind };
+                let result = validate_update_target(&target);
+
+                if target
+                    == (LifecycleTarget {
+                        action_kind: TargetActionKind::Create,
+                        entry_kind: TargetEntryKind::HolonNode,
+                    })
+                {
+                    assert_eq!(result, Ok(()), "valid target was rejected: {target:?}");
+                } else {
+                    assert_eq!(
+                        result,
+                        Err(expected_update_violation(&target)),
+                        "unexpected verdict for {target:?}"
+                    );
+                }
+            }
+        }
+
+        assert_eq!(case_count, 12);
+    }
+
+    #[test]
+    fn delete_rule_exhausts_every_action_and_entry_kind_pair() {
+        let mut case_count = 0;
+
+        for action_kind in ACTION_KINDS {
+            for entry_kind in ENTRY_KINDS {
+                case_count += 1;
+                let target = LifecycleTarget { action_kind, entry_kind };
+                let result = validate_delete_target(&target);
+                let is_valid = matches!(
+                    target.action_kind,
+                    TargetActionKind::Create | TargetActionKind::Update
+                ) && target.entry_kind == TargetEntryKind::HolonNode;
+
+                if is_valid {
+                    assert_eq!(result, Ok(()), "valid target was rejected: {target:?}");
+                } else {
+                    assert_eq!(
+                        result,
+                        Err(expected_delete_violation(&target)),
+                        "unexpected verdict for {target:?}"
+                    );
+                }
+            }
+        }
+
+        assert_eq!(case_count, 12);
+    }
+
+    #[test]
+    fn action_failure_takes_precedence_over_entry_failure() {
+        let target = LifecycleTarget {
+            action_kind: TargetActionKind::Other,
+            entry_kind: TargetEntryKind::Absent,
+        };
+
+        assert_eq!(
+            validate_update_target(&target),
+            Err(PvlViolation::InvalidUpdateTarget {
+                expected_target_kind: CREATE_ACTION_KIND.into(),
+                actual_target_kind: OTHER_ACTION_KIND.into(),
+            })
+        );
+        assert_eq!(
+            validate_delete_target(&target),
+            Err(PvlViolation::InvalidDeleteTarget {
+                expected_target_kind: CREATE_OR_UPDATE_ACTION_KIND.into(),
+                actual_target_kind: OTHER_ACTION_KIND.into(),
+            })
+        );
+    }
+
+    #[test]
+    fn lifecycle_violations_use_stable_codes_and_messages() {
+        let update_violation = validate_update_target(&LifecycleTarget {
+            action_kind: TargetActionKind::Update,
+            entry_kind: TargetEntryKind::HolonNode,
+        })
+        .expect_err("an update-to-update lineage must be rejected");
+        let delete_violation = validate_delete_target(&LifecycleTarget {
+            action_kind: TargetActionKind::Other,
+            entry_kind: TargetEntryKind::HolonNode,
+        })
+        .expect_err("a delete must target an entry-creation action");
+
+        assert_eq!(update_violation.code(), "MAP-PVL-1301");
+        assert_eq!(update_violation.to_string(), "MAP-PVL-1301: update target is invalid");
+        assert_eq!(delete_violation.code(), "MAP-PVL-1303");
+        assert_eq!(delete_violation.to_string(), "MAP-PVL-1303: delete target is invalid");
+    }
+}

--- a/shared_crates/shared_validation/src/lib.rs
+++ b/shared_crates/shared_validation/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod holon_node_envelope;
+pub mod holon_node_lifecycle;
 pub mod holon_node_properties;
 pub mod identifier_validation;
 // Public module, part of the crate's public API
@@ -7,6 +8,7 @@ pub mod validation_helpers;
 
 // Re-exporting key functions/types for ease of use
 pub use holon_node_envelope::*;
+pub use holon_node_lifecycle::*;
 pub use holon_node_properties::*;
 pub use identifier_validation::*;
 pub use validation_helpers::*;

--- a/shared_crates/shared_validation/src/validation_helpers.rs
+++ b/shared_crates/shared_validation/src/validation_helpers.rs
@@ -4,12 +4,6 @@ use integrity_core_types::{LocalId, PersistenceLinkTag};
 /// Foundational routines for property and relationship checks
 /// applicable to both zomes
 
-// ==== Entry CUD ====
-
-pub fn validate_delete_holon() -> Result<(), ValidationError> {
-    Ok(())
-}
-
 // ==== Smartlink ====
 
 pub fn validate_create_smartlink_helper(

--- a/shared_crates/type_system/integrity_core_types/src/hc_action.rs
+++ b/shared_crates/type_system/integrity_core_types/src/hc_action.rs
@@ -57,19 +57,6 @@ pub struct PersistenceUpdate {
 }
 
 #[derive(new, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-// pub struct PersistenceDelete<W = RateWeight> {
-pub struct PersistenceDelete {
-    pub author: PersistenceAgentId,
-    pub timestamp: PersistenceTimestamp,
-    pub action_seq: u32,
-    pub prev_action: LocalId,
-    // pub deletes_address: HoloHash<Action>,
-    // pub deletes_entry_address: HoloHash<Entry>,
-
-    // pub weight: W,
-}
-
-#[derive(new, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersistenceCreateLink {
     // pub struct CreateLink<W = RateWeight> {
     pub author: PersistenceAgentId,

--- a/shared_crates/type_system/integrity_core_types/src/pvl_error.rs
+++ b/shared_crates/type_system/integrity_core_types/src/pvl_error.rs
@@ -188,9 +188,14 @@ pub enum PvlViolation {
         endpoint_kind: String,
     },
     InvalidUpdateTarget {
-        expected_entry_kind: String,
-        actual_entry_kind: String,
+        expected_target_kind: String,
+        actual_target_kind: String,
     },
+    /// Reserved for `MAP-PVL-1302` and intentionally never constructed.
+    ///
+    /// Storage SL2 removes `original_id`, the last native field that could carry a
+    /// cross-version immutability invariant. The variant remains reserved so its
+    /// consensus-visible code cannot be reassigned to a different rule.
     ImmutableNativeFieldChanged {
         field_name: String,
     },
@@ -413,8 +418,8 @@ mod tests {
                 endpoint_kind: "AgentPubKey".into(),
             },
             PvlViolation::InvalidUpdateTarget {
-                expected_entry_kind: "HolonNode".into(),
-                actual_entry_kind: "Other".into(),
+                expected_target_kind: "Create".into(),
+                actual_target_kind: "Update".into(),
             },
             PvlViolation::ImmutableNativeFieldChanged { field_name: "id".into() },
             PvlViolation::InvalidDeleteTarget {
@@ -588,6 +593,24 @@ mod tests {
                     max_bytes: 256,
                 },
                 json!({"IdentifierTooLong":{"field_name":"local_id","identifier_kind":"LocalId","actual_bytes":300,"max_bytes":256}}),
+            ),
+            (
+                PvlViolation::InvalidUpdateTarget {
+                    expected_target_kind: "Create".into(),
+                    actual_target_kind: "Update".into(),
+                },
+                json!({"InvalidUpdateTarget":{"expected_target_kind":"Create","actual_target_kind":"Update"}}),
+            ),
+            (
+                PvlViolation::ImmutableNativeFieldChanged { field_name: "original_id".into() },
+                json!({"ImmutableNativeFieldChanged":{"field_name":"original_id"}}),
+            ),
+            (
+                PvlViolation::InvalidDeleteTarget {
+                    expected_target_kind: "CreateOrUpdate".into(),
+                    actual_target_kind: "Delete".into(),
+                },
+                json!({"InvalidDeleteTarget":{"expected_target_kind":"CreateOrUpdate","actual_target_kind":"Delete"}}),
             ),
         ];
 


### PR DESCRIPTION
## PVL PR 5 — Holon Update and Delete Validation

Closes #609. Implements PVL Design Spec v0.5 §§3.3, 9.2, 10.2, 11, 15(8) and PVL Implementation Plan v2.5 PR 5: descriptor-independent lifecycle validation for `HolonNode` update and delete operations across the two-layer PVL architecture.

### What changed

**Pure core** (`shared_crates/shared_validation/src/holon_node_lifecycle.rs` — new)
- Closed, substrate-free facts model: `TargetActionKind` × `TargetEntryKind` → `LifecycleTarget`, with fixed `&'static str` diagnostic tokens per variant.
- `validate_update_target`: only a `Create` carrying `HolonNode` is a valid update target — update-to-update chains are rejected (`MAP-PVL-1301`), because `original_action_address` is a lineage-root pointer in MAP's root-addressed topology.
- `validate_delete_target`: a `Create` **or** `Update` carrying `HolonNode` is valid (`MAP-PVL-1303` otherwise) — each names one exact persisted version.
- Action kind is evaluated before entry kind, so the violation reports the axis that actually failed.

**Substrate adapter** (`happ/crates/holons_guest_integrity/src/holon_node_lifecycle.rs` — new)
- Update targets resolve via `must_get_valid_record` (inductive validity for the structural lineage root, bounded at one hop); delete targets via `must_get_action` (exact version, no lineage carried forward).
- Both read action kind and entry type from the **action** — no target entry is ever requested or deserialized. This removes the up-to-262,144-byte decode the old delete arm paid per validated op.
- `HolonNode` classification uses complete scoped app-entry identity (zome index + entry index), not entry index alone: the update path compares against the validated op's own `AppEntryDef`; the delete path derives scope from a local `zome_info()` call.
- `ExternResult<Result<T, PvlViolation>>` separation preserved: `must_get_*` failures propagate as outer errors (`UnresolvedDependencies`) and are never converted into deterministic violations.

**Integrity routing** (`holons_integrity/src/lib.rs`)
- All five lifecycle arms route through one adapter path per operation type: `StoreEntry::UpdateEntry`, `RegisterUpdate::Entry`, `StoreRecord::UpdateEntry` → update rule; `RegisterDelete`, `StoreRecord::DeleteEntry` → delete rule.
- The PR 2 raw-op envelope guard remains the first thing `validate` does; an oversized entry is rejected before any decode or dependency lookup (now mechanically proven by a mock that fails if a dependency is requested).
- `RegisterDelete` now validates `deletes_address` — the old path only had `prev_action` available and validated nothing.

**Violation contract correction**
- `InvalidUpdateTarget` fields renamed `expected_entry_kind`/`actual_entry_kind` → `expected_target_kind`/`actual_target_kind` (matching `InvalidDeleteTarget`; the variant's primary failure is an action-kind mismatch). Applied in Rust, `PvlViolationWire`, and `isPvlViolationWire`; `MAP-PVL-1301` and messages unchanged.
- `ImmutableNativeFieldChanged` (`MAP-PVL-1302`) documented as reserved and never constructed.

**Retirement of the superseded path**
- Removed: `validate_delete_holon_node`, the no-op `validate_delete_holon`, both `PersistenceDelete::new` sites, and the `PersistenceDelete` struct. SmartLink `Persistence*` types are untouched (PVL PR 6's scope).

### Behavioral impact

- **No operation authored by current MAP coordinator code is rejected.** Version-producing writes still emit `Create`s (`update_entry` appears nowhere in the workspace), so the update rule is proactive hardening against peer-authored operations; Storage SL2 will be the first to exercise it natively.
- Deletes of exact `HolonNode` versions (`Create` or `Update` originals) remain valid; deletes naming any other action or entry kind are now rejected (the old arm early-accepted non-app originals).
- Temporarily unavailable dependencies still yield `UnresolvedDependencies`, never a PVL rejection.

### Testing

- **Pure core:** both rules exhaust the full 3×4 action-kind × entry-kind matrix, asserting exact violations, tokens, axis precedence, and stable codes/messages.
- **Mocked adapter:** hdi 0.7.1's documented `MockHdiT` is not actually generated by its `mock` feature; tests use a local `mockall` implementation of `HdiT` installed via `set_hdi` (the pattern hdi's docs recommend). Covers valid/invalid targets on both paths, scoped-identity discrimination (equal entry index in another zome scope), exactly-one-dependency-lookup per op, no entry fetch, and unchanged propagation of `must_get_*` failures — the mechanical check on the `Invalid` vs `UnresolvedDependencies` distinction, which no conductor test can reach.
- **Callback level:** synthetic-op tests prove all three update arms and both delete arms route through the lifecycle adapter (exact `MAP-PVL` messages), positive paths return `Valid`, and the envelope guard rejects oversized entries before any dependency mock is touched.
- **Conductor:** the negative cases are unconstructible in-DNA (no MAP path authors a Holochain `Update`; `HolonNode` is the only app entry type), so negative coverage is pure-unit and mocked by design. The existing `delete_holon_fixture` sweetest passes with the delete rule active.
- `mockall` is confined to `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` and the hdi `mock` feature is not enabled, keeping the wasm32 test build (`test:unit:no-run`) and the WASM artifact clean.

All checks pass: `npm run fmt:check`, `npm run check`, `npm run test:unit`, `npm run sweetest`.

### Notes for reviewers

- The `InvalidUpdateTarget` rename is a PR 1 wire-contract change riding in this PR; the TypeScript mirror lands in the same commit, and a TS test rejects the obsolete field names to catch a half-finished rename.
- Lockfile churn is the `mockall` dev-dependency chain only.
- Out of scope (Storage SL2 / later PVL PRs): `original_id` removal, `update_entry` switch, predecessor lineage resolution, SmartLink validation (PR 6), dependency-budget accounting (PR 8), remaining `Persistence*` cleanup.
