### PR TITLE
Add loader-ready ValidationBinding schema corpus 

### DIFF
--- a/generated/json-imports/map-validation-schema.json
+++ b/generated/json-imports/map-validation-schema.json
@@ -1,0 +1,4699 @@
+{
+  "meta": {
+    "export_mode": "design-seed",
+    "generated_at": "2026-08-10",
+    "generator": "MAP validation architecture design seed",
+    "load_with": [
+      "MAP Schema Types-map-core-schema-root.json",
+      "MAP Schema Types-map-core-schema-concrete-value-types.json",
+      "MAP Schema Types-map-core-schema-abstract-value-types.json",
+      "MAP Schema Types-map-core-schema-property-types.json",
+      "MAP Schema Types-map-core-schema-relationship-types.json",
+      "MAP Schema Types-map-core-schema-operator-types.json"
+    ],
+    "source_files": [
+      "docs/core/validation/validation-schema-design-spec.md",
+      "docs/core/validation/validation-arch.md",
+      "docs/core/validation/validation-impl-plan.md"
+    ]
+  },
+  "holons": [
+    {
+      "key": "MAP Validation Schema-v0.1.0",
+      "type": "Schema.HolonType",
+      "properties": {
+        "SchemaName": "MAP Validation Schema-v0.1.0",
+        "Description": "Design seed for validation-owned descriptor types, ValidationRule families, seeded core ValidationRule instances, and ValidationBinding commitments."
+      }
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType",
+      "type": "MetaEnumValueType.MetaValueType",
+      "properties": {
+        "TypeName": "ValidationLevel",
+        "TypeNamePlural": "ValidationLevels",
+        "DisplayName": "Validation Level",
+        "DisplayNamePlural": "Validation Levels",
+        "Description": "Validator level at which a ValidationRule is evaluated."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumValueType.EnumValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "Variants",
+          "target": [
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Holon"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Property"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Value"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Relationship"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Transaction"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Command"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Dance"
+            },
+            {
+              "$ref": "ValidationLevel.MapEnumValueType.Agreement"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Holon",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Holon",
+        "DisplayName": "Holon",
+        "Description": "Validation over a holon and its descriptor-level instance contract."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Property",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Property",
+        "DisplayName": "Property",
+        "Description": "Validation over a populated or required property member."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Value",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Value",
+        "DisplayName": "Value",
+        "Description": "Validation over a property value and its selected ValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Relationship",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Relationship",
+        "DisplayName": "Relationship",
+        "Description": "Validation over relationship descriptors or relationship occurrences."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Transaction",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Transaction",
+        "DisplayName": "Transaction",
+        "Description": "Validation over a staged transaction and available graph snapshot."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Command",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Command",
+        "DisplayName": "Command",
+        "Description": "Validation over command invocation contracts and preconditions."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Dance",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Dance",
+        "DisplayName": "Dance",
+        "Description": "Validation over dance invocation contracts and preconditions."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.MapEnumValueType.Agreement",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Agreement",
+        "DisplayName": "Agreement",
+        "Description": "Validation over agreement, role, trust, or policy commitments."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationSeverity.MapEnumValueType",
+      "type": "MetaEnumValueType.MetaValueType",
+      "properties": {
+        "TypeName": "ValidationSeverity",
+        "TypeNamePlural": "ValidationSeverities",
+        "DisplayName": "Validation Severity",
+        "DisplayNamePlural": "Validation Severities",
+        "Description": "Default severity emitted when a ValidationRule fails."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumValueType.EnumValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "Variants",
+          "target": [
+            {
+              "$ref": "ValidationSeverity.MapEnumValueType.Info"
+            },
+            {
+              "$ref": "ValidationSeverity.MapEnumValueType.Warning"
+            },
+            {
+              "$ref": "ValidationSeverity.MapEnumValueType.Error"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationSeverity.MapEnumValueType.Info",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Info",
+        "DisplayName": "Info",
+        "Description": "Informational validation result."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationSeverity.MapEnumValueType.Warning",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Warning",
+        "DisplayName": "Warning",
+        "Description": "Non-blocking warning validation result."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationSeverity.MapEnumValueType.Error",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Error",
+        "DisplayName": "Error",
+        "Description": "Blocking error validation result when selected by a commit-oriented profile."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationBlockingBehavior.MapEnumValueType",
+      "type": "MetaEnumValueType.MetaValueType",
+      "properties": {
+        "TypeName": "ValidationBlockingBehavior",
+        "TypeNamePlural": "ValidationBlockingBehaviors",
+        "DisplayName": "Validation Blocking Behavior",
+        "DisplayNamePlural": "Validation Blocking Behaviors",
+        "Description": "Minimum operation-blocking behavior for a ValidationRule."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumValueType.EnumValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "Variants",
+          "target": [
+            {
+              "$ref": "ValidationBlockingBehavior.MapEnumValueType.Advisory"
+            },
+            {
+              "$ref": "ValidationBlockingBehavior.MapEnumValueType.CommitBlocking"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationBlockingBehavior.MapEnumValueType.Advisory",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Advisory",
+        "DisplayName": "Advisory",
+        "Description": "The rule may report results without blocking commit."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationBlockingBehavior.MapEnumValueType.CommitBlocking",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "CommitBlocking",
+        "DisplayName": "Commit Blocking",
+        "Description": "The rule blocks commit when it fails in a commit-oriented validation profile."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationDeterminismClass.MapEnumValueType",
+      "type": "MetaEnumValueType.MetaValueType",
+      "properties": {
+        "TypeName": "ValidationDeterminismClass",
+        "TypeNamePlural": "ValidationDeterminismClasses",
+        "DisplayName": "Validation Determinism Class",
+        "DisplayNamePlural": "Validation Determinism Classes",
+        "Description": "Determinism classification for validation-rule execution."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumValueType.EnumValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "Variants",
+          "target": [
+            {
+              "$ref": "ValidationDeterminismClass.MapEnumValueType.Deterministic"
+            },
+            {
+              "$ref": "ValidationDeterminismClass.MapEnumValueType.Contextual"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationDeterminismClass.MapEnumValueType.Deterministic",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Deterministic",
+        "DisplayName": "Deterministic",
+        "Description": "The rule can produce reproducible results with the declared context."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationDeterminismClass.MapEnumValueType.Contextual",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Contextual",
+        "DisplayName": "Contextual",
+        "Description": "The rule depends on local runtime, profile, or snapshot context."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationLevel.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationLevel",
+        "TypeNamePlural": "ValidationLevels",
+        "DisplayName": "validation_level",
+        "DisplayNamePlural": "validation_levels",
+        "Description": "Validator level at which a ValidationRule operates.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "ValidationLevel.MapEnumValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DefaultSeverity.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "DefaultSeverity",
+        "TypeNamePlural": "DefaultSeverities",
+        "DisplayName": "default_severity",
+        "DisplayNamePlural": "default_severities",
+        "Description": "Default severity emitted by a failing ValidationRule.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "ValidationSeverity.MapEnumValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "MinimumBlockingBehavior.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "MinimumBlockingBehavior",
+        "TypeNamePlural": "MinimumBlockingBehaviors",
+        "DisplayName": "minimum_blocking_behavior",
+        "DisplayNamePlural": "minimum_blocking_behaviors",
+        "Description": "Weakest blocking behavior a binding or profile may apply to a ValidationRule.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "ValidationBlockingBehavior.MapEnumValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeterminismClass.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "DeterminismClass",
+        "TypeNamePlural": "DeterminismClasses",
+        "DisplayName": "determinism_class",
+        "DisplayNamePlural": "determinism_classes",
+        "Description": "Determinism class for the ValidationRule implementation contract.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "ValidationDeterminismClass.MapEnumValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "SemanticAuthority.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "SemanticAuthority",
+        "TypeNamePlural": "SemanticAuthorities",
+        "DisplayName": "semantic_authority",
+        "DisplayNamePlural": "semantic_authorities",
+        "Description": "Stable reference to the descriptor-semantics rule family or normative source that defines the ValidationRule meaning.",
+        "IsValueRequired": false
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "MapStringValueType.StringValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationRuleDescription.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationRuleDescription",
+        "TypeNamePlural": "ValidationRuleDescriptions",
+        "DisplayName": "validation_rule_description",
+        "DisplayNamePlural": "validation_rule_descriptions",
+        "Description": "Human-readable ValidationRule description.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "MapStringValueType.StringValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "MetaValidationRule.MetaHolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "MetaValidationRule",
+        "TypeNamePlural": "MetaValidationRules",
+        "DisplayName": "Meta Validation Rule",
+        "DisplayNamePlural": "Meta Validation Rules",
+        "Description": "Meta-type describing ValidationRule family descriptor holons. It narrows local operator affordance to validation-rule descriptors."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MetaHolonType.MetaTypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(ValidationRule.HolonType)-[AffordsOperator]->(OperatorType.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "ValidationRule",
+        "TypeNamePlural": "ValidationRules",
+        "DisplayName": "Validation Rule",
+        "DisplayNamePlural": "Validation Rules",
+        "Description": "Abstract root for first-class validation rule holons.",
+        "IsAbstractType": true,
+        "DefinesInstanceTypeKind": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "ValidationLevel.PropertyType"
+            },
+            {
+              "$ref": "DefaultSeverity.PropertyType"
+            },
+            {
+              "$ref": "MinimumBlockingBehavior.PropertyType"
+            },
+            {
+              "$ref": "DeterminismClass.PropertyType"
+            },
+            {
+              "$ref": "SemanticAuthority.PropertyType"
+            },
+            {
+              "$ref": "ValidationRuleDescription.PropertyType"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(TypeDescriptor)-[ComponentOf]->(Schema.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "AffordsOperator",
+          "target": [
+            {
+              "$ref": "Validate.OperatorType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "HolonValidationRule",
+        "TypeNamePlural": "HolonValidationRules",
+        "DisplayName": "Holon Validation Rule",
+        "DisplayNamePlural": "Holon Validation Rules",
+        "Description": "ValidationRule family for rules evaluated over holons and their descriptor-level contracts.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "PropertyValidationRule",
+        "TypeNamePlural": "PropertyValidationRules",
+        "DisplayName": "Property Validation Rule",
+        "DisplayNamePlural": "Property Validation Rules",
+        "Description": "ValidationRule family for rules evaluated over property descriptors, required properties, and populated property members.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValueValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "ValueValidationRule",
+        "TypeNamePlural": "ValueValidationRules",
+        "DisplayName": "Value Validation Rule",
+        "DisplayNamePlural": "Value Validation Rules",
+        "Description": "ValidationRule family for rules evaluated over property values and their selected ValueType descriptors.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "StringValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "StringValidationRule",
+        "TypeNamePlural": "StringValidationRules",
+        "DisplayName": "String Validation Rule",
+        "DisplayNamePlural": "String Validation Rules",
+        "Description": "ValidationRule family for string value rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "IntegerValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "IntegerValidationRule",
+        "TypeNamePlural": "IntegerValidationRules",
+        "DisplayName": "Integer Validation Rule",
+        "DisplayNamePlural": "Integer Validation Rules",
+        "Description": "ValidationRule family for integer value rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BooleanValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "BooleanValidationRule",
+        "TypeNamePlural": "BooleanValidationRules",
+        "DisplayName": "Boolean Validation Rule",
+        "DisplayNamePlural": "Boolean Validation Rules",
+        "Description": "ValidationRule family for boolean value rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumValueValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "EnumValueValidationRule",
+        "TypeNamePlural": "EnumValueValidationRules",
+        "DisplayName": "Enum Value Validation Rule",
+        "DisplayNamePlural": "Enum Value Validation Rules",
+        "Description": "ValidationRule family for enum value and enum variant membership rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BytesValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "BytesValidationRule",
+        "TypeNamePlural": "BytesValidationRules",
+        "DisplayName": "Bytes Validation Rule",
+        "DisplayNamePlural": "Bytes Validation Rules",
+        "Description": "ValidationRule family for bytes value rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValueArrayValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "ValueArrayValidationRule",
+        "TypeNamePlural": "ValueArrayValidationRules",
+        "DisplayName": "Value Array Validation Rule",
+        "DisplayNamePlural": "Value Array Validation Rules",
+        "Description": "ValidationRule family for value-array and collection value rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValueValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "RelationshipValidationRule",
+        "TypeNamePlural": "RelationshipValidationRules",
+        "DisplayName": "Relationship Validation Rule",
+        "DisplayNamePlural": "Relationship Validation Rules",
+        "Description": "ValidationRule family for relationship descriptor and relationship occurrence rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TransactionValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "TransactionValidationRule",
+        "TypeNamePlural": "TransactionValidationRules",
+        "DisplayName": "Transaction Validation Rule",
+        "DisplayNamePlural": "Transaction Validation Rules",
+        "Description": "ValidationRule family for staged transaction rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "CommandValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "CommandValidationRule",
+        "TypeNamePlural": "CommandValidationRules",
+        "DisplayName": "Command Validation Rule",
+        "DisplayNamePlural": "Command Validation Rules",
+        "Description": "ValidationRule family for command invocation validation rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DanceValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "DanceValidationRule",
+        "TypeNamePlural": "DanceValidationRules",
+        "DisplayName": "Dance Validation Rule",
+        "DisplayNamePlural": "Dance Validation Rules",
+        "Description": "ValidationRule family for dance invocation validation rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "AgreementValidationRule.HolonType",
+      "type": "MetaValidationRule.MetaHolonType",
+      "properties": {
+        "TypeName": "AgreementValidationRule",
+        "TypeNamePlural": "AgreementValidationRules",
+        "DisplayName": "Agreement Validation Rule",
+        "DisplayNamePlural": "Agreement Validation Rules",
+        "Description": "ValidationRule family for agreement, trust, role, and policy validation rules.",
+        "IsAbstractType": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "Validate.OperatorType",
+      "type": "MetaOperatorType.MetaHolonType",
+      "properties": {
+        "TypeName": "Validate",
+        "TypeNamePlural": "ValidateOperators",
+        "DisplayName": "Validate",
+        "DisplayNamePlural": "Validate Operators",
+        "Description": "Local operator contract for evaluating a ValidationRule in a validation context. Initial execution is wrapper-based and does not require generic operator or Dance dispatch.",
+        "Arity": 1,
+        "OperatorCategory": "Equality"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "OperatorType.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(ValidationRule.HolonType)-[AffordsOperator]->(OperatorType.HolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "AffordsOperator",
+        "TypeNamePlural": "AffordsOperatorRelationships",
+        "DisplayName": "AffordsOperator Relationship",
+        "DisplayNamePlural": "AffordsOperator Relationships",
+        "Description": "Links a ValidationRule family descriptor to the local operator descriptors available for rules in that family.",
+        "IsDefinitional": true,
+        "MinCardinality": 0,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "OperatorType.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(OperatorType.HolonType)-[AffordedBy]->(ValidationRule.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(OperatorType.HolonType)-[AffordedBy]->(ValidationRule.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "AffordedBy",
+        "TypeNamePlural": "AffordedByRelationships",
+        "DisplayName": "AffordedBy Relationship",
+        "DisplayNamePlural": "AffordedBy Relationships",
+        "Description": "Inverse of AffordsOperator for ValidationRule family descriptors.",
+        "MinCardinality": 0,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "OperatorType.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationBinding.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationBinding",
+        "TypeNamePlural": "ValidationBindings",
+        "DisplayName": "Validation Binding",
+        "DisplayNamePlural": "Validation Bindings",
+        "Description": "A validation-owned commitment that applies one ValidationRule to one descriptor target."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(TypeDescriptor)-[ComponentOf]->(Schema.HolonType)"
+            },
+            {
+              "$ref": "(ValidationBinding.HolonType)-[AppliesTo]->(TypeDescriptor)"
+            },
+            {
+              "$ref": "(ValidationBinding.HolonType)-[UsesRule]->(ValidationRule.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(ValidationBinding.HolonType)-[AppliesTo]->(TypeDescriptor)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "AppliesTo",
+        "TypeNamePlural": "AppliesTo",
+        "DisplayName": "Applies To",
+        "DisplayNamePlural": "Applies To",
+        "Description": "Identifies the descriptor whose instances are subject to this validation commitment.",
+        "IsDefinitional": true,
+        "MinCardinality": 1,
+        "MaxCardinality": 1,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "ValidationBinding.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(TypeDescriptor)-[HasValidationBinding]->(ValidationBinding.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(TypeDescriptor)-[HasValidationBinding]->(ValidationBinding.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "HasValidationBinding",
+        "TypeNamePlural": "HasValidationBindings",
+        "DisplayName": "Has Validation Binding",
+        "DisplayNamePlural": "Has Validation Bindings",
+        "Description": "Inverse index from a descriptor to validation-owned commitments that apply to it.",
+        "MinCardinality": 0,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "ValidationBinding.HolonType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(ValidationBinding.HolonType)-[UsesRule]->(ValidationRule.HolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "UsesRule",
+        "TypeNamePlural": "UsesRules",
+        "DisplayName": "Uses Rule",
+        "DisplayNamePlural": "Uses Rules",
+        "Description": "Identifies the ValidationRule committed by this binding.",
+        "IsDefinitional": true,
+        "MinCardinality": 1,
+        "MaxCardinality": 1,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "ValidationBinding.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(ValidationRule.HolonType)-[UsedByValidationBinding]->(ValidationBinding.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(ValidationRule.HolonType)-[UsedByValidationBinding]->(ValidationBinding.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "UsedByValidationBinding",
+        "TypeNamePlural": "UsedByValidationBindings",
+        "DisplayName": "Used By Validation Binding",
+        "DisplayNamePlural": "Used By Validation Bindings",
+        "Description": "Inverse index from a ValidationRule to validation bindings that commit it.",
+        "MinCardinality": 0,
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "ValidationRule.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "ValidationBinding.HolonType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationImplementation.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationImplementation",
+        "TypeNamePlural": "ValidationImplementations",
+        "DisplayName": "Validation Implementation",
+        "DisplayNamePlural": "Validation Implementations",
+        "Description": "Descriptor for holons that bind a ValidationRule to executable validation behavior. Dynamic implementation selection is deferred."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationRuleSet.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationRuleSet",
+        "TypeNamePlural": "ValidationRuleSets",
+        "DisplayName": "Validation Rule Set",
+        "DisplayNamePlural": "Validation Rule Sets",
+        "Description": "Descriptor for named compositions of validation rules. Rule-set expansion is deferred until individual rule dispatch is stable."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValidationResult.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "ValidationResult",
+        "TypeNamePlural": "ValidationResults",
+        "DisplayName": "Validation Result",
+        "DisplayNamePlural": "Validation Results",
+        "Description": "Descriptor for durable validation result evidence. Persisted result policy is deferred."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "AtMostOneDirectParent.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "AtMostOneDirectParent",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-STRUCT-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A holon has at most one direct Extends parent."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "AcyclicExtendsLineage.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "AcyclicExtendsLineage",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-STRUCT-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A descriptor Extends lineage must be acyclic."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ExtendsLineageTerminatesAtTypeDescriptor.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ExtendsLineageTerminatesAtTypeDescriptor",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-STRUCT-004",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A parented descriptor lineage must terminate at TypeDescriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "UniqueTypeDescriptorRoot.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "UniqueTypeDescriptorRoot",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-STRUCT-005",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "TypeDescriptor is the unique root of the descriptor hierarchy."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "SchemaDependenciesAcyclic.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "SchemaDependenciesAcyclic",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-SCHEMA-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Versioned schema dependency relationships must be acyclic."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "CrossSchemaDependenciesDeclared.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "CrossSchemaDependenciesDeclared",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-SCHEMA-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every cross-schema reference must have a direct schema dependency declaration."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "CoreAccumulatorsAreAdditive.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "CoreAccumulatorsAreAdditive",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-SCHEMA-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Core contract, behavior, and operator accumulator relationships must declare Additive inheritance."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "LocalInstanceKindAnchorDesignation.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "LocalInstanceKindAnchorDesignation",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KIND-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Instance TypeKind anchor designation is local and singular."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "InstanceKindAnchorsAreAbstract.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "InstanceKindAnchorsAreAbstract",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KIND-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every Instance TypeKind anchor must be abstract."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorRootKindException.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorRootKindException",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KIND-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "TypeDescriptor is the only descriptor root that lacks an Instance TypeKind anchor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DescribingCategoryCompatibility.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "DescribingCategoryCompatibility",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KIND-004",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every describing type must belong to the required describing category."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DescriptorMetaTypeCorrespondence.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "DescriptorMetaTypeCorrespondence",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KIND-005",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Descriptor holons, and only descriptor holons, must use meta-type describers."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "NoInheritedMemberRedeclaration.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "NoInheritedMemberRedeclaration",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONTRACT-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A descriptor must not redundantly redeclare an inherited member."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "UniqueSemanticMemberNames.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "UniqueSemanticMemberNames",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONTRACT-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Effective semantic member names must be unique within each namespace."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "WellFormedEffectiveMemberDefinitions.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "WellFormedEffectiveMemberDefinitions",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONTRACT-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every effective member definition must be well formed."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ContractMemberKindCompatibility.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ContractMemberKindCompatibility",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONTRACT-004",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every effective contract member must have the required instance kind."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "InheritedValueConstraintNonRelaxation.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "InheritedValueConstraintNonRelaxation",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONSTRAINT-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A ValueType subtype must not relax a value constraint inherited through its Extends lineage."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DefaultsRequireRequiredProperties.ValidationRule",
+      "type": "PropertyValidationRule.HolonType",
+      "properties": {
+        "TypeName": "DefaultsRequireRequiredProperties",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-DEFAULT-001",
+        "ValidationLevel": "Property",
+        "ValidationRuleDescription": "Only required properties may declare defaults."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DefaultValueConformance.ValidationRule",
+      "type": "PropertyValidationRule.HolonType",
+      "properties": {
+        "TypeName": "DefaultValueConformance",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-DEFAULT-002",
+        "ValidationLevel": "Property",
+        "ValidationRuleDescription": "Every declared default value must conform to its effective value definition."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "InverseEndpointCorrespondence.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "InverseEndpointCorrespondence",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-REL-002",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "Inverse relationship endpoints must correspond to declared relationship endpoints."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DirectionalDeletionDeclarations.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "DirectionalDeletionDeclarations",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-REL-003",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "Both relationship directions must declare valid deletion semantics."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EffectiveKeyRuleSelection.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "EffectiveKeyRuleSelection",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KEY-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every holon type must resolve exactly one effective instance key rule."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "KeyRuleTargetCompatibility.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "KeyRuleTargetCompatibility",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KEY-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "The selected key rule target must be compatible with and executable for the descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ExplicitKeylessBaseline.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ExplicitKeylessBaseline",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KEY-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "The keyless root must be explicit and key-rule inheritance must use Override semantics."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumMemberNamesUnique.ValidationRule",
+      "type": "EnumValueValidationRule.HolonType",
+      "properties": {
+        "TypeName": "EnumMemberNamesUnique",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-ENUM-001",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "Enum member names must be unique within each effective enum definition."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "AbstractMemberMinimumEnforcement.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "AbstractMemberMinimumEnforcement",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONFORM-002",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Minimum enforcement for abstract descriptors is member-specific."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "UniquePropertyMemberBinding.ValidationRule",
+      "type": "PropertyValidationRule.HolonType",
+      "properties": {
+        "TypeName": "UniquePropertyMemberBinding",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-BIND-001",
+        "ValidationLevel": "Property",
+        "ValidationRuleDescription": "Every declared property name must bind uniquely to a property descriptor admitted by the effective contract."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipOccurrenceGrouping.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipOccurrenceGrouping",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-OCC-001",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "Relationship occurrences must be grouped by resolved relationship descriptor identity."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "AdditionalRelationshipPolicy.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "AdditionalRelationshipPolicy",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-OCC-004",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "Every unbound relationship must be permitted by the effective additional-relationship policy."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ExplicitKeylessness.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ExplicitKeylessness",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KEY-004",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A keyless holon must carry no semantic key."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "KeyPresenceAndValue.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "KeyPresenceAndValue",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-KEY-005",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A keyed new holon must carry exactly the computed semantic key."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ExactlyOneDescribedBy.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ExactlyOneDescribedBy",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-STRUCT-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A holon must have exactly one describing descriptor before descriptor-aware validation can continue."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ConcreteDescribingType.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "ConcreteDescribingType",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CONFORM-001",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "A runtime holon must be described by a concrete descriptor that can describe instances."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "NoUndescribedProperties.ValidationRule",
+      "type": "HolonValidationRule.HolonType",
+      "properties": {
+        "TypeName": "NoUndescribedProperties",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-PROP-003",
+        "ValidationLevel": "Holon",
+        "ValidationRuleDescription": "Every unbound property must be permitted by the effective additional-property policy."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RequiredPropertyPresence.ValidationRule",
+      "type": "PropertyValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RequiredPropertyPresence",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-PROP-001",
+        "ValidationLevel": "Property",
+        "ValidationRuleDescription": "A property declared required by the effective descriptor contract must be present."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyValueConformance.ValidationRule",
+      "type": "PropertyValidationRule.HolonType",
+      "properties": {
+        "TypeName": "PropertyValueConformance",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-PROP-002",
+        "ValidationLevel": "Property",
+        "ValidationRuleDescription": "A populated property value must conform to the selected ValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BaseValueKindMatchesString.ValidationRule",
+      "type": "StringValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BaseValueKindMatchesString",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Built-in value-dispatch rule",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A value governed by a StringValueType descriptor must use the string BaseValue representation."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "StringLength.ValidationRule",
+      "type": "StringValidationRule.HolonType",
+      "properties": {
+        "TypeName": "StringLength",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "String constraint semantics; Unicode extended grapheme cluster counting",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A string value must satisfy the min and max length constraints declared by its StringValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BaseValueKindMatchesInteger.ValidationRule",
+      "type": "IntegerValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BaseValueKindMatchesInteger",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Built-in value-dispatch rule",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A value governed by an IntegerValueType descriptor must use the integer BaseValue representation."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "IntegerRange.ValidationRule",
+      "type": "IntegerValidationRule.HolonType",
+      "properties": {
+        "TypeName": "IntegerRange",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Integer constraint semantics",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "An integer value must satisfy the min and max constraints declared by its IntegerValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BaseValueKindMatchesBoolean.ValidationRule",
+      "type": "BooleanValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BaseValueKindMatchesBoolean",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Built-in value-dispatch rule",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A value governed by a BooleanValueType descriptor must use the boolean BaseValue representation."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BaseValueKindMatchesEnum.ValidationRule",
+      "type": "EnumValueValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BaseValueKindMatchesEnum",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Built-in value-dispatch rule",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A value governed by an EnumValueType descriptor must use the enum BaseValue representation."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumTokenMembership.ValidationRule",
+      "type": "EnumValueValidationRule.HolonType",
+      "properties": {
+        "TypeName": "EnumTokenMembership",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-ENUM-002",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "An enum value token must match one of the effective enum variants admitted by the EnumValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumTokenNonRetroactivity.ValidationRule",
+      "type": "EnumValueValidationRule.HolonType",
+      "properties": {
+        "TypeName": "EnumTokenNonRetroactivity",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Contextual",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-ENUM-003",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "Enum token changes must never rewrite or alias persisted enum values."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BaseValueKindMatchesBytes.ValidationRule",
+      "type": "BytesValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BaseValueKindMatchesBytes",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Built-in value-dispatch rule",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A value governed by a BytesValueType descriptor must use the bytes BaseValue representation."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BytesLength.ValidationRule",
+      "type": "BytesValidationRule.HolonType",
+      "properties": {
+        "TypeName": "BytesLength",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "Bytes constraint semantics",
+        "ValidationLevel": "Value",
+        "ValidationRuleDescription": "A bytes value must satisfy the min and max length constraints declared by its BytesValueType descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipOccurrenceBinding.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipOccurrenceBinding",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-BIND-002",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "A populated relationship name must bind uniquely to a relationship descriptor admitted by the effective contract."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipEndpointCompatibility.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipEndpointCompatibility",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-OCC-002",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "A relationship occurrence endpoint must be compatible with the effective source and target descriptors."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipCollectionPolicy.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipCollectionPolicy",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-OCC-003",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "A relationship occurrence collection must honor ordering and duplicate policies declared by the relationship descriptor."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipCardinality.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipCardinality",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Contextual",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-CARD-001",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "A relationship occurrence set must satisfy descriptor cardinality where the validation context supplies the required transaction or graph snapshot."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "RelationshipDescriptorPairing.ValidationRule",
+      "type": "RelationshipValidationRule.HolonType",
+      "properties": {
+        "TypeName": "RelationshipDescriptorPairing",
+        "DefaultSeverity": "Error",
+        "DeterminismClass": "Deterministic",
+        "MinimumBlockingBehavior": "CommitBlocking",
+        "SemanticAuthority": "DS-REL-001",
+        "ValidationLevel": "Relationship",
+        "ValidationRuleDescription": "Declared and inverse relationship descriptor pairing must be bijective."
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorAtMostOneDirectParent.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorAtMostOneDirectParent"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "AtMostOneDirectParent.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorAcyclicExtendsLineage.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorAcyclicExtendsLineage"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "AcyclicExtendsLineage.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorExtendsLineageTerminates.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorExtendsLineageTerminates"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ExtendsLineageTerminatesAtTypeDescriptor.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorUniqueRoot.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorUniqueRoot"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "UniqueTypeDescriptorRoot.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorSchemaDependenciesAcyclic.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorSchemaDependenciesAcyclic"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "SchemaDependenciesAcyclic.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorCrossSchemaDependenciesDeclared.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorCrossSchemaDependenciesDeclared"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "CrossSchemaDependenciesDeclared.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorCoreAccumulatorsAdditive.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorCoreAccumulatorsAdditive"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "CoreAccumulatorsAreAdditive.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorLocalInstanceKindAnchor.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorLocalInstanceKindAnchor"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "LocalInstanceKindAnchorDesignation.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorInstanceKindAnchorAbstract.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorInstanceKindAnchorAbstract"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "InstanceKindAnchorsAreAbstract.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorRootKindException.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorRootKindException"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "TypeDescriptorRootKindException.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorDescribingCategoryCompatibility.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorDescribingCategoryCompatibility"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "DescribingCategoryCompatibility.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorMetaTypeCorrespondence.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorMetaTypeCorrespondence"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "DescriptorMetaTypeCorrespondence.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorNoInheritedMemberRedeclaration.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorNoInheritedMemberRedeclaration"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "NoInheritedMemberRedeclaration.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorUniqueSemanticMemberNames.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorUniqueSemanticMemberNames"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "UniqueSemanticMemberNames.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorWellFormedEffectiveMembers.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorWellFormedEffectiveMembers"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "WellFormedEffectiveMemberDefinitions.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TypeDescriptorContractMemberKindCompatibility.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "TypeDescriptorContractMemberKindCompatibility"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ContractMemberKindCompatibility.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeExactlyOneDescribedBy.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeExactlyOneDescribedBy"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ExactlyOneDescribedBy.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeConcreteDescribingType.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeConcreteDescribingType"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ConcreteDescribingType.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeNoUndescribedProperties.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeNoUndescribedProperties"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "NoUndescribedProperties.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeAbstractMemberMinimum.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeAbstractMemberMinimum"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "AbstractMemberMinimumEnforcement.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeEffectiveKeyRuleSelection.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeEffectiveKeyRuleSelection"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "EffectiveKeyRuleSelection.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeKeyRuleTargetCompatibility.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeKeyRuleTargetCompatibility"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "KeyRuleTargetCompatibility.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeExplicitKeylessBaseline.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeExplicitKeylessBaseline"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ExplicitKeylessBaseline.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeExplicitKeylessness.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeExplicitKeylessness"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "ExplicitKeylessness.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "HolonTypeKeyPresenceAndValue.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "HolonTypeKeyPresenceAndValue"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "KeyPresenceAndValue.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValueTypeInheritedConstraintNonRelaxation.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "ValueTypeInheritedConstraintNonRelaxation"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "ValueType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "InheritedValueConstraintNonRelaxation.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyTypeDefaultsRequireRequiredProperties.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "PropertyTypeDefaultsRequireRequiredProperties"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "DefaultsRequireRequiredProperties.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyTypeDefaultValueConformance.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "PropertyTypeDefaultValueConformance"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "DefaultValueConformance.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyTypeUniquePropertyMemberBinding.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "PropertyTypeUniquePropertyMemberBinding"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "UniquePropertyMemberBinding.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyTypeRequiredPropertyPresence.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "PropertyTypeRequiredPropertyPresence"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RequiredPropertyPresence.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyTypePropertyValueConformance.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "PropertyTypePropertyValueConformance"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "PropertyValueConformance.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "StringValueTypeBaseValueKind.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "StringValueTypeBaseValueKind"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "StringValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BaseValueKindMatchesString.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "StringValueTypeLength.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "StringValueTypeLength"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "StringValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "StringLength.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "IntegerValueTypeBaseValueKind.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "IntegerValueTypeBaseValueKind"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "IntegerValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BaseValueKindMatchesInteger.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "IntegerValueTypeRange.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "IntegerValueTypeRange"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "IntegerValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "IntegerRange.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BooleanValueTypeBaseValueKind.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "BooleanValueTypeBaseValueKind"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "BooleanValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BaseValueKindMatchesBoolean.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumValueTypeMemberNamesUnique.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "EnumValueTypeMemberNamesUnique"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "EnumValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "EnumMemberNamesUnique.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumValueTypeBaseValueKind.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "EnumValueTypeBaseValueKind"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "EnumValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BaseValueKindMatchesEnum.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumValueTypeTokenMembership.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "EnumValueTypeTokenMembership"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "EnumValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "EnumTokenMembership.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "EnumValueTypeTokenNonRetroactivity.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "EnumValueTypeTokenNonRetroactivity"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "EnumValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "EnumTokenNonRetroactivity.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BytesValueTypeBaseValueKind.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "BytesValueTypeBaseValueKind"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "BytesValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BaseValueKindMatchesBytes.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "BytesValueTypeLength.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "BytesValueTypeLength"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "BytesValueType.ValueType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "BytesLength.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeOccurrenceBinding.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeOccurrenceBinding"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipOccurrenceBinding.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeOccurrenceGrouping.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeOccurrenceGrouping"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipOccurrenceGrouping.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeEndpointCompatibility.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeEndpointCompatibility"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipEndpointCompatibility.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeCollectionPolicy.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeCollectionPolicy"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipCollectionPolicy.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeAdditionalPolicy.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeAdditionalPolicy"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "AdditionalRelationshipPolicy.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeCardinality.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeCardinality"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipCardinality.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeDescriptorPairing.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeDescriptorPairing"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "RelationshipDescriptorPairing.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeInverseEndpointCorrespondence.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeInverseEndpointCorrespondence"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "InverseEndpointCorrespondence.ValidationRule"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "DeclaredRelationshipTypeDirectionalDeletion.ValidationBinding",
+      "type": "ValidationBinding.HolonType",
+      "properties": {
+        "TypeName": "DeclaredRelationshipTypeDirectionalDeletion"
+      },
+      "relationships": [
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP Validation Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "AppliesTo",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "UsesRule",
+          "target": [
+            {
+              "$ref": "DirectionalDeletionDeclarations.ValidationRule"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schema-src/map-validation-schema.tdl
+++ b/schema-src/map-validation-schema.tdl
@@ -1,0 +1,1546 @@
+meta {
+  generator: "MAP validation architecture design seed"
+  generated_at: "2026-08-10"
+  export_mode: "design-seed"
+  source_files: ["docs/core/validation/validation-schema-design-spec.md","docs/core/validation/validation-arch.md","docs/core/validation/validation-impl-plan.md"]
+  load_with: ["MAP Schema Types-map-core-schema-root.json","MAP Schema Types-map-core-schema-concrete-value-types.json","MAP Schema Types-map-core-schema-abstract-value-types.json","MAP Schema Types-map-core-schema-property-types.json","MAP Schema Types-map-core-schema-relationship-types.json","MAP Schema Types-map-core-schema-operator-types.json"]
+}
+
+schema "MAP Validation Schema-v0.1.0" {
+  header {
+    description: "Design seed for validation-owned descriptor types, ValidationRule families, seeded core ValidationRule instances, and ValidationBinding commitments."
+  }
+}
+
+enum ValidationLevel.MapEnumValueType {
+  type MetaEnumValueType.MetaValueType
+  extends MapEnumValueType.EnumValueType
+  header {
+    description: "Validator level at which a ValidationRule is evaluated."
+    display_name: "Validation Level"
+    display_plural: "Validation Levels"
+    plural: "ValidationLevels"
+  }
+  variants {
+    variant Holon {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over a holon and its descriptor-level instance contract."
+        display_name: "Holon"
+      }
+    }
+    variant Property {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over a populated or required property member."
+        display_name: "Property"
+      }
+    }
+    variant Value {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over a property value and its selected ValueType descriptor."
+        display_name: "Value"
+      }
+    }
+    variant Relationship {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over relationship descriptors or relationship occurrences."
+        display_name: "Relationship"
+      }
+    }
+    variant Transaction {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over a staged transaction and available graph snapshot."
+        display_name: "Transaction"
+      }
+    }
+    variant Command {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over command invocation contracts and preconditions."
+        display_name: "Command"
+      }
+    }
+    variant Dance {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over dance invocation contracts and preconditions."
+        display_name: "Dance"
+      }
+    }
+    variant Agreement {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Validation over agreement, role, trust, or policy commitments."
+        display_name: "Agreement"
+      }
+    }
+  }
+}
+
+enum ValidationSeverity.MapEnumValueType {
+  type MetaEnumValueType.MetaValueType
+  extends MapEnumValueType.EnumValueType
+  header {
+    description: "Default severity emitted when a ValidationRule fails."
+    display_name: "Validation Severity"
+    display_plural: "Validation Severities"
+    plural: "ValidationSeverities"
+  }
+  variants {
+    variant Info {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Informational validation result."
+        display_name: "Info"
+      }
+    }
+    variant Warning {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Non-blocking warning validation result."
+        display_name: "Warning"
+      }
+    }
+    variant Error {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "Blocking error validation result when selected by a commit-oriented profile."
+        display_name: "Error"
+      }
+    }
+  }
+}
+
+enum ValidationBlockingBehavior.MapEnumValueType {
+  type MetaEnumValueType.MetaValueType
+  extends MapEnumValueType.EnumValueType
+  header {
+    description: "Minimum operation-blocking behavior for a ValidationRule."
+    display_name: "Validation Blocking Behavior"
+    display_plural: "Validation Blocking Behaviors"
+    plural: "ValidationBlockingBehaviors"
+  }
+  variants {
+    variant Advisory {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "The rule may report results without blocking commit."
+        display_name: "Advisory"
+      }
+    }
+    variant CommitBlocking {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "The rule blocks commit when it fails in a commit-oriented validation profile."
+        display_name: "Commit Blocking"
+      }
+    }
+  }
+}
+
+enum ValidationDeterminismClass.MapEnumValueType {
+  type MetaEnumValueType.MetaValueType
+  extends MapEnumValueType.EnumValueType
+  header {
+    description: "Determinism classification for validation-rule execution."
+    display_name: "Validation Determinism Class"
+    display_plural: "Validation Determinism Classes"
+    plural: "ValidationDeterminismClasses"
+  }
+  variants {
+    variant Deterministic {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "The rule can produce reproducible results with the declared context."
+        display_name: "Deterministic"
+      }
+    }
+    variant Contextual {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "The rule depends on local runtime, profile, or snapshot context."
+        display_name: "Contextual"
+      }
+    }
+  }
+}
+
+property ValidationLevel.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value ValidationLevel.MapEnumValueType
+  IsValueRequired true
+  header {
+    description: "Validator level at which a ValidationRule operates."
+    display_name: "validation_level"
+    display_plural: "validation_levels"
+    plural: "ValidationLevels"
+  }
+}
+
+property DefaultSeverity.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value ValidationSeverity.MapEnumValueType
+  IsValueRequired true
+  header {
+    description: "Default severity emitted by a failing ValidationRule."
+    display_name: "default_severity"
+    display_plural: "default_severities"
+    plural: "DefaultSeverities"
+  }
+}
+
+property MinimumBlockingBehavior.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value ValidationBlockingBehavior.MapEnumValueType
+  IsValueRequired true
+  header {
+    description: "Weakest blocking behavior a binding or profile may apply to a ValidationRule."
+    display_name: "minimum_blocking_behavior"
+    display_plural: "minimum_blocking_behaviors"
+    plural: "MinimumBlockingBehaviors"
+  }
+}
+
+property DeterminismClass.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value ValidationDeterminismClass.MapEnumValueType
+  IsValueRequired true
+  header {
+    description: "Determinism class for the ValidationRule implementation contract."
+    display_name: "determinism_class"
+    display_plural: "determinism_classes"
+    plural: "DeterminismClasses"
+  }
+}
+
+property SemanticAuthority.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value MapStringValueType.StringValueType
+  IsValueRequired false
+  header {
+    description: "Stable reference to the descriptor-semantics rule family or normative source that defines the ValidationRule meaning."
+    display_name: "semantic_authority"
+    display_plural: "semantic_authorities"
+    plural: "SemanticAuthorities"
+  }
+}
+
+property ValidationRuleDescription.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value MapStringValueType.StringValueType
+  IsValueRequired true
+  header {
+    description: "Human-readable ValidationRule description."
+    display_name: "validation_rule_description"
+    display_plural: "validation_rule_descriptions"
+    plural: "ValidationRuleDescriptions"
+  }
+}
+
+holon MetaValidationRule.MetaHolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends MetaHolonType.MetaTypeDescriptor
+  header {
+    description: "Meta-type describing ValidationRule family descriptor holons. It narrows local operator affordance to validation-rule descriptors."
+    display_name: "Meta Validation Rule"
+    display_plural: "Meta Validation Rules"
+    plural: "MetaValidationRules"
+  }
+  relationships {
+    InstanceRelationships -> [
+      (ValidationRule.HolonType)-[AffordsOperator]->(OperatorType.HolonType)
+    ]
+  }
+}
+
+abstract holon ValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends HolonType.TypeDescriptor
+  DefinesInstanceTypeKind true
+  header {
+    description: "Abstract root for first-class validation rule holons."
+    display_name: "Validation Rule"
+    display_plural: "Validation Rules"
+    plural: "ValidationRules"
+  }
+  relationships {
+    InstanceProperties -> [
+      ValidationLevel.PropertyType,
+      DefaultSeverity.PropertyType,
+      MinimumBlockingBehavior.PropertyType,
+      DeterminismClass.PropertyType,
+      SemanticAuthority.PropertyType,
+      ValidationRuleDescription.PropertyType
+    ]
+    // The loader currently resolves instance relationship declarations directly
+    // from this descriptor rather than through TypeDescriptor's inherited list.
+    // Reuse the Core declaration; this does not define a validation-owned
+    // ComponentOf relationship.
+    InstanceRelationships -> [
+      (TypeDescriptor)-[ComponentOf]->(Schema.HolonType)
+    ]
+    AffordsOperator -> [
+      Validate.OperatorType
+    ]
+  }
+}
+
+abstract holon HolonValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for rules evaluated over holons and their descriptor-level contracts."
+    display_name: "Holon Validation Rule"
+    display_plural: "Holon Validation Rules"
+    plural: "HolonValidationRules"
+  }
+}
+
+abstract holon PropertyValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for rules evaluated over property descriptors, required properties, and populated property members."
+    display_name: "Property Validation Rule"
+    display_plural: "Property Validation Rules"
+    plural: "PropertyValidationRules"
+  }
+}
+
+abstract holon ValueValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for rules evaluated over property values and their selected ValueType descriptors."
+    display_name: "Value Validation Rule"
+    display_plural: "Value Validation Rules"
+    plural: "ValueValidationRules"
+  }
+}
+
+abstract holon StringValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for string value rules."
+    display_name: "String Validation Rule"
+    display_plural: "String Validation Rules"
+    plural: "StringValidationRules"
+  }
+}
+
+abstract holon IntegerValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for integer value rules."
+    display_name: "Integer Validation Rule"
+    display_plural: "Integer Validation Rules"
+    plural: "IntegerValidationRules"
+  }
+}
+
+abstract holon BooleanValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for boolean value rules."
+    display_name: "Boolean Validation Rule"
+    display_plural: "Boolean Validation Rules"
+    plural: "BooleanValidationRules"
+  }
+}
+
+abstract holon EnumValueValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for enum value and enum variant membership rules."
+    display_name: "Enum Value Validation Rule"
+    display_plural: "Enum Value Validation Rules"
+    plural: "EnumValueValidationRules"
+  }
+}
+
+abstract holon BytesValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for bytes value rules."
+    display_name: "Bytes Validation Rule"
+    display_plural: "Bytes Validation Rules"
+    plural: "BytesValidationRules"
+  }
+}
+
+abstract holon ValueArrayValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValueValidationRule.HolonType
+  header {
+    description: "ValidationRule family for value-array and collection value rules."
+    display_name: "Value Array Validation Rule"
+    display_plural: "Value Array Validation Rules"
+    plural: "ValueArrayValidationRules"
+  }
+}
+
+abstract holon RelationshipValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for relationship descriptor and relationship occurrence rules."
+    display_name: "Relationship Validation Rule"
+    display_plural: "Relationship Validation Rules"
+    plural: "RelationshipValidationRules"
+  }
+}
+
+abstract holon TransactionValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for staged transaction rules."
+    display_name: "Transaction Validation Rule"
+    display_plural: "Transaction Validation Rules"
+    plural: "TransactionValidationRules"
+  }
+}
+
+abstract holon CommandValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for command invocation validation rules."
+    display_name: "Command Validation Rule"
+    display_plural: "Command Validation Rules"
+    plural: "CommandValidationRules"
+  }
+}
+
+abstract holon DanceValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for dance invocation validation rules."
+    display_name: "Dance Validation Rule"
+    display_plural: "Dance Validation Rules"
+    plural: "DanceValidationRules"
+  }
+}
+
+abstract holon AgreementValidationRule.HolonType {
+  type MetaValidationRule.MetaHolonType
+  extends ValidationRule.HolonType
+  header {
+    description: "ValidationRule family for agreement, trust, role, and policy validation rules."
+    display_name: "Agreement Validation Rule"
+    display_plural: "Agreement Validation Rules"
+    plural: "AgreementValidationRules"
+  }
+}
+
+holon Validate.OperatorType {
+  type MetaOperatorType.MetaHolonType
+  extends OperatorType.HolonType
+  Arity 1
+  OperatorCategory Equality
+  header {
+    description: "Local operator contract for evaluating a ValidationRule in a validation context. Initial execution is wrapper-based and does not require generic operator or Dance dispatch."
+    display_name: "Validate"
+    display_plural: "Validate Operators"
+    plural: "ValidateOperators"
+  }
+}
+
+def relationship (ValidationRule.HolonType)-[AffordsOperator]->(OperatorType.HolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    HasInverse -> AffordedBy
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source ValidationRule.HolonType
+  target OperatorType.HolonType
+  cardinality 0..*
+  deletion_semantic Block
+  header {
+    description: "Links a ValidationRule family descriptor to the local operator descriptors available for rules in that family."
+    display_name: "AffordsOperator Relationship"
+    display_plural: "AffordsOperator Relationships"
+    plural: "AffordsOperatorRelationships"
+  }
+}
+
+inverse relationship (OperatorType.HolonType)-[AffordedBy]->(ValidationRule.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source OperatorType.HolonType
+  target ValidationRule.HolonType
+  cardinality 0..*
+  deletion_semantic Block
+  header {
+    description: "Inverse of AffordsOperator for ValidationRule family descriptors."
+    display_name: "AffordedBy Relationship"
+    display_plural: "AffordedBy Relationships"
+    plural: "AffordedByRelationships"
+  }
+}
+
+holon ValidationBinding.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "A validation-owned commitment that applies one ValidationRule to one descriptor target."
+    display_name: "Validation Binding"
+    display_plural: "Validation Bindings"
+    plural: "ValidationBindings"
+  }
+  relationships {
+    InstanceRelationships -> [
+      (TypeDescriptor)-[ComponentOf]->(Schema.HolonType),
+      (ValidationBinding.HolonType)-[AppliesTo]->(TypeDescriptor),
+      (ValidationBinding.HolonType)-[UsesRule]->(ValidationRule.HolonType)
+    ]
+  }
+}
+
+def relationship (ValidationBinding.HolonType)-[AppliesTo]->(TypeDescriptor) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    HasInverse -> HasValidationBinding
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source ValidationBinding.HolonType
+  target TypeDescriptor
+  cardinality 1..1
+  deletion_semantic Block
+  header {
+    description: "Identifies the descriptor whose instances are subject to this validation commitment."
+    display_name: "Applies To"
+    display_plural: "Applies To"
+    plural: "AppliesTo"
+  }
+}
+
+inverse relationship (TypeDescriptor)-[HasValidationBinding]->(ValidationBinding.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source TypeDescriptor
+  target ValidationBinding.HolonType
+  cardinality 0..*
+  deletion_semantic Block
+  header {
+    description: "Inverse index from a descriptor to validation-owned commitments that apply to it."
+    display_name: "Has Validation Binding"
+    display_plural: "Has Validation Bindings"
+    plural: "HasValidationBindings"
+  }
+}
+
+def relationship (ValidationBinding.HolonType)-[UsesRule]->(ValidationRule.HolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    HasInverse -> UsedByValidationBinding
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source ValidationBinding.HolonType
+  target ValidationRule.HolonType
+  cardinality 1..1
+  deletion_semantic Block
+  header {
+    description: "Identifies the ValidationRule committed by this binding."
+    display_name: "Uses Rule"
+    display_plural: "Uses Rules"
+    plural: "UsesRules"
+  }
+}
+
+inverse relationship (ValidationRule.HolonType)-[UsedByValidationBinding]->(ValidationBinding.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source ValidationRule.HolonType
+  target ValidationBinding.HolonType
+  cardinality 0..*
+  deletion_semantic Block
+  header {
+    description: "Inverse index from a ValidationRule to validation bindings that commit it."
+    display_name: "Used By Validation Binding"
+    display_plural: "Used By Validation Bindings"
+    plural: "UsedByValidationBindings"
+  }
+}
+
+holon ValidationImplementation.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "Descriptor for holons that bind a ValidationRule to executable validation behavior. Dynamic implementation selection is deferred."
+    display_name: "Validation Implementation"
+    display_plural: "Validation Implementations"
+    plural: "ValidationImplementations"
+  }
+}
+
+holon ValidationRuleSet.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "Descriptor for named compositions of validation rules. Rule-set expansion is deferred until individual rule dispatch is stable."
+    display_name: "Validation Rule Set"
+    display_plural: "Validation Rule Sets"
+    plural: "ValidationRuleSets"
+  }
+}
+
+holon ValidationResult.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "Descriptor for durable validation result evidence. Persisted result policy is deferred."
+    display_name: "Validation Result"
+    display_plural: "Validation Results"
+    plural: "ValidationResults"
+  }
+}
+
+holon AtMostOneDirectParent.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-STRUCT-002"
+  ValidationRuleDescription "A holon has at most one direct Extends parent."
+}
+
+holon AcyclicExtendsLineage.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-STRUCT-003"
+  ValidationRuleDescription "A descriptor Extends lineage must be acyclic."
+}
+
+holon ExtendsLineageTerminatesAtTypeDescriptor.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-STRUCT-004"
+  ValidationRuleDescription "A parented descriptor lineage must terminate at TypeDescriptor."
+}
+
+holon UniqueTypeDescriptorRoot.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-STRUCT-005"
+  ValidationRuleDescription "TypeDescriptor is the unique root of the descriptor hierarchy."
+}
+
+holon SchemaDependenciesAcyclic.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-SCHEMA-001"
+  ValidationRuleDescription "Versioned schema dependency relationships must be acyclic."
+}
+
+holon CrossSchemaDependenciesDeclared.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-SCHEMA-002"
+  ValidationRuleDescription "Every cross-schema reference must have a direct schema dependency declaration."
+}
+
+holon CoreAccumulatorsAreAdditive.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-SCHEMA-003"
+  ValidationRuleDescription "Core contract, behavior, and operator accumulator relationships must declare Additive inheritance."
+}
+
+holon LocalInstanceKindAnchorDesignation.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KIND-001"
+  ValidationRuleDescription "Instance TypeKind anchor designation is local and singular."
+}
+
+holon InstanceKindAnchorsAreAbstract.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KIND-002"
+  ValidationRuleDescription "Every Instance TypeKind anchor must be abstract."
+}
+
+holon TypeDescriptorRootKindException.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KIND-003"
+  ValidationRuleDescription "TypeDescriptor is the only descriptor root that lacks an Instance TypeKind anchor."
+}
+
+holon DescribingCategoryCompatibility.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KIND-004"
+  ValidationRuleDescription "Every describing type must belong to the required describing category."
+}
+
+holon DescriptorMetaTypeCorrespondence.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KIND-005"
+  ValidationRuleDescription "Descriptor holons, and only descriptor holons, must use meta-type describers."
+}
+
+holon NoInheritedMemberRedeclaration.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONTRACT-001"
+  ValidationRuleDescription "A descriptor must not redundantly redeclare an inherited member."
+}
+
+holon UniqueSemanticMemberNames.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONTRACT-002"
+  ValidationRuleDescription "Effective semantic member names must be unique within each namespace."
+}
+
+holon WellFormedEffectiveMemberDefinitions.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONTRACT-003"
+  ValidationRuleDescription "Every effective member definition must be well formed."
+}
+
+holon ContractMemberKindCompatibility.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONTRACT-004"
+  ValidationRuleDescription "Every effective contract member must have the required instance kind."
+}
+
+holon InheritedValueConstraintNonRelaxation.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONSTRAINT-001"
+  ValidationRuleDescription "A ValueType subtype must not relax a value constraint inherited through its Extends lineage."
+}
+
+holon DefaultsRequireRequiredProperties.ValidationRule {
+  type PropertyValidationRule.HolonType
+  ValidationLevel Property
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-DEFAULT-001"
+  ValidationRuleDescription "Only required properties may declare defaults."
+}
+
+holon DefaultValueConformance.ValidationRule {
+  type PropertyValidationRule.HolonType
+  ValidationLevel Property
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-DEFAULT-002"
+  ValidationRuleDescription "Every declared default value must conform to its effective value definition."
+}
+
+holon InverseEndpointCorrespondence.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-REL-002"
+  ValidationRuleDescription "Inverse relationship endpoints must correspond to declared relationship endpoints."
+}
+
+holon DirectionalDeletionDeclarations.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-REL-003"
+  ValidationRuleDescription "Both relationship directions must declare valid deletion semantics."
+}
+
+holon EffectiveKeyRuleSelection.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KEY-001"
+  ValidationRuleDescription "Every holon type must resolve exactly one effective instance key rule."
+}
+
+holon KeyRuleTargetCompatibility.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KEY-002"
+  ValidationRuleDescription "The selected key rule target must be compatible with and executable for the descriptor."
+}
+
+holon ExplicitKeylessBaseline.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KEY-003"
+  ValidationRuleDescription "The keyless root must be explicit and key-rule inheritance must use Override semantics."
+}
+
+holon EnumMemberNamesUnique.ValidationRule {
+  type EnumValueValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-ENUM-001"
+  ValidationRuleDescription "Enum member names must be unique within each effective enum definition."
+}
+
+holon AbstractMemberMinimumEnforcement.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONFORM-002"
+  ValidationRuleDescription "Minimum enforcement for abstract descriptors is member-specific."
+}
+
+holon UniquePropertyMemberBinding.ValidationRule {
+  type PropertyValidationRule.HolonType
+  ValidationLevel Property
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-BIND-001"
+  ValidationRuleDescription "Every declared property name must bind uniquely to a property descriptor admitted by the effective contract."
+}
+
+holon RelationshipOccurrenceGrouping.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-OCC-001"
+  ValidationRuleDescription "Relationship occurrences must be grouped by resolved relationship descriptor identity."
+}
+
+holon AdditionalRelationshipPolicy.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-OCC-004"
+  ValidationRuleDescription "Every unbound relationship must be permitted by the effective additional-relationship policy."
+}
+
+holon ExplicitKeylessness.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KEY-004"
+  ValidationRuleDescription "A keyless holon must carry no semantic key."
+}
+
+holon KeyPresenceAndValue.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-KEY-005"
+  ValidationRuleDescription "A keyed new holon must carry exactly the computed semantic key."
+}
+
+holon ExactlyOneDescribedBy.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-STRUCT-001"
+  ValidationRuleDescription "A holon must have exactly one describing descriptor before descriptor-aware validation can continue."
+}
+
+holon ConcreteDescribingType.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-CONFORM-001"
+  ValidationRuleDescription "A runtime holon must be described by a concrete descriptor that can describe instances."
+}
+
+holon NoUndescribedProperties.ValidationRule {
+  type HolonValidationRule.HolonType
+  ValidationLevel Holon
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-PROP-003"
+  ValidationRuleDescription "Every unbound property must be permitted by the effective additional-property policy."
+}
+
+holon RequiredPropertyPresence.ValidationRule {
+  type PropertyValidationRule.HolonType
+  ValidationLevel Property
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-PROP-001"
+  ValidationRuleDescription "A property declared required by the effective descriptor contract must be present."
+}
+
+holon PropertyValueConformance.ValidationRule {
+  type PropertyValidationRule.HolonType
+  ValidationLevel Property
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-PROP-002"
+  ValidationRuleDescription "A populated property value must conform to the selected ValueType descriptor."
+}
+
+holon BaseValueKindMatchesString.ValidationRule {
+  type StringValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Built-in value-dispatch rule"
+  ValidationRuleDescription "A value governed by a StringValueType descriptor must use the string BaseValue representation."
+}
+
+holon StringLength.ValidationRule {
+  type StringValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "String constraint semantics; Unicode extended grapheme cluster counting"
+  ValidationRuleDescription "A string value must satisfy the min and max length constraints declared by its StringValueType descriptor."
+}
+
+holon BaseValueKindMatchesInteger.ValidationRule {
+  type IntegerValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Built-in value-dispatch rule"
+  ValidationRuleDescription "A value governed by an IntegerValueType descriptor must use the integer BaseValue representation."
+}
+
+holon IntegerRange.ValidationRule {
+  type IntegerValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Integer constraint semantics"
+  ValidationRuleDescription "An integer value must satisfy the min and max constraints declared by its IntegerValueType descriptor."
+}
+
+holon BaseValueKindMatchesBoolean.ValidationRule {
+  type BooleanValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Built-in value-dispatch rule"
+  ValidationRuleDescription "A value governed by a BooleanValueType descriptor must use the boolean BaseValue representation."
+}
+
+holon BaseValueKindMatchesEnum.ValidationRule {
+  type EnumValueValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Built-in value-dispatch rule"
+  ValidationRuleDescription "A value governed by an EnumValueType descriptor must use the enum BaseValue representation."
+}
+
+holon EnumTokenMembership.ValidationRule {
+  type EnumValueValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-ENUM-002"
+  ValidationRuleDescription "An enum value token must match one of the effective enum variants admitted by the EnumValueType descriptor."
+}
+
+holon EnumTokenNonRetroactivity.ValidationRule {
+  type EnumValueValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Contextual
+  SemanticAuthority "DS-ENUM-003"
+  ValidationRuleDescription "Enum token changes must never rewrite or alias persisted enum values."
+}
+
+holon BaseValueKindMatchesBytes.ValidationRule {
+  type BytesValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Built-in value-dispatch rule"
+  ValidationRuleDescription "A value governed by a BytesValueType descriptor must use the bytes BaseValue representation."
+}
+
+holon BytesLength.ValidationRule {
+  type BytesValidationRule.HolonType
+  ValidationLevel Value
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "Bytes constraint semantics"
+  ValidationRuleDescription "A bytes value must satisfy the min and max length constraints declared by its BytesValueType descriptor."
+}
+
+holon RelationshipOccurrenceBinding.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-BIND-002"
+  ValidationRuleDescription "A populated relationship name must bind uniquely to a relationship descriptor admitted by the effective contract."
+}
+
+holon RelationshipEndpointCompatibility.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-OCC-002"
+  ValidationRuleDescription "A relationship occurrence endpoint must be compatible with the effective source and target descriptors."
+}
+
+holon RelationshipCollectionPolicy.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-OCC-003"
+  ValidationRuleDescription "A relationship occurrence collection must honor ordering and duplicate policies declared by the relationship descriptor."
+}
+
+holon RelationshipCardinality.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Contextual
+  SemanticAuthority "DS-CARD-001"
+  ValidationRuleDescription "A relationship occurrence set must satisfy descriptor cardinality where the validation context supplies the required transaction or graph snapshot."
+}
+
+holon RelationshipDescriptorPairing.ValidationRule {
+  type RelationshipValidationRule.HolonType
+  ValidationLevel Relationship
+  DefaultSeverity Error
+  MinimumBlockingBehavior CommitBlocking
+  DeterminismClass Deterministic
+  SemanticAuthority "DS-REL-001"
+  ValidationRuleDescription "Declared and inverse relationship descriptor pairing must be bijective."
+}
+
+holon TypeDescriptorAtMostOneDirectParent.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> AtMostOneDirectParent.ValidationRule
+  }
+}
+
+holon TypeDescriptorAcyclicExtendsLineage.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> AcyclicExtendsLineage.ValidationRule
+  }
+}
+
+holon TypeDescriptorExtendsLineageTerminates.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> ExtendsLineageTerminatesAtTypeDescriptor.ValidationRule
+  }
+}
+
+holon TypeDescriptorUniqueRoot.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> UniqueTypeDescriptorRoot.ValidationRule
+  }
+}
+
+holon TypeDescriptorSchemaDependenciesAcyclic.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> SchemaDependenciesAcyclic.ValidationRule
+  }
+}
+
+holon TypeDescriptorCrossSchemaDependenciesDeclared.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> CrossSchemaDependenciesDeclared.ValidationRule
+  }
+}
+
+holon TypeDescriptorCoreAccumulatorsAdditive.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> CoreAccumulatorsAreAdditive.ValidationRule
+  }
+}
+
+holon TypeDescriptorLocalInstanceKindAnchor.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> LocalInstanceKindAnchorDesignation.ValidationRule
+  }
+}
+
+holon TypeDescriptorInstanceKindAnchorAbstract.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> InstanceKindAnchorsAreAbstract.ValidationRule
+  }
+}
+
+holon TypeDescriptorRootKindException.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> TypeDescriptorRootKindException.ValidationRule
+  }
+}
+
+holon TypeDescriptorDescribingCategoryCompatibility.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> DescribingCategoryCompatibility.ValidationRule
+  }
+}
+
+holon TypeDescriptorMetaTypeCorrespondence.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> DescriptorMetaTypeCorrespondence.ValidationRule
+  }
+}
+
+holon TypeDescriptorNoInheritedMemberRedeclaration.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> NoInheritedMemberRedeclaration.ValidationRule
+  }
+}
+
+holon TypeDescriptorUniqueSemanticMemberNames.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> UniqueSemanticMemberNames.ValidationRule
+  }
+}
+
+holon TypeDescriptorWellFormedEffectiveMembers.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> WellFormedEffectiveMemberDefinitions.ValidationRule
+  }
+}
+
+holon TypeDescriptorContractMemberKindCompatibility.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> TypeDescriptor
+    UsesRule -> ContractMemberKindCompatibility.ValidationRule
+  }
+}
+
+holon HolonTypeExactlyOneDescribedBy.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> ExactlyOneDescribedBy.ValidationRule
+  }
+}
+
+holon HolonTypeConcreteDescribingType.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> ConcreteDescribingType.ValidationRule
+  }
+}
+
+holon HolonTypeNoUndescribedProperties.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> NoUndescribedProperties.ValidationRule
+  }
+}
+
+holon HolonTypeAbstractMemberMinimum.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> AbstractMemberMinimumEnforcement.ValidationRule
+  }
+}
+
+holon HolonTypeEffectiveKeyRuleSelection.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> EffectiveKeyRuleSelection.ValidationRule
+  }
+}
+
+holon HolonTypeKeyRuleTargetCompatibility.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> KeyRuleTargetCompatibility.ValidationRule
+  }
+}
+
+holon HolonTypeExplicitKeylessBaseline.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> ExplicitKeylessBaseline.ValidationRule
+  }
+}
+
+holon HolonTypeExplicitKeylessness.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> ExplicitKeylessness.ValidationRule
+  }
+}
+
+holon HolonTypeKeyPresenceAndValue.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> HolonType.TypeDescriptor
+    UsesRule -> KeyPresenceAndValue.ValidationRule
+  }
+}
+
+holon ValueTypeInheritedConstraintNonRelaxation.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> ValueType.TypeDescriptor
+    UsesRule -> InheritedValueConstraintNonRelaxation.ValidationRule
+  }
+}
+
+holon PropertyTypeDefaultsRequireRequiredProperties.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> PropertyType.TypeDescriptor
+    UsesRule -> DefaultsRequireRequiredProperties.ValidationRule
+  }
+}
+
+holon PropertyTypeDefaultValueConformance.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> PropertyType.TypeDescriptor
+    UsesRule -> DefaultValueConformance.ValidationRule
+  }
+}
+
+holon PropertyTypeUniquePropertyMemberBinding.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> PropertyType.TypeDescriptor
+    UsesRule -> UniquePropertyMemberBinding.ValidationRule
+  }
+}
+
+holon PropertyTypeRequiredPropertyPresence.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> PropertyType.TypeDescriptor
+    UsesRule -> RequiredPropertyPresence.ValidationRule
+  }
+}
+
+holon PropertyTypePropertyValueConformance.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> PropertyType.TypeDescriptor
+    UsesRule -> PropertyValueConformance.ValidationRule
+  }
+}
+
+holon StringValueTypeBaseValueKind.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> StringValueType.ValueType
+    UsesRule -> BaseValueKindMatchesString.ValidationRule
+  }
+}
+
+holon StringValueTypeLength.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> StringValueType.ValueType
+    UsesRule -> StringLength.ValidationRule
+  }
+}
+
+holon IntegerValueTypeBaseValueKind.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> IntegerValueType.ValueType
+    UsesRule -> BaseValueKindMatchesInteger.ValidationRule
+  }
+}
+
+holon IntegerValueTypeRange.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> IntegerValueType.ValueType
+    UsesRule -> IntegerRange.ValidationRule
+  }
+}
+
+holon BooleanValueTypeBaseValueKind.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> BooleanValueType.ValueType
+    UsesRule -> BaseValueKindMatchesBoolean.ValidationRule
+  }
+}
+
+holon EnumValueTypeMemberNamesUnique.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> EnumValueType.ValueType
+    UsesRule -> EnumMemberNamesUnique.ValidationRule
+  }
+}
+
+holon EnumValueTypeBaseValueKind.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> EnumValueType.ValueType
+    UsesRule -> BaseValueKindMatchesEnum.ValidationRule
+  }
+}
+
+holon EnumValueTypeTokenMembership.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> EnumValueType.ValueType
+    UsesRule -> EnumTokenMembership.ValidationRule
+  }
+}
+
+holon EnumValueTypeTokenNonRetroactivity.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> EnumValueType.ValueType
+    UsesRule -> EnumTokenNonRetroactivity.ValidationRule
+  }
+}
+
+holon BytesValueTypeBaseValueKind.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> BytesValueType.ValueType
+    UsesRule -> BaseValueKindMatchesBytes.ValidationRule
+  }
+}
+
+holon BytesValueTypeLength.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> BytesValueType.ValueType
+    UsesRule -> BytesLength.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeOccurrenceBinding.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipOccurrenceBinding.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeOccurrenceGrouping.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipOccurrenceGrouping.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeEndpointCompatibility.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipEndpointCompatibility.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeCollectionPolicy.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipCollectionPolicy.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeAdditionalPolicy.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> AdditionalRelationshipPolicy.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeCardinality.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipCardinality.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeDescriptorPairing.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> RelationshipDescriptorPairing.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeInverseEndpointCorrespondence.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> InverseEndpointCorrespondence.ValidationRule
+  }
+}
+
+holon DeclaredRelationshipTypeDirectionalDeletion.ValidationBinding {
+  type ValidationBinding.HolonType
+  relationships {
+    AppliesTo -> DeclaredRelationshipType.RelationshipType
+    UsesRule -> DirectionalDeletionDeclarations.ValidationRule
+  }
+}

--- a/tests/sweetests/src/harness/helpers/core_schema.rs
+++ b/tests/sweetests/src/harness/helpers/core_schema.rs
@@ -22,6 +22,8 @@ const GENERATED_CORE_SCHEMA_FILENAMES: [&str; 12] = [
     "MAP Schema Types-map-core-schema-value-constraint-types.json",
 ];
 
+const GENERATED_VALIDATION_SCHEMA_FILENAME: &str = "map-validation-schema.json";
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct CoreSchemaLoadMetrics {
     pub staged: i64,
@@ -85,6 +87,20 @@ pub fn build_generated_core_schema_content_set() -> Result<ContentSet, HolonErro
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(ContentSet { schema, files_to_load })
+}
+
+/// Builds the checked-in validation package artifact. Callers must have
+/// loaded the generated Core schema in an earlier completed transaction.
+pub fn build_generated_validation_schema_content_set() -> Result<ContentSet, HolonError> {
+    let schema_path = PathBuf::from(BOOTSTRAP_IMPORT_VALIDATION_SCHEMA_PATH);
+    let schema = read_file_data(&schema_path, "validation schema")?;
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+    let validation_schema_path =
+        repo_root.join("generated/json-imports").join(GENERATED_VALIDATION_SCHEMA_FILENAME);
+    let files_to_load =
+        vec![read_file_data(&validation_schema_path, "generated validation schema import")?];
 
     Ok(ContentSet { schema, files_to_load })
 }

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -174,6 +174,17 @@ impl DancesTestCase {
         Ok(())
     }
 
+    pub fn add_load_generated_validation_schema_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description = description
+            .unwrap_or_else(|| "Load generated validation Schema JSON after Core".to_string());
+        self.steps.push(DanceTestStep::LoadGeneratedValidationSchema { description });
+        Ok(())
+    }
+
     pub fn add_load_book_person_inverse_test_schema_step(
         &mut self,
         description: Option<String>,

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -103,6 +103,9 @@ pub enum DanceTestStep {
     LoadGeneratedCoreSchema {
         description: String,
     },
+    LoadGeneratedValidationSchema {
+        description: String,
+    },
     LoadBookPersonInverseTestSchema {
         description: String,
     },
@@ -255,6 +258,9 @@ impl core::fmt::Display for DanceTestStep {
                 write!(f, "{description}")
             }
             DanceTestStep::LoadGeneratedCoreSchema { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::LoadGeneratedValidationSchema { description } => {
                 write!(f, "{description}")
             }
             DanceTestStep::LoadBookPersonInverseTestSchema { description } => {

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -46,6 +46,7 @@ use execution_steps::load_book_person_inverse_test_schema_executor::execute_load
 use execution_steps::load_book_person_inverse_test_schema_executor::execute_load_inverse_oriented_book_person_instances_expect_failure;
 use execution_steps::load_core_schema_executor::{
     execute_load_core_schema, execute_load_generated_core_schema,
+    execute_load_generated_validation_schema,
 };
 use execution_steps::load_holons_internal_executor::execute_load_holons_internal;
 use execution_steps::lookup_saved_holon_executor::execute_lookup_saved_holon_by_key;
@@ -66,6 +67,7 @@ use fixture_cases::ergonomic_add_remove_related_holons_fixture::*;
 use fixture_cases::load_book_person_inverse_schema_fixture::*;
 use fixture_cases::load_core_schema_fixture::*;
 use fixture_cases::load_generated_core_schema_fixture::*;
+use fixture_cases::load_generated_validation_schema_fixture::*;
 use fixture_cases::load_holons_internal_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
@@ -118,6 +120,7 @@ use holons_prelude::prelude::*;
 #[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
 #[case::load_core_schema_test(load_core_schema_fixture())]
 #[case::load_generated_core_schema_test(load_generated_core_schema_fixture())]
+#[case::load_generated_validation_schema_test(load_generated_validation_schema_fixture())]
 #[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
 #[case::frozen_member_head_redirect_test(frozen_member_head_redirect_fixture())]
 #[case::frozen_member_head_redirect_cross_tx_test(frozen_member_head_redirect_cross_tx_fixture())]
@@ -235,6 +238,9 @@ async fn run_dance_test_case(mut test_case: DancesTestCase) {
             }
             DanceTestStep::LoadGeneratedCoreSchema { .. } => {
                 execute_load_generated_core_schema(&mut test_execution_state).await
+            }
+            DanceTestStep::LoadGeneratedValidationSchema { .. } => {
+                execute_load_generated_validation_schema(&mut test_execution_state).await
             }
             DanceTestStep::LoadBookPersonInverseTestSchema { .. } => {
                 execute_load_book_person_inverse_test_schema(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/load_core_schema_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_core_schema_executor.rs
@@ -1,12 +1,15 @@
 use holons_prelude::prelude::*;
 
 use holons_test::harness::helpers::{
-    build_core_schema_content_set, build_generated_core_schema_content_set, CORE_SCHEMA_METRICS,
+    build_core_schema_content_set, build_generated_core_schema_content_set,
+    build_generated_validation_schema_content_set, CORE_SCHEMA_METRICS,
     GENERATED_CORE_SCHEMA_METRICS,
 };
 use holons_test::TestExecutionState;
 
-use super::load_holons_client_executor::execute_load_holons_client;
+use super::load_holons_client_executor::{
+    execute_load_holons_client, execute_load_holons_client_expect_success,
+};
 
 pub async fn execute_load_core_schema(test_state: &mut TestExecutionState) {
     let content_set = build_core_schema_content_set()
@@ -24,6 +27,15 @@ pub async fn execute_load_core_schema(test_state: &mut TestExecutionState) {
         CORE_SCHEMA_METRICS.commit_status,
     )
     .await;
+}
+
+/// Loads the validation-owned generated package after Core has committed.
+pub async fn execute_load_generated_validation_schema(test_state: &mut TestExecutionState) {
+    let content_set = build_generated_validation_schema_content_set().unwrap_or_else(|error| {
+        panic!("failed to build generated validation schema ContentSet: {error:?}")
+    });
+
+    execute_load_holons_client_expect_success(test_state, content_set, 155, 1).await;
 }
 
 /// Loads the checked-in Schema 2.0 compiler artifact. Metrics are recorded by

--- a/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_holons_client_executor.rs
@@ -154,6 +154,62 @@ pub async fn execute_load_holons_client(
     }
 }
 
+/// Execute a successful package load where the topology is the assertion. The
+/// validation package has a fixed holon count, while its link count is an
+/// implementation detail of generated descriptor relationships; requiring it
+/// to be positive catches a relationship-free import without fossilizing that
+/// internal count.
+pub async fn execute_load_holons_client_expect_success(
+    test_state: &mut TestExecutionState,
+    content_set: ContentSet,
+    expected_holons: i64,
+    expected_bundles: i64,
+) {
+    let context = test_state.context();
+    let command = MapCommand::Transaction(TransactionCommand {
+        context: context.clone(),
+        action: TransactionAction::LoadHolons { content_set },
+    });
+    let result = test_state
+        .dispatch_command(command, "load_holons_client_expect_success")
+        .await
+        .unwrap_or_else(|error| panic!("load_holons_client_expect_success failed: {error:?}"));
+
+    let response_reference = match result {
+        MapResult::Reference(HolonReference::Transient(reference)) => reference,
+        other => panic!("LoadHolons: expected Reference(Transient), got {other:?}"),
+    };
+
+    let staged = read_int_property(&response_reference, CorePropertyTypeName::HolonsStaged);
+    let committed = read_int_property(&response_reference, CorePropertyTypeName::HolonsCommitted);
+    let links_created = read_int_property(&response_reference, CorePropertyTypeName::LinksCreated);
+    let errors = read_int_property(&response_reference, CorePropertyTypeName::ErrorCount);
+    let total_bundles = read_int_property(&response_reference, CorePropertyTypeName::TotalBundles);
+    let total_loader_holons =
+        read_int_property(&response_reference, CorePropertyTypeName::TotalLoaderHolons);
+    let commit_status =
+        read_string_property(&response_reference, CorePropertyTypeName::LoadCommitStatus);
+
+    if errors != 0 {
+        panic!(
+            "validation package import reported {errors} errors.{}{}",
+            dump_full_response(&response_reference),
+            dump_error_holons_from_response(&response_reference),
+        );
+    }
+
+    assert_eq!(staged, expected_holons, "unexpected staged holon count");
+    assert_eq!(committed, expected_holons, "unexpected committed holon count");
+    assert!(links_created > 0, "validation package must create relationships");
+    assert_eq!(total_bundles, expected_bundles, "unexpected content bundle count");
+    assert_eq!(total_loader_holons, expected_holons, "unexpected loader holon count");
+    assert_eq!(
+        commit_status,
+        ExpectedLoadStatus::Complete.to_string(),
+        "validation package load must complete"
+    );
+}
+
 pub async fn execute_load_holons_client_expect_failure(
     test_state: &mut TestExecutionState,
     content_set: ContentSet,

--- a/tests/sweetests/tests/fixture_cases/load_generated_validation_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_generated_validation_schema_fixture.rs
@@ -1,0 +1,16 @@
+use holons_prelude::prelude::*;
+use holons_test::{DancesTestCase, TestCaseInit};
+
+/// Acceptance fixture proving that validation-owned bindings resolve against
+/// already committed Core descriptors without changing Core's package boundary.
+pub fn load_generated_validation_schema_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, fixture_holons, .. } = TestCaseInit::new(
+        "load_generated_validation_schema",
+        "Load Core, then the generated validation package in a separate transaction",
+    );
+    test_case.add_load_generated_core_schema_step(None)?;
+    test_case.add_begin_transaction_step(None, None)?;
+    test_case.add_load_generated_validation_schema_step(None)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+    Ok(test_case)
+}

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -5,6 +5,7 @@ pub mod ergonomic_add_remove_related_holons_fixture;
 pub mod load_book_person_inverse_schema_fixture;
 pub mod load_core_schema_fixture;
 pub mod load_generated_core_schema_fixture;
+pub mod load_generated_validation_schema_fixture;
 pub mod load_holons_internal_fixture;
 pub mod load_inverse_oriented_book_person_instances_fixture;
 pub mod setup_book_and_authors_fixture;


### PR DESCRIPTION
# Summary

Implements #628: deliver the loader-ready MAP Validation Schema as canonical TDL and generated JSON.

Validation applicability is now validation-owned:

    ValidationBinding -[AppliesTo]-> TypeDescriptor
    ValidationBinding -[UsesRule]-> ValidationRule

This preserves Core ownership of Core descriptors while making rule applicability explicit and traversable.

## Changes

- Adds `schema-src/map-validation-schema.tdl` as the canonical Validation Schema source.
- Adds generated `map-validation-schema.json` under `generated/json-imports`.
- Replaces descriptor-owned `Validations` attachments with `ValidationBinding`, `AppliesTo`, `UsesRule`, and inverse relationships.
- Seeds 51 bindings and distinct rules for all 43 stable `DS-*` semantic authorities, including `DS-CONSTRAINT-001`.
- Ensures validation rule and binding descriptor roots expose Core `ComponentOf` through `InstanceRelationships`, allowing the package to load after Core.
- Adds Sweettest coverage that loads generated Core, begins a new transaction, then loads the generated Validation Schema.
- Adds clearer loader-response diagnostics for package-import failures.

## Validation

- `npm run map-schema:check -- schema-src`
- `npm test`
- Sweettest validation package import: 155 holons staged and committed, zero errors.
- Holon Data Validator & Uploader path previously confirmed clean package loading with zero errors and `Complete` status.
- Pre-push formatting checks passed.

## Notes

This PR delivers the Validation Schema corpus and loader-ready package boundary. It does not implement descriptor-aware runtime validation, `ValidationRule` wrapper dispatch, or `Validate` execution; those remain later Validation-track work.