### PR TITLE
631 - SL5 - retire revision indexes

### DIFF
--- a/happ/coordinator-surface.toml
+++ b/happ/coordinator-surface.toml
@@ -125,13 +125,6 @@ rationale = "Scaffolded enumeration ingress over the AllHolonNodes infrastructur
 
 [[export]]
 zome = "holons"
-symbol = "get_latest_holon_node"
-exposure_kind = "zome_call"
-classification = "legacy_ingress"
-rationale = "Scaffolded revision lookup whose legacy link-based semantics predate version-aware storage."
-
-[[export]]
-zome = "holons"
 symbol = "get_original_holon_node"
 exposure_kind = "zome_call"
 classification = "legacy_ingress"
@@ -143,13 +136,6 @@ symbol = "get_original_holon_node_with_details"
 exposure_kind = "zome_call"
 classification = "legacy_ingress"
 rationale = "Scaffolded exact-action details lookup retained for the legacy coordinator surface."
-
-[[export]]
-zome = "holons"
-symbol = "get_all_revisions_for_holon_node"
-exposure_kind = "zome_call"
-classification = "legacy_ingress"
-rationale = "Scaffolded revision traversal retained despite MAP not maintaining its legacy HolonNodeUpdates index."
 
 [[export]]
 zome = "holons"

--- a/happ/crates/holons_guest/src/persistence_layer/all_holon_nodes.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/all_holon_nodes.rs
@@ -1,4 +1,3 @@
-use crate::persistence_layer::holon_node::get_latest_holon_node;
 use core_types::{HolonError, HolonId};
 use hdk::prelude::*;
 use holons_guest_integrity::{type_conversions::*, ALL_HOLON_NODES_PATH};
@@ -11,10 +10,9 @@ use holons_integrity::*;
 /// addressed at its lineage root and deliberately adds no index entry, so a lineage never appears
 /// more than once here.
 ///
-/// The stated intent of returning the *latest* version is not met. `get_latest_holon_node` has no
-/// `HolonNodeUpdates` links to follow, so each result is the lineage root — which, once a lineage
-/// has versions, is no longer its current content. Head selection is later storage work; until
-/// then a caller needing the current version traverses `Successor` from the root.
+/// Each result is therefore a lineage *root*, which once a lineage has versions is no longer its
+/// current content. Head selection is later storage work; until then a caller needing the current
+/// version traverses `Successor` from the root.
 #[hdk_extern]
 pub fn get_all_holon_nodes(_: ()) -> ExternResult<Vec<Record>> {
     let path = Path::from(ALL_HOLON_NODES_PATH);
@@ -27,14 +25,7 @@ pub fn get_all_holon_nodes(_: ()) -> ExternResult<Vec<Record>> {
         .map(|link| GetInput::new(link.target.try_into().unwrap(), GetOptions::default()))
         .collect();
     let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-    let records: Vec<Record> = records.into_iter().filter_map(|r| r).collect();
-    let mut latest_records = Vec::new();
-    for record in &records {
-        if let Some(latest_record) = get_latest_holon_node(record.action_address().clone())? {
-            latest_records.push(latest_record);
-        }
-    }
-    Ok(latest_records)
+    Ok(records.into_iter().flatten().collect())
 }
 
 /// Get the `HolonId` of every HolonNode in the HolonSpace, one per lineage.
@@ -43,7 +34,8 @@ pub fn get_all_holon_nodes(_: ()) -> ExternResult<Vec<Record>> {
 /// identities rather than records, so callers that only need ids skip the record fetch.
 /// The one-entry-per-lineage and lineage-root caveats documented above apply here too.
 ///
-/// This global-index reader is preserved until Storage SL5 replaces the index itself.
+/// This global-index reader is preserved until the `AllHolonNodes` index itself is retired, which
+/// waits on a coordinator-owned replacement for whole-space discovery (Storage SL5b, #631).
 /// It moved here from the retired guest SmartLink facade (Storage SL4, #630): despite
 /// the old `fetch_links_to_all_holons` name it never returned links, and `AllHolonNodes`
 /// is not a SmartLink relationship.

--- a/happ/crates/holons_guest/src/persistence_layer/holon_node.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/holon_node.rs
@@ -70,45 +70,6 @@ pub fn get_all_deletes_for_holon_node(
     }
 }
 
-/// Enumerates revisions reachable through `HolonNodeUpdates` links.
-///
-/// Scaffolded, and currently reports only the record it was given: MAP authors versions as native
-/// root-addressed updates and deliberately does not maintain a parallel `HolonNodeUpdates` link
-/// index, so there are no links for this to follow. Revision-history traversal is later storage
-/// work, which will decide whether to build on Holochain's own update graph (`get_details`) or on
-/// the link index — it should not harden both.
-#[hdk_extern]
-pub fn get_all_revisions_for_holon_node(
-    original_holon_node_hash: ActionHash,
-) -> ExternResult<Vec<Record>> {
-    let Some(original_record) =
-        get_original_holon_node_with_details(original_holon_node_hash.clone())?
-    else {
-        return Ok(vec![]);
-    };
-    let links_query =
-        LinkQuery::try_new(original_holon_node_hash.clone(), LinkTypes::HolonNodeUpdates)?;
-    let links = get_links(links_query, GetStrategy::default())?;
-    let get_input: Vec<GetInput> = links
-        .into_iter()
-        .map(|link| {
-            Ok(GetInput::new(
-                link.target
-                    .into_action_hash()
-                    .ok_or(wasm_error!(WasmErrorInner::Guest(
-                        "No action hash associated with link".to_string()
-                    )))?
-                    .into(),
-                GetOptions::default(),
-            ))
-        })
-        .collect::<ExternResult<Vec<GetInput>>>()?;
-    let records = HDK.with(|hdk| hdk.borrow().get(get_input))?;
-    let mut records: Vec<Record> = records.into_iter().flatten().collect();
-    records.insert(0, original_record);
-    Ok(records)
-}
-
 #[hdk_extern]
 pub fn get_holon_node_by_path(input: GetPathInput) -> ExternResult<Option<Record>> {
     let links_query = LinkQuery::try_new(input.path.path_entry_hash()?, input.link_type)?;
@@ -134,29 +95,6 @@ pub fn get_original_holon_node(
     original_holon_node_hash: ActionHash,
 ) -> ExternResult<Option<Record>> {
     get(original_holon_node_hash, GetOptions::default())
-}
-
-/// Selects the newest revision reachable through `HolonNodeUpdates` links.
-///
-/// Scaffolded, and currently equivalent to `get_original_holon_node`: MAP authors no
-/// `HolonNodeUpdates` links (see `get_all_revisions_for_holon_node`), so this always falls through
-/// to the hash it was given. Note that hash is now a lineage *root* rather than the only version
-/// of a holon, so this returns the root's content, not the lineage head. Head selection is later
-/// storage work.
-#[hdk_extern]
-pub fn get_latest_holon_node(original_holon_node_hash: ActionHash) -> ExternResult<Option<Record>> {
-    let links_query =
-        LinkQuery::try_new(original_holon_node_hash.clone(), LinkTypes::HolonNodeUpdates)?;
-    let links = get_links(links_query, GetStrategy::default())?;
-    let latest_link =
-        links.into_iter().max_by(|link_a, link_b| link_a.timestamp.cmp(&link_b.timestamp));
-    let latest_holon_node_hash = match latest_link {
-        Some(link) => link.target.clone().into_action_hash().ok_or(wasm_error!(
-            WasmErrorInner::Guest("No action hash associated with link".to_string())
-        ))?,
-        None => original_holon_node_hash.clone(),
-    };
-    get(latest_holon_node_hash, GetOptions::default())
 }
 
 #[hdk_extern]

--- a/happ/crates/holons_guest/src/persistence_layer/holon_storage.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/holon_storage.rs
@@ -12,15 +12,14 @@
 //! deliberately absent — they are later storage work, and folding them in here would make an
 //! exact read ambiguous.
 //!
-//! Two deliberate non-decisions, recorded so they are not mistaken for oversights:
+//! One deliberate non-decision, recorded so it is not mistaken for an oversight: `PublishRoot`
+//! indexes the new holon under `AllHolonNodes`; `PublishVersion` does not. The lineage root is
+//! already indexed, and one index entry per version would make a get-all return every version of
+//! every holon as a separate top-level result.
 //!
-//! - `PublishRoot` indexes the new holon under `AllHolonNodes`; `PublishVersion` does not. The
-//!   lineage root is already indexed, and one index entry per version would make a get-all
-//!   return every version of every holon as a separate top-level result.
-//! - `PublishVersion` does not author `HolonNodeUpdates` links. Holochain's own update graph
-//!   already records that an update happened, and a parallel link index would be a second
-//!   source of truth for the same fact. Those links remain declared for later storage work
-//!   that will decide deliberately which model to build on.
+//! Versions are authored as native root-addressed Holochain updates and nothing else: Holochain's
+//! own update graph already records that an update happened, so there is no parallel link index
+//! to keep in step with it.
 
 use core_types::{
     resolve_shared_lineage_root, HolonError, HolonWriteRequest, LineageId, StoredHolonNode,

--- a/happ/crates/holons_guest_integrity/src/infrastructure_links.rs
+++ b/happ/crates/holons_guest_integrity/src/infrastructure_links.rs
@@ -20,7 +20,6 @@ use crate::holon_node_envelope::HOLON_NODE_ENTRY_DEF_INDEX;
 /// policy and are outside descriptor-independent PVL.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InfrastructureLinkRejection {
-    HolonNodeUpdatesCreate,
     NonCanonicalBase { link_name: &'static str, expected_path: &'static str },
     NonEmptyTag { link_name: &'static str },
     NonActionTarget { link_name: &'static str },
@@ -31,9 +30,6 @@ pub enum InfrastructureLinkRejection {
 impl fmt::Display for InfrastructureLinkRejection {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::HolonNodeUpdatesCreate => {
-                formatter.write_str("HolonNodeUpdates links are obsolete and cannot be created")
-            }
             Self::NonCanonicalBase { link_name, expected_path } => write!(
                 formatter,
                 "{link_name} links must use the canonical `{expected_path}` path base"
@@ -53,22 +49,6 @@ impl fmt::Display for InfrastructureLinkRejection {
             }
         }
     }
-}
-
-/// Rejects the obsolete revision index without inspecting either endpoint.
-pub fn validate_holon_node_updates_create(
-    _base_address: &AnyLinkableHash,
-    _target_address: &AnyLinkableHash,
-    _tag: &LinkTag,
-) -> ExternResult<Result<(), InfrastructureLinkRejection>> {
-    Ok(Err(InfrastructureLinkRejection::HolonNodeUpdatesCreate))
-}
-
-/// Allows removal of obsolete revision-index links until Storage SL5 retires the link type.
-pub fn validate_holon_node_updates_delete(
-    _original_action: &CreateLink,
-) -> ExternResult<Result<(), InfrastructureLinkRejection>> {
-    Ok(Ok(()))
 }
 
 /// Validates a whole-space index link to one `HolonNode` lineage root.
@@ -310,17 +290,6 @@ mod tests {
     }
 
     #[test]
-    fn holon_node_updates_create_rejects_without_dependencies_or_endpoint_inspection() {
-        set_hdi(no_dependency_mock());
-        let arbitrary: AnyLinkableHash = ExternalHash::from_raw_36(vec![8; 36]).into();
-
-        assert_eq!(
-            validate_holon_node_updates_create(&arbitrary, &arbitrary, &LinkTag::new(vec![1])),
-            Ok(Err(InfrastructureLinkRejection::HolonNodeUpdatesCreate))
-        );
-    }
-
-    #[test]
     fn active_indexes_accept_canonical_empty_tagged_create_targets_with_one_dependency() {
         for (_, path, validate) in active_indexes() {
             install_target(create_action(EntryType::App(holon_entry_def())));
@@ -445,8 +414,6 @@ mod tests {
     fn fixed_delete_policies_use_no_dependencies() {
         let original = original_create_link();
 
-        set_hdi(no_dependency_mock());
-        assert_eq!(validate_holon_node_updates_delete(&original), Ok(Ok(())));
         set_hdi(no_dependency_mock());
         assert_eq!(validate_local_holon_space_delete(&original), Ok(Ok(())));
         set_hdi(no_dependency_mock());

--- a/happ/crates/holons_guest_integrity/src/lib.rs
+++ b/happ/crates/holons_guest_integrity/src/lib.rs
@@ -30,7 +30,6 @@ pub use holon_node_lifecycle::{
 };
 pub use infrastructure_links::{
     validate_all_holon_nodes_create, validate_all_holon_nodes_delete,
-    validate_holon_node_updates_create, validate_holon_node_updates_delete,
     validate_local_holon_space_create, validate_local_holon_space_delete,
     InfrastructureLinkRejection,
 };

--- a/happ/zomes/integrity/holons_integrity/src/lib.rs
+++ b/happ/zomes/integrity/holons_integrity/src/lib.rs
@@ -25,7 +25,6 @@ pub enum EntryTypes {
 #[hdk_link_types]
 pub enum LinkTypes {
     AllHolonNodes,
-    HolonNodeUpdates,
     LocalHolonSpace,
     SmartLink,
 }
@@ -121,9 +120,6 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         },
         FlatOp::RegisterCreateLink { link_type, base_address, target_address, tag, .. } => {
             match link_type {
-                LinkTypes::HolonNodeUpdates => Ok(fixed_callback_result(
-                    validate_holon_node_updates_create(&base_address, &target_address, &tag)?,
-                )),
                 LinkTypes::SmartLink => Ok(pvl_callback_result(validate_smartlink_create(
                     &base_address,
                     &target_address,
@@ -138,9 +134,6 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             }
         }
         FlatOp::RegisterDeleteLink { link_type, original_action, .. } => match link_type {
-            LinkTypes::HolonNodeUpdates => {
-                Ok(fixed_callback_result(validate_holon_node_updates_delete(&original_action)?))
-            }
             LinkTypes::SmartLink => {
                 Ok(pvl_callback_result(validate_smartlink_delete(&original_action)?))
             }
@@ -171,9 +164,6 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             }
             OpRecord::CreateLink { base_address, target_address, tag, link_type, .. } => {
                 match link_type {
-                    LinkTypes::HolonNodeUpdates => Ok(fixed_callback_result(
-                        validate_holon_node_updates_create(&base_address, &target_address, &tag)?,
-                    )),
                     LinkTypes::SmartLink => Ok(pvl_callback_result(validate_smartlink_create(
                         &base_address,
                         &target_address,
@@ -200,9 +190,6 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                     return Ok(ValidateCallbackResult::Valid);
                 };
                 match link_type {
-                    LinkTypes::HolonNodeUpdates => {
-                        Ok(fixed_callback_result(validate_holon_node_updates_delete(&create_link)?))
-                    }
                     LinkTypes::SmartLink => {
                         Ok(pvl_callback_result(validate_smartlink_delete(&create_link)?))
                     }

--- a/happ/zomes/integrity/holons_integrity/src/tests.rs
+++ b/happ/zomes/integrity/holons_integrity/src/tests.rs
@@ -6,7 +6,6 @@ use shared_validation::pvl_limits_v1::MAX_HOLON_NODE_BYTES;
 const HOLON_ENTRY_DEF_INDEX: EntryDefIndex = EntryDefIndex(0);
 const HOLON_ZOME_INDEX: ZomeIndex = ZomeIndex(0);
 const ALL_HOLON_NODES_LINK_TYPE: LinkType = LinkType(LinkTypes::AllHolonNodes as u8);
-const HOLON_NODE_UPDATES_LINK_TYPE: LinkType = LinkType(LinkTypes::HolonNodeUpdates as u8);
 const LOCAL_HOLON_SPACE_LINK_TYPE: LinkType = LinkType(LinkTypes::LocalHolonSpace as u8);
 const SMARTLINK_LINK_TYPE: LinkType = LinkType(LinkTypes::SmartLink as u8);
 
@@ -259,12 +258,7 @@ fn zome_info() -> ZomeInfo {
             // flattening and StoreRecord delete dispatch.
             links: ScopedZomeTypes(vec![(
                 HOLON_ZOME_INDEX,
-                vec![
-                    ALL_HOLON_NODES_LINK_TYPE,
-                    HOLON_NODE_UPDATES_LINK_TYPE,
-                    LOCAL_HOLON_SPACE_LINK_TYPE,
-                    SMARTLINK_LINK_TYPE,
-                ],
+                vec![ALL_HOLON_NODES_LINK_TYPE, LOCAL_HOLON_SPACE_LINK_TYPE, SMARTLINK_LINK_TYPE],
             )]),
         },
     )
@@ -427,11 +421,9 @@ fn create_link(link_type: LinkType, tag: LinkTag) -> CreateLink {
 fn infrastructure_create_link(link_type: LinkType) -> CreateLink {
     let path = if link_type == ALL_HOLON_NODES_LINK_TYPE {
         ALL_HOLON_NODES_PATH
-    } else if link_type == LOCAL_HOLON_SPACE_LINK_TYPE {
-        LOCAL_HOLON_SPACE_PATH
     } else {
-        assert_eq!(link_type, HOLON_NODE_UPDATES_LINK_TYPE);
-        "obsolete_holon_node_updates_has_no_canonical_base"
+        assert_eq!(link_type, LOCAL_HOLON_SPACE_LINK_TYPE);
+        LOCAL_HOLON_SPACE_PATH
     };
     let mut create = create_link(link_type, LinkTag::new(Vec::new()));
     create.base_address = Path::from(path).path_entry_hash().expect("path hashing is local").into();
@@ -516,18 +508,6 @@ fn both_smartlink_create_forms_use_no_dependencies() {
 #[test]
 fn infrastructure_create_forms_pin_their_structural_dependency_counts() {
     for form in [CreateLinkOpForm::RegisterCreateLink, CreateLinkOpForm::StoreRecord] {
-        install_infrastructure_create_target(0);
-        assert_eq!(
-            validate(create_link_op(
-                form,
-                infrastructure_create_link(HOLON_NODE_UPDATES_LINK_TYPE),
-            )),
-            Ok(ValidateCallbackResult::Invalid(
-                "HolonNodeUpdates links are obsolete and cannot be created".into()
-            )),
-            "{form:?} bypassed HolonNodeUpdates create rejection"
-        );
-
         for link_type in [ALL_HOLON_NODES_LINK_TYPE, LOCAL_HOLON_SPACE_LINK_TYPE] {
             install_infrastructure_create_target(1);
             assert_eq!(
@@ -541,12 +521,7 @@ fn infrastructure_create_forms_pin_their_structural_dependency_counts() {
 
 #[test]
 fn every_register_delete_link_form_uses_no_dependencies() {
-    for link_type in [
-        ALL_HOLON_NODES_LINK_TYPE,
-        HOLON_NODE_UPDATES_LINK_TYPE,
-        LOCAL_HOLON_SPACE_LINK_TYPE,
-        SMARTLINK_LINK_TYPE,
-    ] {
+    for link_type in [ALL_HOLON_NODES_LINK_TYPE, LOCAL_HOLON_SPACE_LINK_TYPE, SMARTLINK_LINK_TYPE] {
         let mut mock = MockHdi::new();
         mock.expect_must_get_action().times(0);
         mock.expect_must_get_valid_record().times(0);
@@ -572,12 +547,7 @@ fn every_register_delete_link_form_uses_no_dependencies() {
 
 #[test]
 fn every_store_record_delete_link_form_uses_one_action_dependency() {
-    for link_type in [
-        ALL_HOLON_NODES_LINK_TYPE,
-        HOLON_NODE_UPDATES_LINK_TYPE,
-        LOCAL_HOLON_SPACE_LINK_TYPE,
-        SMARTLINK_LINK_TYPE,
-    ] {
+    for link_type in [ALL_HOLON_NODES_LINK_TYPE, LOCAL_HOLON_SPACE_LINK_TYPE, SMARTLINK_LINK_TYPE] {
         let create = if link_type == SMARTLINK_LINK_TYPE {
             create_link(link_type, valid_smartlink_tag())
         } else {

--- a/tests/sweetests/tests/pvl_validation_tests.rs
+++ b/tests/sweetests/tests/pvl_validation_tests.rs
@@ -32,8 +32,10 @@ const EXPECTED_MALFORMED_SMARTLINK_REJECTION: &str =
 #[derive(Clone, Copy, Debug, Serialize)]
 enum LinkTypeInput {
     AllHolonNodes,
-    HolonNodeUpdates,
     LocalHolonSpace,
+    /// Retired in Storage SL5a (#631). Kept here with no guest counterpart so
+    /// `obsolete_updates_link_type_is_no_longer_addressable` can prove the ingress refuses it.
+    HolonNodeUpdates,
 }
 
 #[derive(Debug, Serialize)]
@@ -321,21 +323,35 @@ async fn infrastructure_root_indexes_reject_update_targets_at_the_public_ingress
     }
 }
 
+/// The obsolete revision index is unreachable, not merely rejected.
+///
+/// Storage SL5a removed `HolonNodeUpdates` from `LinkTypes`, so the public ingress can no longer
+/// deserialize the name into a link type at all — a stronger guarantee than the validation
+/// rejection it replaces. The failure is an HDK deserialization error, so this asserts only that
+/// the call fails; its wording is not ours to pin.
 #[tokio::test(flavor = "multi_thread")]
-async fn obsolete_updates_create_and_all_holon_nodes_delete_are_rejected() {
-    let backend = setup_probe_enabled_conductor().await;
+async fn obsolete_updates_link_type_is_no_longer_addressable() {
+    let backend = setup_test_conductor().await;
     let target = publish_root(&backend, "target").await;
-    let updates = create_path(
+
+    let result = create_path(
         &backend,
         "arbitrary_obsolete_base",
         LinkTypeInput::HolonNodeUpdates,
         target.version_id(),
     )
     .await;
-    assert_commit_rejected_with_message(
-        updates,
-        "HolonNodeUpdates links are obsolete and cannot be created",
+
+    assert!(
+        result.is_err(),
+        "the retired HolonNodeUpdates link type must not be addressable through the ingress"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn all_holon_nodes_delete_is_rejected() {
+    let backend = setup_probe_enabled_conductor().await;
+    let target = publish_root(&backend, "target").await;
 
     let all_link =
         create_path(&backend, "all_holon_nodes", LinkTypeInput::AllHolonNodes, target.version_id())


### PR DESCRIPTION

Advances #631. **Does not close it** — the `AllHolonNodes` half is blocked; see below.

## Summary

Removes the obsolete `HolonNodeUpdates` link type: the parallel revision-topology model MAP declared but
never wrote. Versions are now recorded one way only — Holochain's native root-addressed update graph — and
`LinkTypes` carries no dead variant.

**No behavior changes.** Nothing authored these links, so nothing read them: both externs that traversed the
index were scaffolded no-ops, and the create-validator rejected every write unconditionally.

## Changes

**`persistence_layer/holon_node.rs`** — deletes `get_all_revisions_for_holon_node` and
`get_latest_holon_node`. Both returned what they were given, since no links existed to follow. The rest of
the scaffolded surface is retained per #631 §4.7: exact-action retrieval, deletion helpers, and the
bootstrap path pair.

**`persistence_layer/all_holon_nodes.rs`** — `get_all_holon_nodes` drops its per-record
`get_latest_holon_node` call and returns the batch directly. Doc comment now states plainly that results are
lineage roots.

This is the one change worth reading closely, since it looks like it could weaken a guarantee. It cannot:
`get_latest_holon_node(record.action_address())` was a `get()` on the hash of the record already in hand,
because zero `HolonNodeUpdates` links have ever existed. Old and new return the same set — true regardless
of what the index contains, so no assumption about the index is load-bearing here. The one asymmetry favors
the new code: the old loop dropped a record whenever that redundant second `get` returned `None`.

Separately, the index does hold only lineage roots, and that is enforced rather than conventional.
`validate_root_index_create` fetches the target with `must_get_valid_record` and rejects unless its
`action_kind` is `Create`, so an update-addressed target is unwritable; the write side matches, since
`index_under_all_holon_nodes` is called only from the `PublishRoot` arm of `persist_holon`. The invariant is
pinned by `infrastructure_root_indexes_reject_update_targets_at_the_public_ingress`, which publishes a root,
publishes a version, attempts to index the version, and asserts rejection. That test is untouched by this PR
and passes. Both the write path and that validation are `AllHolonNodes` surface, so they are SL5b's to
remove, not SL5a's.

**`persistence_layer/holon_storage.rs`** — the module doc recorded two deliberate non-decisions; this PR
makes one of them, so it becomes a statement of fact. The `PublishRoot` → `AllHolonNodes` non-decision stays
verbatim — still live.

**`holons_integrity/src/lib.rs`** — removes the variant and its four dispatch arms. Those exhaustive matches
are the compiler-driven checklist: nothing routes to a removed validator without a build failure.
`LinkTypes::from_type` already returns `Valid` for unresolvable types, so legacy on-chain deletes degrade
through that path.

**`holons_guest_integrity`** — removes both validators, the `HolonNodeUpdatesCreate` rejection variant, and
two re-export names. `validate_root_index_create` and the whole `LocalHolonSpace` / `AllHolonNodes` policy
set are untouched (#631 §9 calls out `LocalHolonSpace` preservation specifically).

**`coordinator-surface.toml`** — drops the two removed externs' `[[export]]` blocks. The manifest pins the
extern symbol set, so `check:happ-artifacts` fails if it and the WASM disagree either way.

## Notable decisions

- **Deleted outright rather than reserving the slot.** `#[hdk_link_types]` numbers variants by declaration
  order, so removing index 1 shifts `LocalHolonSpace` 2 → 1 and `SmartLink` 3 → 2, changing the DNA hash.
  A `_Reserved` placeholder was rejected: no deployment needs migrating, and a placeholder still needs a
  validation arm — the dead surface this issue exists to remove. `AllHolonNodes` stays at index 0.
- **The shift is inert by construction.** The enum is the single source of truth for both the write and the
  read of every link, so uniform renumbering cannot desynchronize them within a build. `smartlink_tests.rs`
  and the relationship fixtures exercise `SmartLink` across it end to end.
- **The obsolete-create test was repurposed, not deleted.** Its old assertion — that authoring such a link
  is *rejected* — is now unstatable, since the ingress can no longer deserialize the name into a link type
  at all. `obsolete_updates_link_type_is_no_longer_addressable` asserts the stronger property: unreachable
  rather than reachable-and-rejected. It asserts failure only, not the message, which is HDK's wording. The
  sweetest `LinkTypeInput` mirror keeps a `HolonNodeUpdates` variant with no guest counterpart, commented as
  a negative fixture so it isn't later "fixed" away.
- **The `AllHolonNodes`-delete half became its own test**, `all_holon_nodes_delete_is_rejected`, so SL5b can
  remove it as a unit.

## Why SL5b exists

#631 §3 and §9 make `AllHolonNodes` depend on a coordinator-owned replacement for whole-space discovery.
That dependency is real and unstarted, so this PR does the unblocked half.

`get_all_holons_internal` still reads the index. Behind `LookupFacade::get_all_holons()` sit seven live
consumers wanting two different things:

- **Lookup by key**, using get-all as a stand-in — `loader_ref_resolver.rs`, `errors.rs`,
  `lookup_saved_holon_executor`, `descriptor_verification_executor`,
  `command_affordance_verification_executor`. Three say so in comments.
- **Enumeration or count** — `ensure_database_count_executor`, `print_database_executor`.

Plus `TransactionAction::GetAllHolons`, the legacy dance, and the TS SDK's `getAllHolons()`. Neither
capability exists elsewhere: no key index, no type index, no predicate query (`QueryExpression` carries only
a relationship name and needs a source collection), and the space holon has no membership edges. No branch
is building a replacement. Repairing `GetAllHolons` here is out of scope — #631 §8 rejects that combination
as unbounded — and deleting the index anyway would break the loader and five sweetest flows, exactly as §9
predicts.

**SL5b**, once the replacement lands and every consumer adopts it: remove `index_under_all_holon_nodes` and
its `PublishRoot` call; delete `all_holon_nodes.rs` and its `mod.rs` wiring; remove the variant, its four
arms, both validators, and the `AllHolonNodesDelete` rejection; remove `ALL_HOLON_NODES_PATH`, the
`all_holon_nodes_delete_for_test` probe with its surface entry, and `all_holon_nodes_delete_is_rejected`;
repoint `mock_conductor.rs`'s liveness probe, which calls the `get_all_holon_nodes` extern, at a surviving
one. Same shape as this PR; #631 closes there. The replacement itself is coordinator work and a separate
issue.

Diffstat: 9 files, +41 / −187.

## Scope

Unchanged: the entire `AllHolonNodes` surface; `persistence_layer::smartlink` and the Tag v1 codec;
`LocalHolonSpace` bootstrap behavior; exact-version reads and Storage SL2 record behavior; occurrence
identity and inverse pairing.

No replacement whole-space query or revision-traversal API is added (#631 §5). Head selection over the
native update graph remains later storage work — now with one model to build on rather than a choice
between two, which was the point.

Still open, unaffected: the `put_smartlink` candidate-scan cost (SL3), and the reference-layer/storage
disagreement over what "the same link" means (SL4), which duplicate-aware collections will make non-benign.
