### PR TITLE
617 - SL3 occurence id semantics

### DIFF
--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -644,6 +644,11 @@ fn save_smartlinks_for_collection(
     for (target_index, resolved_target) in resolved_targets.iter().enumerate() {
         // Persist both directions from one resolved endpoint pair so the forward
         // and inverse SmartLinks stay anchored to the same committed source.
+        //
+        // Both directions pass `occurrence_id: None` because commit processing only
+        // emits set-style links today. That is a coordinator choice, not a storage
+        // limitation: storage persists supplied occurrences as distinct identities
+        // (Storage SL3). Assigning and pairing them is deferred coordinator work.
         let forward_smartlink = PreparedSmartLink {
             source_id: source_id.clone(),
             target_id: HolonId::Local(resolved_target.target_local_id.clone()),

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -1,8 +1,12 @@
-//! Storage-layer SmartLink persistence API (Storage SL1 Part 2, Issue #594).
+//! Storage-layer SmartLink persistence API (Storage SL1 Part 2, Issue #594; occurrence
+//! semantics activated by Storage SL3).
 //!
 //! Descriptor-unaware read/write/delete over `LinkTypes::SmartLink`. Callers supply
 //! fully-prepared inputs; this layer never resolves relationship descriptors, computes
-//! canonical keys, pairs occurrence ids, or selects target-property cache candidates.
+//! canonical keys, or selects target-property cache candidates. A supplied `occurrence_id`
+//! is honored as part of insertion identity and round-tripped verbatim, but never
+//! generated, defaulted, validated against `AllowsDuplicates`, or paired across the
+//! declared and inverse directions — all of that stays above storage.
 //! It reuses the Tag v1 codec (`core_types::smartlink`) for all encode/decode/prefix work.
 
 use core_types::{

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -2,11 +2,15 @@
 //! semantics activated by Storage SL3).
 //!
 //! Descriptor-unaware read/write/delete over `LinkTypes::SmartLink`. Callers supply
-//! fully-prepared inputs; this layer never resolves relationship descriptors, computes
-//! canonical keys, or selects target-property cache candidates. A supplied `occurrence_id`
-//! is honored as part of insertion identity and round-tripped verbatim, but never
-//! generated, defaulted, validated against `AllowsDuplicates`, or paired across the
-//! declared and inverse directions — all of that stays above storage.
+//! fully-prepared inputs; this layer computes no canonical keys and selects no
+//! target-property cache candidates. Descriptor-unawareness here is structural, not a
+//! convention: no descriptor type is reachable from this module, so whether a relationship
+//! may carry duplicates is necessarily decided upstream — see `DuplicatePolicy` in
+//! `holons_core::reference_layer`, which is where `AllowsDuplicates` is actually enforced.
+//!
+//! A supplied `occurrence_id` is honored as part of insertion identity and round-tripped
+//! verbatim. Generating one, defaulting it, and pairing it across the declared and inverse
+//! directions all stay above storage.
 //! It reuses the Tag v1 codec (`core_types::smartlink`) for all encode/decode/prefix work.
 
 use core_types::{

--- a/shared_crates/type_system/core_types/src/smartlink/codec.rs
+++ b/shared_crates/type_system/core_types/src/smartlink/codec.rs
@@ -793,6 +793,24 @@ mod tests {
         assert_eq!(decoded.occurrence_id, input.occurrence_id);
     }
 
+    /// The external-target test above sets the occurrence flag only alongside the
+    /// proxy flag. This pins the local-target layout, where the 16 occurrence bytes
+    /// follow the flags byte directly with no proxy in between.
+    #[test]
+    fn round_trips_local_target_with_occurrence() {
+        let mut input = local_input();
+        input.occurrence_id = Some(OccurrenceId([7; 16]));
+        input.relationship_property_values = all_values();
+
+        let encoded = encode_smartlink_tag(&input).unwrap();
+        let decoded = decode_smartlink_tag(&encoded, hash(1)).unwrap();
+
+        assert_eq!(decoded.target_id, input.target_id);
+        assert_eq!(decoded.occurrence_id, Some(OccurrenceId([7; 16])));
+        assert_eq!(decoded.canonical_key, input.canonical_key);
+        assert_eq!(decoded.relationship_property_values, all_values());
+    }
+
     #[test]
     fn round_trips_empty_canonical_key() {
         let mut input = local_input();

--- a/shared_crates/type_system/core_types/src/smartlink/types.rs
+++ b/shared_crates/type_system/core_types/src/smartlink/types.rs
@@ -155,7 +155,9 @@ pub struct DecodedSmartLinkTag {
 /// Fully-prepared, descriptor-unaware input to `put_smartlink`.
 ///
 /// Coordination supplies every field; the storage layer never infers or derives
-/// a missing one. `occurrence_id` is always `None` in SL1 Part 2.
+/// a missing one. `occurrence_id` may be `Some(_)` — storage accepts it without any
+/// descriptor-policy gate — and `None` and `Some(id)` are *different* insertion
+/// identities, so a set-style link and an occurrence-bearing one coexist.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedSmartLink {
     pub source_id: LocalId,
@@ -184,8 +186,8 @@ impl PreparedSmartLink {
 /// One decoded, unhydrated SmartLink returned by the storage expansion APIs.
 ///
 /// Preserves the physical `SmartLinkId`, keeps the relationship-property and
-/// target-property caches as separate maps, and round-trips the optional
-/// `OccurrenceId` (always absent in SL1 Part 2).
+/// target-property caches as separate maps, and carries the optional `OccurrenceId`
+/// verbatim from the persisted Tag v1 bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmartLink {
     pub smartlink_id: SmartLinkId,
@@ -411,6 +413,44 @@ mod tests {
         assert!(!live.is_already_present(&p)); // -> Conflict
     }
 
+    fn occ(seed: u8) -> OccurrenceId {
+        OccurrenceId([seed; 16])
+    }
+
+    #[test]
+    fn same_identity_distinguishes_none_from_some() {
+        let p = prepared(); // occurrence_id: None
+        let mut live = live_from(&p, 9);
+        live.occurrence_id = Some(occ(1));
+        // A set-style link and an occurrence-bearing one are separate identities, so
+        // both can be inserted rather than one conflicting with the other.
+        assert!(!live.same_identity(&p));
+    }
+
+    #[test]
+    fn same_identity_distinguishes_distinct_occurrences() {
+        let mut p = prepared();
+        p.occurrence_id = Some(occ(1));
+        let mut live = live_from(&p, 9);
+        live.occurrence_id = Some(occ(2));
+        assert!(!live.same_identity(&p));
+    }
+
+    #[test]
+    fn same_identity_matches_on_equal_occurrence() {
+        let mut p = prepared();
+        p.occurrence_id = Some(occ(1));
+        let live = live_from(&p, 9);
+        assert!(live.same_identity(&p));
+        assert!(live.is_already_present(&p));
+
+        // The conflict path stays reachable *within* one occurrence.
+        let mut conflicting = live_from(&p, 9);
+        conflicting.canonical_key = CanonicalKey::new("other-key").unwrap();
+        assert!(conflicting.same_identity(&p));
+        assert!(!conflicting.is_already_present(&p)); // -> Conflict
+    }
+
     /// 39-byte action-hash-shaped id, required by the codec's hash validation.
     fn hash39(seed: u8) -> LocalId {
         let mut bytes = vec![seed; 39];
@@ -435,6 +475,25 @@ mod tests {
         assert_eq!(sl.source_id, hash39(1));
         assert_eq!(sl.target_id, HolonId::Local(hash39(2)));
         assert_eq!(sl.relationship_name, rel("Likes"));
+        assert_eq!(sl.canonical_key, CanonicalKey::new("apple").unwrap());
+        assert_eq!(sl.occurrence_id, None);
+    }
+
+    #[test]
+    fn decode_smartlink_round_trips_occurrence() {
+        let input = SmartLinkTagInput {
+            target_id: HolonId::Local(hash39(2)),
+            relationship_name: rel("Likes"),
+            canonical_key: CanonicalKey::new("apple").unwrap(),
+            occurrence_id: Some(occ(7)),
+            relationship_property_values: PropertyMap::new(),
+            target_property_cache_candidates: Vec::new(),
+        };
+        let bytes = super::super::encode_smartlink_tag(&input).unwrap();
+
+        let sl = decode_smartlink(SmartLinkId(hash39(9)), hash39(1), hash39(2), &bytes).unwrap();
+        // The occurrence survives encode -> persist -> decode verbatim.
+        assert_eq!(sl.occurrence_id, Some(occ(7)));
         assert_eq!(sl.canonical_key, CanonicalKey::new("apple").unwrap());
     }
 

--- a/shared_crates/type_system/core_types/src/smartlink/types.rs
+++ b/shared_crates/type_system/core_types/src/smartlink/types.rs
@@ -155,9 +155,11 @@ pub struct DecodedSmartLinkTag {
 /// Fully-prepared, descriptor-unaware input to `put_smartlink`.
 ///
 /// Coordination supplies every field; the storage layer never infers or derives
-/// a missing one. `occurrence_id` may be `Some(_)` — storage accepts it without any
-/// descriptor-policy gate — and `None` and `Some(id)` are *different* insertion
-/// identities, so a set-style link and an occurrence-bearing one coexist.
+/// a missing one. `occurrence_id` may be `Some(_)`: the persistence layer resolves no
+/// relationship descriptor, so whether a relationship *may* carry duplicates is decided
+/// above storage (`DuplicatePolicy` in the reference layer), never here. `None` and
+/// `Some(id)` are *different* insertion identities, so a set-style link and an
+/// occurrence-bearing one coexist.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedSmartLink {
     pub source_id: LocalId,

--- a/tests/sweetests/tests/smartlink_tests.rs
+++ b/tests/sweetests/tests/smartlink_tests.rs
@@ -7,16 +7,20 @@
 //!
 //! Endpoints are real committed holon nodes published through canonical `holon_storage_persist`,
 //! because SmartLink integrity validation requires 39-byte action-hash source/target ids.
+//!
+//! `occurrence_persistence_semantics` covers Storage SL3: occurrence ids as part of
+//! insertion identity. Storage stays descriptor-unaware there — it never inspects
+//! `AllowsDuplicates`, assigns an occurrence, or pairs inverse occurrences.
 
 use base_types::{BaseValue, MapString};
 use core_types::{
     CanonicalKey, CanonicalKeyPrefix, DeleteSmartLinkOutcome, HolonId, HolonWriteRequest, KeyMatch,
-    PreparedSmartLink, PropertyName, PutSmartLinkOutcome, SmartLink, StoredHolonNode,
-    TargetPropertyCacheCandidate,
+    OccurrenceId, PreparedSmartLink, PropertyName, PutSmartLinkOutcome, SmartLink, SmartLinkId,
+    StoredHolonNode, TargetPropertyCacheCandidate,
 };
 use holons_test::setup_test_conductor;
 use integrity_core_types::{HolonNodeModel, LocalId, PropertyMap, RelationshipName};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 const ZOME: &str = "holons";
 
@@ -45,6 +49,22 @@ fn prepared(source: &LocalId, target: &LocalId, relationship: &str, k: &str) -> 
         relationship_property_values: PropertyMap::new(),
         target_property_cache_candidates: Vec::new(),
     }
+}
+
+fn occ(seed: u8) -> OccurrenceId {
+    OccurrenceId([seed; 16])
+}
+
+fn prepared_with_occurrence(
+    source: &LocalId,
+    target: &LocalId,
+    relationship: &str,
+    k: &str,
+    occurrence: OccurrenceId,
+) -> PreparedSmartLink {
+    let mut p = prepared(source, target, relationship, k);
+    p.occurrence_id = Some(occurrence);
+    p
 }
 
 /// Commits an empty holon node and returns its physical id (a valid 39-byte action hash).
@@ -256,4 +276,222 @@ async fn expand_by_key_keyless_exact() {
     assert_eq!(exact.len(), 1);
     assert_eq!(exact[0].smartlink_id, id);
     assert_eq!(exact[0].canonical_key, key(""));
+}
+
+fn expect_inserted(outcome: PutSmartLinkOutcome, phase: &str) -> SmartLinkId {
+    match outcome {
+        PutSmartLinkOutcome::Inserted(id) => id,
+        other => panic!("{phase}: expected Inserted, got {other:?}"),
+    }
+}
+
+/// Storage SL3: `occurrence_id` is part of SmartLink insertion identity.
+///
+/// Runs every occurrence scenario against one conductor, in four phases. Storage stays
+/// descriptor-unaware throughout: nothing here resolves `AllowsDuplicates`, generates an
+/// occurrence, or pairs occurrences across directions — the test only supplies occurrences
+/// and asserts what storage does with them.
+#[tokio::test(flavor = "multi_thread")]
+async fn occurrence_persistence_semantics() {
+    let backend = setup_test_conductor().await;
+    let zome = backend.cell.zome(ZOME);
+    let source = new_endpoint(&backend).await;
+    let target = new_endpoint(&backend).await;
+
+    // -----------------------------------------------------------------------
+    // Phase 1: occurrence is part of identity, and round-trips through the DHT.
+    // -----------------------------------------------------------------------
+
+    // A set-style link (no occurrence).
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(&zome, "smartlink_put", prepared(&source, &target, "Likes", "a"))
+        .await;
+    let id_none = expect_inserted(out, "phase 1");
+
+    // Same source/target/relationship/key, but occurrence-bearing => a different
+    // identity, so it inserts rather than conflicting with the keyless-occurrence link.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "a", occ(1)),
+        )
+        .await;
+    let id_1 = expect_inserted(out, "phase 1: None and Some(id) are different identities");
+    assert_ne!(id_1, id_none);
+
+    // A second, distinct occurrence: two otherwise-identical links coexist.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "a", occ(2)),
+        )
+        .await;
+    let id_2 = expect_inserted(out, "phase 1: distinct occurrences both insert");
+    assert_ne!(id_2, id_none);
+    assert_ne!(id_2, id_1);
+
+    // Retrying the same occurrence unchanged is idempotent and reports the original id.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "a", occ(1)),
+        )
+        .await;
+    assert_eq!(
+        out,
+        PutSmartLinkOutcome::AlreadyPresent(id_1.clone()),
+        "phase 1: replaying an occurrence must return AlreadyPresent with the original id"
+    );
+
+    // All three are live, and each carries back exactly the occurrence it was written with.
+    let all: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    let observed: HashSet<(SmartLinkId, Option<OccurrenceId>)> =
+        all.iter().map(|l| (l.smartlink_id.clone(), l.occurrence_id)).collect();
+    let expected: HashSet<(SmartLinkId, Option<OccurrenceId>)> = HashSet::from([
+        (id_none.clone(), None),
+        (id_1.clone(), Some(occ(1))),
+        (id_2.clone(), Some(occ(2))),
+    ]);
+    assert_eq!(observed, expected, "phase 1: occurrences must round-trip verbatim");
+
+    // Occurrence bytes sit after the NUL-delimited key region in Tag v1, so they are not
+    // prefix-queryable: a key query returns every occurrence sharing that key, and callers
+    // that want one occurrence must filter in-process on `SmartLink::occurrence_id`.
+    let by_key: Vec<SmartLink> = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_expand_by_key",
+            (source.clone(), rel("Likes"), KeyMatch::Exact(key("a"))),
+        )
+        .await;
+    assert_eq!(by_key.len(), 3, "phase 1: key queries do not discriminate by occurrence");
+
+    // -----------------------------------------------------------------------
+    // Phase 2: within one occurrence, key/prop divergence still conflicts.
+    // -----------------------------------------------------------------------
+
+    // Same occurrence, different canonical key => Conflict against the original link.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "b", occ(1)),
+        )
+        .await;
+    assert_eq!(
+        out,
+        PutSmartLinkOutcome::Conflict(id_1.clone()),
+        "phase 2: same occurrence with a different key must conflict"
+    );
+
+    // Same occurrence, different authoritative relationship props => Conflict.
+    let mut diff_props = prepared_with_occurrence(&source, &target, "Likes", "a", occ(1));
+    diff_props.relationship_property_values = string_props("weight", "heavy");
+    let out: PutSmartLinkOutcome = backend.conductor.call(&zome, "smartlink_put", diff_props).await;
+    assert_eq!(
+        out,
+        PutSmartLinkOutcome::Conflict(id_1.clone()),
+        "phase 2: same occurrence with different rel props must conflict"
+    );
+
+    // The load-bearing contrast: a *differing* occurrence is never a conflict, even when
+    // the canonical key differs — it is simply another identity.
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "b", occ(3)),
+        )
+        .await;
+    let id_3 = expect_inserted(out, "phase 2: a differing occurrence must insert, not conflict");
+
+    // Neither conflicting put wrote a link, and id_1 kept its original key.
+    let all: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    assert_eq!(all.len(), 4, "phase 2: conflicting puts must not insert");
+    let live_1 = all
+        .iter()
+        .find(|l| l.smartlink_id == id_1)
+        .expect("phase 2: the conflicted-against link must still be live");
+    assert_eq!(live_1.canonical_key, key("a"), "phase 2: a conflict must not rewrite the key");
+
+    // -----------------------------------------------------------------------
+    // Phase 3: declared and inverse directions may share one occurrence.
+    //
+    // Storage proves only the *shape* here. These two PreparedSmartLinks are paired by
+    // hand: assigning a shared occurrence to a declared/inverse pair is coordinator work,
+    // and storage neither performs nor validates that pairing.
+    // -----------------------------------------------------------------------
+
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&source, &target, "Likes", "a", occ(9)),
+        )
+        .await;
+    let fwd_9 = expect_inserted(out, "phase 3: forward direction");
+
+    let out: PutSmartLinkOutcome = backend
+        .conductor
+        .call(
+            &zome,
+            "smartlink_put",
+            prepared_with_occurrence(&target, &source, "LikedBy", "a", occ(9)),
+        )
+        .await;
+    let inv_9 = expect_inserted(out, "phase 3: inverse direction");
+
+    // One shared OccurrenceId, two distinct physical links.
+    assert_ne!(fwd_9, inv_9, "phase 3: each direction gets its own SmartLinkId");
+
+    let inverse: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", target.clone()).await;
+    assert_eq!(inverse.len(), 1, "phase 3: the inverse link is anchored to the target");
+    assert_eq!(inverse[0].smartlink_id, inv_9);
+    assert_eq!(inverse[0].occurrence_id, Some(occ(9)));
+    assert_eq!(inverse[0].relationship_name, rel("LikedBy"));
+
+    // -----------------------------------------------------------------------
+    // Phase 4: deletion is keyed by SmartLinkId, never by OccurrenceId.
+    // -----------------------------------------------------------------------
+
+    let out: DeleteSmartLinkOutcome =
+        backend.conductor.call(&zome, "smartlink_delete", id_1.clone()).await;
+    assert_eq!(out, DeleteSmartLinkOutcome::Deleted, "phase 4");
+
+    let out: DeleteSmartLinkOutcome =
+        backend.conductor.call(&zome, "smartlink_delete", id_1.clone()).await;
+    assert_eq!(out, DeleteSmartLinkOutcome::AlreadyAbsent, "phase 4: delete stays idempotent");
+
+    // Deleting one occurrence leaves every sibling occurrence untouched.
+    let remaining: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", source.clone()).await;
+    let survivors: HashSet<SmartLinkId> =
+        remaining.iter().map(|l| l.smartlink_id.clone()).collect();
+    assert_eq!(
+        survivors,
+        HashSet::from([id_none, id_2, id_3, fwd_9]),
+        "phase 4: deleting one occurrence must not delete its siblings"
+    );
+
+    // The inverse link is a separate physical link, so deleting a forward occurrence
+    // never reaches it — even though both were written with occ(9).
+    let inverse: Vec<SmartLink> =
+        backend.conductor.call(&zome, "smartlink_expand_all", target.clone()).await;
+    assert_eq!(inverse.len(), 1, "phase 4: the inverse direction is unaffected");
+    assert_eq!(inverse[0].smartlink_id, inv_9);
+    assert_eq!(inverse[0].occurrence_id, Some(occ(9)));
 }


### PR DESCRIPTION
# PR: Storage SL3 — OccurrenceId persistence semantics

## Summary

Activates occurrence-aware SmartLink persistence: storage can now persist, distinguish, retrieve, and delete
duplicate relationship occurrences when coordination supplies an `OccurrenceId`. **No production logic
changed.** 

This PR is verification plus documentation: the comments now state the real contract, and a
live-conductor sweettest pins every persistence behavior the issue's Definition of Done names.

Supersedes the SL1 part 2 note "`occurrence_id` stays `None` (SL3 scope)".

## Changes

**Contract comments** (the three stale claims, all now corrected)
- `core_types::smartlink::types` — `PreparedSmartLink`: coordination may supply `Some(_)`; storage accepts it
  with no descriptor-policy gate, and `None` vs `Some(id)` are *different insertion identities*.
- `core_types::smartlink::types` — `SmartLink`: occurrence carried verbatim from the persisted Tag v1 bytes
  (dropped "always absent in SL1 Part 2").
- `persistence_layer::smartlink` module doc — kept the load-bearing "never pairs occurrence ids" claim but
  split it from the implication that the layer never *handles* them. A supplied occurrence is honored as part
  of insertion identity and round-tripped, but never generated, defaulted, validated against
  `AllowsDuplicates`, or paired across directions.
- `commit_functions.rs` — the two commit-Pass-2 writers still pass `occurrence_id: None`; a comment records
  that this is a *coordinator* choice (set-style links only, for now), not a storage limitation. No behavior
  change; occurrence assignment above storage stays deferred.

**Unit tests** (`core_types::smartlink`)
- `same_identity_distinguishes_none_from_some` — a set-style link and an occurrence-bearing one coexist.
- `same_identity_distinguishes_distinct_occurrences` — `Some(a)` vs `Some(b)`.
- `same_identity_matches_on_equal_occurrence` — matching occurrence is the same identity, and the Conflict
  path stays reachable *within* one occurrence.
- `decode_smartlink_round_trips_occurrence` — closes a gap: nothing round-tripped a `Some(_)` through
  `decode_smartlink`. Also strengthened the existing round-trip test to assert `occurrence_id == None`.
- `round_trips_local_target_with_occurrence` (codec) — closes a second gap: the only prior positive occurrence
  test set the occurrence flag *only alongside* the external-target flag, leaving the local-target layout
  (16 occurrence bytes following the flags byte with no 39-byte proxy in between) untested.

**Sweettest** (`tests/sweetests/tests/smartlink_tests.rs`)

One consolidated `occurrence_persistence_semantics` on a single conductor — matching the suite-wide idiom
that no sweettest uses more than one conductor instance — in four commented phases:

1. **Identity + round-trip.** `None`, `occ(1)`, `occ(2)` on one source/target/relationship/key all
   `Inserted` with distinct ids; replaying `occ(1)` returns `AlreadyPresent` with the *original* id;
   `expand_all` returns exactly the three `(SmartLinkId, occurrence_id)` pairs written.
2. **Conflicts.** Same occurrence + different canonical key → `Conflict`; same occurrence + different
   authoritative rel props → `Conflict`; neither writes. The contrast that carries the issue: a *differing*
   occurrence inserts even when the key differs.
3. **Declared/inverse shape.** Forward `Likes` and inverse `LikedBy` sharing one `OccurrenceId` both insert
   with distinct `SmartLinkId`s. Storage proves shape only — the pair is assembled by hand in the test.
4. **Deletion.** Keyed by `SmartLinkId`, never by `OccurrenceId`: deleting one occurrence leaves every sibling
   occurrence live and does not reach the inverse direction, which shares the same occurrence.

New local helpers `occ()` and `prepared_with_occurrence()`; `prepared()` left untouched so the four existing
tests are unaffected.

## Notable decisions

- **Occurrence is not prefix-queryable, and the test pins this.** The occurrence bytes sit *after* the
  NUL-delimited key region in Tag v1, so `expand_by_key` returns every occurrence sharing a key and callers
  must filter in-process on `SmartLink::occurrence_id`. Phase 1 asserts this explicitly — it will be a real
  constraint for duplicate-aware relationship collections.
- **Single consolidated sweettest** over 3–7 focused ones, to keep conductor startups down. Mitigated by
  per-phase assertion messages so a mid-test failure identifies itself without a rerun.


## Scope / follow-ups

Out of scope and unchanged: descriptor resolution and `AllowsDuplicates` enforcement; occurrence generation,
preservation, or inverse pairing above storage; duplicate-aware relationship collections; changes to the
Tag v1 grammar or canonical-key computation; commit processing assigning occurrence ids; SL4 facade
retirement.

