### PR TITLE
624 tdl r4b reconcile core schema tdl corpus with descriptor kernel semantics

### DIFF
--- a/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -270,7 +270,7 @@
         "TypeNamePlural": "ValueTypes",
         "DisplayName": "Value Type",
         "DisplayNamePlural": "Value Types",
-        "Description": "Abstract descriptor category for scalar, enum, variant, and array value types.",
+        "Description": "Abstract root for value-type descriptor families. It classifies scalar, enum, variant, and array value descriptors and supplies their shared instance kind, but never directly describes a runtime value. Concrete value types inherit through this lineage.",
         "IsAbstractType": true,
         "DefinesInstanceTypeKind": true
       },
@@ -301,7 +301,7 @@
         "TypeNamePlural": "StringValueTypes",
         "DisplayName": "String Value Type",
         "DisplayNamePlural": "String Value Types",
-        "Description": "Abstract descriptor category for string-based value types.",
+        "Description": "Abstract descriptor family for string-based value types. It does not directly describe runtime values; every concrete descendant inherits its string classification and core Equals and LessThan operator affordances additively. A specialization retains those affordances and may add its own operators.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -342,7 +342,7 @@
         "TypeNamePlural": "IntegerValueTypes",
         "DisplayName": "Integer Value Type",
         "DisplayNamePlural": "Integer Value Types",
-        "Description": "Abstract descriptor category for integer-based value types.",
+        "Description": "Abstract descriptor family for integer-based value types. It does not directly describe runtime values; every concrete descendant inherits its integer classification and core Equals and LessThan operator affordances additively. A specialization retains those affordances and may add its own operators.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -383,7 +383,7 @@
         "TypeNamePlural": "BooleanValueTypes",
         "DisplayName": "Boolean Value Type",
         "DisplayNamePlural": "Boolean Value Types",
-        "Description": "Abstract descriptor category for Boolean value types.",
+        "Description": "Abstract descriptor family for Boolean value types. It does not directly describe runtime values; every concrete descendant inherits its Boolean classification and core Equals operator affordance additively. A specialization retains that affordance and may add its own operators.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -421,7 +421,7 @@
         "TypeNamePlural": "BytesValueTypes",
         "DisplayName": "Bytes Value Type",
         "DisplayNamePlural": "Bytes Value Types",
-        "Description": "Abstract descriptor category for byte-sequence value types.",
+        "Description": "Abstract descriptor family for byte-sequence value types. It does not directly describe runtime values; concrete descendants inherit its bytes classification without implying operator affordances that bytes value types may not share.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -451,7 +451,7 @@
         "TypeNamePlural": "EnumValueTypes",
         "DisplayName": "Enum Value Type",
         "DisplayNamePlural": "Enum Value Types",
-        "Description": "Abstract descriptor category for enum value types.",
+        "Description": "Abstract descriptor family for enum value types. It does not directly describe runtime values; every concrete enum descendant inherits the enum classification and core Equals operator affordance additively, without requiring each enum definition to author it locally. A specialization retains that affordance and may add its own operators.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -489,7 +489,7 @@
         "TypeNamePlural": "MapEnumValueTypes",
         "DisplayName": "MapEnumValueType",
         "DisplayNamePlural": "MapEnumValueTypes",
-        "Description": "Abstract base for concrete enum value-type descriptors.",
+        "Description": "Abstract MAP enum lineage anchor for concrete enum value-type descriptors. It is not a generic runtime enum value; concrete enum definitions extend it to share the generic enum semantics inherited from EnumValueType while retaining their own variants and domain-specific metadata.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -519,7 +519,7 @@
         "TypeNamePlural": "EnumVariantValueTypes",
         "DisplayName": "Enum Variant Value Type",
         "DisplayNamePlural": "Enum Variant Value Types",
-        "Description": "Abstract descriptor category for symbolic variants owned by enum value types.",
+        "Description": "Abstract descriptor family for symbolic values owned by enum value types. It does not directly describe runtime values; concrete variant descriptors inherit this classification while their owning enum supplies the permitted member set.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -549,7 +549,7 @@
         "TypeNamePlural": "MapEnumVariantValueTypes",
         "DisplayName": "MapEnumVariant Value Type",
         "DisplayNamePlural": "MapEnumVariant Value Types",
-        "Description": "Abstract base for concrete variants of enum-based value types.",
+        "Description": "Abstract MAP enum-variant lineage anchor for concrete enum-member descriptors. It is not a generic runtime variant; concrete variants extend it to share the enum-variant classification while remaining owner-qualified members of a particular enum definition.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -579,7 +579,7 @@
         "TypeNamePlural": "ValueArrayValueTypes",
         "DisplayName": "Value Array Type",
         "DisplayNamePlural": "Value Array Types",
-        "Description": "Abstract descriptor category for array value types.",
+        "Description": "Abstract descriptor family for array value types. It does not directly describe runtime values; concrete descendants inherit the array classification and supply the element value type and any applicable array constraints.",
         "IsAbstractType": true
       },
       "relationships": [
@@ -609,7 +609,7 @@
         "TypeNamePlural": "MapValueArrayTypes",
         "DisplayName": "MapValueArrayType",
         "DisplayNamePlural": "MapValueArrayTypes",
-        "Description": "Abstract base for concrete array value-type descriptors, which supply their element value type.",
+        "Description": "Abstract MAP array lineage anchor for concrete array value-type descriptors. It is not a generic runtime array value; concrete descendants extend it to share array semantics while supplying their own element value type and applicable constraints.",
         "IsAbstractType": true
       },
       "relationships": [

--- a/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-abstract-value-types.json
@@ -1,4 +1,19 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-value-constraint-types.json",
+      "MAP Schema Types-map-core-schema-operator-types.json",
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-abstract-value-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "MetaValueType.MetaTypeDescriptor",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-command-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-command-types.json
@@ -1,4 +1,16 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-dance-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-command-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "MetaCommandType.MetaHolonType",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-concrete-value-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-concrete-value-types.json
@@ -1,4 +1,17 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-root.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-concrete-value-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "MapStringValueType.StringValueType",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-dance-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-dance-schema.json
@@ -1,26 +1,19 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-property-types.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-dance-schema.csv"
+    ]
+  },
   "holons": [
-    {
-      "key": "MAP Dance Schema-v0.0.4",
-      "type": "Schema.HolonType",
-      "properties": {
-        "SchemaName": "MAP Dance Schema-v0.0.4",
-        "Description": "Schema containing all the abstract and core type definitions comprising the MAP Core Dance Schema."
-      },
-      "relationships": [
-        {
-          "name": "DependsOn",
-          "target": [
-            {
-              "$ref": "MAP Core Schema-v0.0.7"
-            },
-            {
-              "$ref": "MAP Key Rule Schema"
-            }
-          ]
-        }
-      ]
-    },
     {
       "key": "ImplementationName.FormatRule",
       "type": "FormatRule.KeyRuleType",
@@ -62,7 +55,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -110,7 +103,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -149,7 +142,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -180,7 +173,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -218,7 +211,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -247,7 +240,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -298,7 +291,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -372,7 +365,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -416,7 +409,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -449,7 +442,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -507,7 +500,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -556,7 +549,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -615,7 +608,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -664,7 +657,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -722,7 +715,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -771,7 +764,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -829,7 +822,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -878,7 +871,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -936,7 +929,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -985,7 +978,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1043,7 +1036,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1092,7 +1085,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1150,7 +1143,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1199,7 +1192,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1257,7 +1250,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1306,7 +1299,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1364,7 +1357,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1412,7 +1405,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1470,7 +1463,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1516,7 +1509,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1553,7 +1546,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1591,7 +1584,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1628,7 +1621,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1665,7 +1658,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1702,7 +1695,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1739,7 +1732,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1776,7 +1769,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1813,7 +1806,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1850,7 +1843,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1887,7 +1880,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1924,7 +1917,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1961,7 +1954,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1998,7 +1991,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2036,7 +2029,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2073,7 +2066,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2116,7 +2109,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2145,7 +2138,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2174,7 +2167,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2203,7 +2196,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2243,7 +2236,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2272,7 +2265,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2301,7 +2294,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2368,7 +2361,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2397,7 +2390,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2426,7 +2419,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2455,7 +2448,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2484,7 +2477,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2513,7 +2506,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2542,7 +2535,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2571,7 +2564,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2600,7 +2593,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2629,7 +2622,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2658,7 +2651,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2687,7 +2680,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2733,7 +2726,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2762,7 +2755,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2791,7 +2784,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2820,7 +2813,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -2849,7 +2842,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2886,7 +2879,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2937,7 +2930,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2974,7 +2967,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -3014,7 +3007,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -3043,7 +3036,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -3072,7 +3065,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -3111,7 +3104,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -3170,7 +3163,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -3217,7 +3210,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -3276,7 +3269,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Dance Schema-v0.0.4"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },

--- a/generated/json-imports/MAP Schema Types-map-core-schema-keyrules-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-keyrules-schema.json
@@ -1,23 +1,19 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-dance-schema.json",
+      "MAP Schema Types-map-core-schema-property-types.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-keyrules-schema.csv"
+    ]
+  },
   "holons": [
-    {
-      "key": "MAP Key Rule Schema",
-      "type": "Schema.HolonType",
-      "properties": {
-        "SchemaName": "MAP Key Rule Schema",
-        "Description": "Groups all type descriptors related to holon key derivation strategies in MAP."
-      },
-      "relationships": [
-        {
-          "name": "DependsOn",
-          "target": [
-            {
-              "$ref": "MAP Core Schema-v0.0.7"
-            }
-          ]
-        }
-      ]
-    },
     {
       "key": "KeyRuleType.HolonType",
       "type": "MetaHolonType.MetaTypeDescriptor",
@@ -42,7 +38,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -71,7 +67,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -127,7 +123,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -156,7 +152,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -185,7 +181,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -214,7 +210,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -243,7 +239,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -272,7 +268,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -301,7 +297,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -335,7 +331,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -393,7 +389,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Key Rule Schema"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },

--- a/generated/json-imports/MAP Schema Types-map-core-schema-loader-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-loader-types.json
@@ -1,4 +1,18 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-property-types.json",
+      "MAP Schema Types-map-core-schema-dance-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-loader-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "LoaderHolon.HolonType",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
@@ -79,7 +79,7 @@
         "TypeNamePlural": "AffordsOperatorRelationships",
         "DisplayName": "AffordsOperator Relationship",
         "DisplayNamePlural": "AffordsOperator Relationships",
-        "Description": "Links a ValueType descriptor to the concrete operator descriptors available for that value type, supporting validation and query construction.",
+        "Description": "Links a ValueType descriptor to the concrete operator descriptors available for that value type, supporting validation and query construction. Core operator targets may be populated on an abstract value-family anchor so that every specialization inherits them through Additive relationship semantics. A specialization retains those inherited affordances and may add distinct operators, but cannot replace or remove the core targets.",
         "IsDefinitional": true,
         "MinCardinality": 0,
         "DeletionSemantic": "Block",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-operator-types.json
@@ -1,4 +1,18 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-operator-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "MetaOperatorType.MetaHolonType",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-property-types.json
@@ -1,4 +1,16 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-root.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-property-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "AllowsDuplicates.PropertyType",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-query-schema.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-query-schema.json
@@ -1,26 +1,19 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-dance-schema.json",
+      "MAP Schema Types-map-core-schema-loader-types.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-query-schema.csv"
+    ]
+  },
   "holons": [
-    {
-      "key": "MAP Query Schema-v0.0.1",
-      "type": "Schema.HolonType",
-      "properties": {
-        "SchemaName": "MAP Query Schema-v0.0.1",
-        "Description": "Schema containing the minimal query substrate (QueryDance, request/graph/step, bindings, and execution state) needed for the SeedHolons + Expand QueryDance vertical slice."
-      },
-      "relationships": [
-        {
-          "name": "DependsOn",
-          "target": [
-            {
-              "$ref": "MAP Core Schema-v0.0.7"
-            },
-            {
-              "$ref": "MAP Dance Schema-v0.0.4"
-            }
-          ]
-        }
-      ]
-    },
     {
       "key": "QueryDanceRequest.HolonType",
       "type": "MetaHolonType.MetaTypeDescriptor",
@@ -44,7 +37,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -84,7 +77,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -121,7 +114,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -175,7 +168,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -235,7 +228,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -279,7 +272,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -308,7 +301,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -345,7 +338,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -385,7 +378,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -436,7 +429,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -474,7 +467,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -519,7 +512,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -556,7 +549,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -610,7 +603,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -647,7 +640,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -684,7 +677,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -722,7 +715,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -759,7 +752,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -796,7 +789,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -833,7 +826,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -879,7 +872,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -908,7 +901,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -937,7 +930,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -966,7 +959,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         }
@@ -999,7 +992,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1057,7 +1050,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1106,7 +1099,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1164,7 +1157,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1213,7 +1206,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1272,7 +1265,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1321,7 +1314,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1379,7 +1372,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1428,7 +1421,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1487,7 +1480,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1536,7 +1529,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1594,7 +1587,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1643,7 +1636,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1701,7 +1694,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1750,7 +1743,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1809,7 +1802,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1858,7 +1851,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1916,7 +1909,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -1965,7 +1958,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2023,7 +2016,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2072,7 +2065,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2130,7 +2123,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2179,7 +2172,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2237,7 +2230,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2286,7 +2279,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2344,7 +2337,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2393,7 +2386,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2451,7 +2444,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2499,7 +2492,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2558,7 +2551,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2607,7 +2600,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2665,7 +2658,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2714,7 +2707,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2772,7 +2765,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2820,7 +2813,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },
@@ -2878,7 +2871,7 @@
           "name": "ComponentOf",
           "target": [
             {
-              "$ref": "MAP Query Schema-v0.0.1"
+              "$ref": "MAP Core Schema-v0.0.7"
             }
           ]
         },

--- a/generated/json-imports/MAP Schema Types-map-core-schema-relationship-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-relationship-types.json
@@ -1,4 +1,17 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-relationship-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "(TypeDescriptor)-[ComponentOf]->(Schema.HolonType)",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-root.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-root.json
@@ -1,4 +1,20 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-command-types.json",
+      "MAP Schema Types-map-core-schema-property-types.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json",
+      "MAP Schema Types-map-core-schema-dance-schema.json",
+      "MAP Schema Types-map-core-schema-query-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-root.csv"
+    ]
+  },
   "holons": [
     {
       "key": "MAP Core Schema-v0.0.7",
@@ -6,23 +22,7 @@
       "properties": {
         "SchemaName": "MAP Core Schema-v0.0.7",
         "Description": "Schema containing the root descriptor types, meta-types, and foundational holon types for the MAP type system."
-      },
-      "relationships": [
-        {
-          "name": "DependsOn",
-          "target": [
-            {
-              "$ref": "MAP Key Rule Schema"
-            },
-            {
-              "$ref": "MAP Dance Schema-v0.0.4"
-            },
-            {
-              "$ref": "MAP Query Schema-v0.0.1"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "key": "TypeDescriptor",

--- a/generated/json-imports/MAP Schema Types-map-core-schema-value-constraint-types.json
+++ b/generated/json-imports/MAP Schema Types-map-core-schema-value-constraint-types.json
@@ -1,4 +1,18 @@
 {
+  "meta": {
+    "export_mode": "by-file",
+    "generated_at": "2026-07-21T14:08:14",
+    "generator": "MAP Airtable CSV to MAP JSON Python Script",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-keyrules-schema.json"
+    ],
+    "source_files": [
+      "MAP Schema Types-map-core-schema-value-constraint-types.csv"
+    ]
+  },
   "holons": [
     {
       "key": "ValueConstraintType.HolonType",

--- a/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-abstract-value-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-value-constraint-types.json","MAP Schema Types-map-core-schema-operator-types.json","MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-keyrules-schema.json","MAP Schema Types-map-core-schema-relationship-types.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
 }
 
 holon MetaValueType.MetaTypeDescriptor {

--- a/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-abstract-value-types.tdl
@@ -116,7 +116,7 @@ abstract value ValueType.TypeDescriptor {
   extends TypeDescriptor
   DefinesInstanceTypeKind true
   header {
-    description: "Abstract descriptor category for scalar, enum, variant, and array value types."
+    description: "Abstract root for value-type descriptor families. It classifies scalar, enum, variant, and array value descriptors and supplies their shared instance kind, but never directly describes a runtime value. Concrete value types inherit through this lineage."
     display_name: "Value Type"
     display_plural: "Value Types"
     plural: "ValueTypes"
@@ -127,7 +127,7 @@ abstract value StringValueType.ValueType {
   type MetaStringValueType.MetaValueType
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for string-based value types."
+    description: "Abstract descriptor family for string-based value types. It does not directly describe runtime values; every concrete descendant inherits its string classification and core Equals and LessThan operator affordances additively. A specialization retains those affordances and may add its own operators."
     display_name: "String Value Type"
     display_plural: "String Value Types"
     plural: "StringValueTypes"
@@ -144,7 +144,7 @@ abstract value IntegerValueType.ValueType {
   type MetaIntegerValueType.MetaValueType
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for integer-based value types."
+    description: "Abstract descriptor family for integer-based value types. It does not directly describe runtime values; every concrete descendant inherits its integer classification and core Equals and LessThan operator affordances additively. A specialization retains those affordances and may add its own operators."
     display_name: "Integer Value Type"
     display_plural: "Integer Value Types"
     plural: "IntegerValueTypes"
@@ -161,7 +161,7 @@ abstract value BooleanValueType.ValueType {
   type MetaValueType.MetaTypeDescriptor
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for Boolean value types."
+    description: "Abstract descriptor family for Boolean value types. It does not directly describe runtime values; every concrete descendant inherits its Boolean classification and core Equals operator affordance additively. A specialization retains that affordance and may add its own operators."
     display_name: "Boolean Value Type"
     display_plural: "Boolean Value Types"
     plural: "BooleanValueTypes"
@@ -175,7 +175,7 @@ abstract value BytesValueType.ValueType {
   type MetaBytesValueType.MetaValueType
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for byte-sequence value types."
+    description: "Abstract descriptor family for byte-sequence value types. It does not directly describe runtime values; concrete descendants inherit its bytes classification without implying operator affordances that bytes value types may not share."
     display_name: "Bytes Value Type"
     display_plural: "Bytes Value Types"
     plural: "BytesValueTypes"
@@ -186,7 +186,7 @@ abstract enum EnumValueType.ValueType {
   type MetaEnumValueType.MetaValueType
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for enum value types."
+    description: "Abstract descriptor family for enum value types. It does not directly describe runtime values; every concrete enum descendant inherits the enum classification and core Equals operator affordance additively, without requiring each enum definition to author it locally. A specialization retains that affordance and may add its own operators."
     display_name: "Enum Value Type"
     display_plural: "Enum Value Types"
     plural: "EnumValueTypes"
@@ -200,7 +200,7 @@ abstract enum MapEnumValueType.EnumValueType {
   type MetaEnumValueType.MetaValueType
   extends EnumValueType.ValueType
   header {
-    description: "Abstract base for concrete enum value-type descriptors."
+    description: "Abstract MAP enum lineage anchor for concrete enum value-type descriptors. It is not a generic runtime enum value; concrete enum definitions extend it to share the generic enum semantics inherited from EnumValueType while retaining their own variants and domain-specific metadata."
     display_name: "MapEnumValueType"
     display_plural: "MapEnumValueTypes"
     plural: "MapEnumValueTypes"
@@ -211,7 +211,7 @@ abstract variant EnumVariantValueType.ValueType {
   type MetaValueType.MetaTypeDescriptor
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for symbolic variants owned by enum value types."
+    description: "Abstract descriptor family for symbolic values owned by enum value types. It does not directly describe runtime values; concrete variant descriptors inherit this classification while their owning enum supplies the permitted member set."
     display_name: "Enum Variant Value Type"
     display_plural: "Enum Variant Value Types"
     plural: "EnumVariantValueTypes"
@@ -222,7 +222,7 @@ abstract variant MapEnumVariantValueType.EnumVariantValueType {
   type MetaValueType.MetaTypeDescriptor
   extends EnumVariantValueType.ValueType
   header {
-    description: "Abstract base for concrete variants of enum-based value types."
+    description: "Abstract MAP enum-variant lineage anchor for concrete enum-member descriptors. It is not a generic runtime variant; concrete variants extend it to share the enum-variant classification while remaining owner-qualified members of a particular enum definition."
     display_name: "MapEnumVariant Value Type"
     display_plural: "MapEnumVariant Value Types"
     plural: "MapEnumVariantValueTypes"
@@ -233,7 +233,7 @@ abstract value ValueArrayValueType.ValueType {
   type MetaValueArrayValueType.MetaValueType
   extends ValueType.TypeDescriptor
   header {
-    description: "Abstract descriptor category for array value types."
+    description: "Abstract descriptor family for array value types. It does not directly describe runtime values; concrete descendants inherit the array classification and supply the element value type and any applicable array constraints."
     display_name: "Value Array Type"
     display_plural: "Value Array Types"
     plural: "ValueArrayValueTypes"
@@ -244,7 +244,7 @@ abstract value MapValueArrayType.ValueArrayValueType {
   type MetaValueArrayValueType.MetaValueType
   extends ValueArrayValueType.ValueType
   header {
-    description: "Abstract base for concrete array value-type descriptors, which supply their element value type."
+    description: "Abstract MAP array lineage anchor for concrete array value-type descriptors. It is not a generic runtime array value; concrete descendants extend it to share array semantics while supplying their own element value type and applicable constraints."
     display_name: "MapValueArrayType"
     display_plural: "MapValueArrayTypes"
     plural: "MapValueArrayTypes"

--- a/schema-src/MAP Schema Types-map-core-schema-command-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-command-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-command-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-dance-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Dance Schema-v0.0.4"
 }
 
 holon MetaCommandType.MetaHolonType {

--- a/schema-src/MAP Schema Types-map-core-schema-concrete-value-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-concrete-value-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-concrete-value-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-abstract-value-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json","MAP Schema Types-map-core-schema-root.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
 }
 
 value MapStringValueType.StringValueType {

--- a/schema-src/MAP Schema Types-map-core-schema-dance-schema.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-dance-schema.tdl
@@ -1,6 +1,11 @@
-schema "MAP Dance Schema-v0.0.4" {
-  depends_on "MAP Core Schema-v0.0.7"
-  depends_on "MAP Key Rule Schema"
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-dance-schema.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json","MAP Schema Types-map-core-schema-property-types.json"]
+}
+schema "MAP Core Schema-v0.0.7" {
   header {
     description: "Schema containing all the abstract and core type definitions comprising the MAP Core Dance Schema."
   }

--- a/schema-src/MAP Schema Types-map-core-schema-keyrules-schema.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-keyrules-schema.tdl
@@ -1,5 +1,11 @@
-schema "MAP Key Rule Schema" {
-  depends_on "MAP Core Schema-v0.0.7"
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-keyrules-schema.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-dance-schema.json","MAP Schema Types-map-core-schema-property-types.json","MAP Schema Types-map-core-schema-relationship-types.json"]
+}
+schema "MAP Core Schema-v0.0.7" {
   header {
     description: "Groups all type descriptors related to holon key derivation strategies in MAP."
   }

--- a/schema-src/MAP Schema Types-map-core-schema-loader-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-loader-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-loader-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-property-types.json","MAP Schema Types-map-core-schema-dance-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Dance Schema-v0.0.4"
 }
 holon LoaderHolon.HolonType {
   type MetaHolonType.MetaTypeDescriptor

--- a/schema-src/MAP Schema Types-map-core-schema-operator-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-operator-types.tdl
@@ -43,7 +43,7 @@ def relationship (ValueType.TypeDescriptor)-[AffordsOperator]->(OperatorType.Hol
   cardinality 0..*
   deletion_semantic Block
   header {
-    description: "Links a ValueType descriptor to the concrete operator descriptors available for that value type, supporting validation and query construction."
+    description: "Links a ValueType descriptor to the concrete operator descriptors available for that value type, supporting validation and query construction. Core operator targets may be populated on an abstract value-family anchor so that every specialization inherits them through Additive relationship semantics. A specialization retains those inherited affordances and may add distinct operators, but cannot replace or remove the core targets."
     display_name: "AffordsOperator Relationship"
     display_plural: "AffordsOperator Relationships"
     plural: "AffordsOperatorRelationships"

--- a/schema-src/MAP Schema Types-map-core-schema-operator-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-operator-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-operator-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-abstract-value-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
 }
 
 holon MetaOperatorType.MetaHolonType {

--- a/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-property-types.tdl
@@ -1,3 +1,10 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-property-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-root.json"]
+}
 schema "MAP Core Schema-v0.0.7"
 property AllowsDuplicates.PropertyType {
   type MetaPropertyType.MetaTypeDescriptor

--- a/schema-src/MAP Schema Types-map-core-schema-query-schema.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-query-schema.tdl
@@ -1,6 +1,11 @@
-schema "MAP Query Schema-v0.0.1" {
-  depends_on "MAP Core Schema-v0.0.7"
-  depends_on "MAP Dance Schema-v0.0.4"
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-query-schema.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-dance-schema.json","MAP Schema Types-map-core-schema-loader-types.json"]
+}
+schema "MAP Core Schema-v0.0.7" {
   header {
     description: "Schema containing the minimal query substrate (QueryDance, request/graph/step, bindings, and execution state) needed for the SeedHolons + Expand QueryDance vertical slice."
   }

--- a/schema-src/MAP Schema Types-map-core-schema-relationship-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-relationship-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-relationship-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-abstract-value-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
 }
 
 def relationship (TypeDescriptor)-[ComponentOf]->(Schema.HolonType) {

--- a/schema-src/MAP Schema Types-map-core-schema-root.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-root.tdl
@@ -1,7 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-root.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-command-types.json","MAP Schema Types-map-core-schema-property-types.json","MAP Schema Types-map-core-schema-relationship-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json","MAP Schema Types-map-core-schema-dance-schema.json","MAP Schema Types-map-core-schema-query-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
-  depends_on "MAP Dance Schema-v0.0.4"
-  depends_on "MAP Query Schema-v0.0.1"
   header {
     description: "Schema containing the root descriptor types, meta-types, and foundational holon types for the MAP type system."
   }

--- a/schema-src/MAP Schema Types-map-core-schema-value-constraint-types.tdl
+++ b/schema-src/MAP Schema Types-map-core-schema-value-constraint-types.tdl
@@ -1,5 +1,11 @@
+meta {
+  generator: "MAP Airtable CSV to MAP JSON Python Script"
+  generated_at: "2026-07-21T14:08:14"
+  export_mode: "by-file"
+  source_files: ["MAP Schema Types-map-core-schema-value-constraint-types.csv"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-abstract-value-types.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-keyrules-schema.json"]
+}
 schema "MAP Core Schema-v0.0.7" {
-  depends_on "MAP Key Rule Schema"
 }
 
 abstract holon ValueConstraintType.HolonType {

--- a/tools/map-schema/src/lib.rs
+++ b/tools/map-schema/src/lib.rs
@@ -23,6 +23,8 @@ const INDENT: &str = "  ";
 
 #[derive(Debug, Clone, Deserialize)]
 struct ImportFile {
+    #[serde(default)]
+    meta: serde_json::Map<String, Value>,
     holons: Vec<HolonRecord>,
 }
 
@@ -196,6 +198,7 @@ struct LoaderFactProject {
 #[derive(Debug, Clone)]
 struct LoaderFactFile {
     relative_path: PathBuf,
+    meta: serde_json::Map<String, Value>,
     schema_key: String,
     schema_holon: Option<LoaderFactHolon>,
     emits_schema_holon: bool,
@@ -218,6 +221,7 @@ struct LoaderFactSignature {
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct LoaderFactFileSignature {
     relative_path: String,
+    meta: String,
     holons: Vec<LoaderFactHolonSignature>,
 }
 
@@ -259,6 +263,7 @@ fn loader_fact_project_from_parsed(parsed: Vec<ParsedFile>) -> Result<LoaderFact
 
         files.push(LoaderFactFile {
             relative_path: parsed_file.relative_path,
+            meta: parsed_file.import.meta.clone(),
             schema_key,
             schema_holon,
             emits_schema_holon,
@@ -357,6 +362,7 @@ fn loader_fact_signature(project: &LoaderFactProject) -> LoaderFactSignature {
             holons.extend(file.holons.iter().map(loader_fact_holon_signature));
             LoaderFactFileSignature {
                 relative_path: normalize_relative_path(&file.relative_path),
+                meta: canonical_value_string(&Value::Object(file.meta.clone())),
                 holons,
             }
         })
@@ -392,6 +398,13 @@ fn loader_fact_signature_diff(
 fn render_loader_fact_file(file: &LoaderFactFile) -> Result<String> {
     let mut out = String::new();
     let variant_targets = loader_fact_variant_targets(file);
+    if !file.meta.is_empty() {
+        out.push_str("meta {\n");
+        for (name, value) in &file.meta {
+            out.push_str(&format!("{}{}: {}\n", INDENT, name, canonical_value_string(value)));
+        }
+        out.push_str("}\n\n");
+    }
     render_loader_fact_schema_decl(&mut out, file)?;
 
     for holon in &file.holons {
@@ -736,7 +749,7 @@ fn infer_schema_name(import: &ImportFile) -> Option<String> {
         .iter()
         .find(|holon| holon.descriptor_type == "Schema.HolonType")
         .and_then(schema_name_from_holon)
-        .or_else(|| import.holons.first().and_then(component_of_schema_name))
+        .or_else(|| import.holons.iter().find_map(component_of_schema_name))
 }
 
 fn schema_name_from_holon(holon: &HolonRecord) -> Option<String> {

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -84,6 +84,7 @@ struct DiscoveredFile {
 #[derive(Debug, Clone)]
 struct ParsedTdlFile {
     relative_path: PathBuf,
+    meta: TdlLiteralObject,
     schema: TdlSchema,
     descriptors: Vec<TdlDescriptor>,
 }
@@ -330,6 +331,9 @@ fn lower_r6_file_to_import_json(
     }
 
     let mut root = serde_json::Map::new();
+    if !file.meta.is_empty() {
+        root.insert("meta".to_string(), literal_to_json(&TdlLiteralValue::Object(file.meta.clone())));
+    }
     root.insert("holons".to_string(), Value::Array(holons));
     Ok(Value::Object(root))
 }
@@ -870,11 +874,17 @@ impl<'a> Parser<'a> {
     fn parse_file(&mut self) -> Result<ParsedTdlFile> {
         let file_path = self.relative_path.clone();
         let mut schema: Option<TdlSchema> = None;
+        let mut meta = TdlLiteralObject::new();
         let mut descriptors = Vec::new();
 
         while self.skip_blank_lines() {
             let line = self.peek_trimmed().unwrap().to_string();
-            if line.starts_with("schema ") {
+            if line == "meta {" {
+                self.consume_trimmed();
+                let (properties, references) = self.parse_properties_block()?;
+                if !meta.is_empty() || !references.is_empty() { return Err(anyhow!("invalid meta declaration in {}", file_path.display())); }
+                meta = properties;
+            } else if line.starts_with("schema ") {
                 if schema.is_some() {
                     return Err(anyhow!("multiple schema declarations in {}", file_path.display()));
                 }
@@ -895,7 +905,7 @@ impl<'a> Parser<'a> {
 
         let schema = schema
             .ok_or_else(|| anyhow!("missing schema declaration in {}", file_path.display()))?;
-        Ok(ParsedTdlFile { relative_path: file_path, schema, descriptors })
+        Ok(ParsedTdlFile { relative_path: file_path, meta, schema, descriptors })
     }
 
     fn parse_schema_decl(&mut self) -> Result<TdlSchema> {
@@ -2084,7 +2094,8 @@ enum Color.EnumType {
         assert!(root_json.contains(r#""$ref": "MAP Core Schema-v0.0.7""#));
         assert!(!root_json.contains(r#""type_name""#));
         assert!(!root_json.contains(r#""InstanceTypeKind""#));
-        assert!(!root_json.contains(r#""meta""#));
+        assert!(root_json.contains(r#""meta""#));
+        assert!(root_json.contains(r#""load_with""#));
 
         Ok(())
     }


### PR DESCRIPTION
# Summary

Reconciles the MAP Core Schema TDL corpus with Schema 2.0 descriptor-kernel semantics, restores canonical file metadata fidelity, and removes provisional cross-schema dependency cycles from the current Core corpus.

The corpus and TDL toolchain changes were merged into `main` before the corresponding Schema 2.0 DevDocs PR was approved. This PR records the resulting implementation alignment and makes the remaining documentation sequencing explicit.

## Changes

- Replace legacy authored `TypeKind` state with explicit local `DefinesInstanceTypeKind` anchor designations.
- Model inverse pairing only through declared-side `HasInverse`.
- Preserve the unified descriptor hierarchy and graph-defined meta-type pairing.
- Document abstract value-family anchors and additive operator inheritance:
  - Abstract value-family descriptors contribute shared classification and affordances without directly describing runtime values.
  - Core operator affordances are inherited by every specialization.
  - Specializations may add distinct operators but cannot replace or remove inherited core affordances.
- Restore lossless file-level `meta` support in TDL and MAP JSON conversion.
- Preserve `generator`, `generated_at`, `export_mode`, `source_files`, and `load_with` metadata through JSON-to-TDL-to-JSON fidelity operations.
- Keep `meta.load_with` as file and loader-bundle metadata; do not lower it into semantic schema `DependsOn` relationships.
- Collapse the current Core, Key Rule, Dance, Query, loader, and related corpus files into the single semantic `MAP Core Schema-v0.0.7`.
- Remove the resulting provisional Core-corpus `DependsOn` cycles.
- Update schema inference so a file may begin with a generic instance and still resolve its owning schema from any later `ComponentOf` fact.
- Regenerate MAP JSON imports from `schema-src`.

## Validation

- `cargo test --manifest-path tools/map-schema/Cargo.toml --lib`
- `npm run map-schema:check:coreschema`
- `npm run map-schema:compile:coreschema`
- `npm run map-schema:roundtrip:coreschema`
- `git diff --check`
- Reported manual verification: hApp build, host build, `npm test`, and `npm start` nominal.

## Scope Boundary

This PR deliberately does not define Extension Schema ownership, compatibility, or evolution rules. It treats the current files as source modules and loader-bundle units, rather than independent semantic schema boundaries.

The independent Book test schema retains its valid dependency on `MAP Core Schema-v0.0.7`. Future Extension Schema work can introduce distinct versioned schema identities and DAG dependencies on top of this Core baseline.

## Review Context

The revised Schema 2.0 specifications are proposed in [map-dev-docs PR #6](https://github.com/memetic-activation-platform/map-dev-docs/pull/6). The implementation is now ahead of that documentation approval. Any further review finding requiring corpus or compiler changes should be handled in a new focused `map-holons` PR.