### PR TITLE
642 Storage SL5b allholonNodes fix

### DIFF
--- a/generated/json-imports/commands/schema.json
+++ b/generated/json-imports/commands/schema.json
@@ -896,7 +896,7 @@
         "TypeNamePlural": "GetAllHolonsCommands",
         "DisplayName": "Get All Holons Command",
         "DisplayNamePlural": "Get All Holons Commands",
-        "Description": "Returns all holons visible in the active transaction."
+        "Description": "Returns the holons owned by the active transaction's holon space."
       },
       "relationships": [
         {

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -436,7 +436,6 @@ fn commit_holon(
             StagedState::ForCreate => {
                 trace!("StagedState::ForCreate — publishing a new HolonNode lineage");
                 staged_holon.prepare_full_relationship_commit_scope()?;
-                stage_space_membership(staged_holon, context)?;
                 let stored = persist_holon(HolonWriteRequest::PublishRoot {
                     holon_node: staged_holon.into_node_model(),
                 })?;
@@ -446,7 +445,10 @@ fn commit_holon(
                     short_hex(&stored.version_metadata.version_id, 8)
                 );
 
-                staged_holon.to_committed(stored.version_metadata.version_id)?;
+                let new_local_id = stored.version_metadata.version_id;
+                persist_space_membership(context, &new_local_id, staged_holon.key())?;
+
+                staged_holon.to_committed(new_local_id)?;
                 Ok(CommitOutcome::Saved)
             }
 
@@ -468,10 +470,7 @@ fn commit_holon(
             StagedState::ForUpdateNewVersion => {
                 trace!("StagedState::ForUpdateNewVersion — publishing the next HolonNode version");
                 let predecessor_id = staged_holon.get_versioned_source_id()?;
-                // Full replay, except space membership: the lineage already belongs to the
-                // space, and re-emitting `OwnedBy` here would make the space `Owns` both the
-                // lineage root and every version published after it.
-                staged_holon.prepare_new_version_relationship_commit_scope()?;
+                staged_holon.prepare_full_relationship_commit_scope()?;
                 // Storage decides how a version is written: it resolves the lineage this
                 // predecessor belongs to and roots the new version there. Immediate-predecessor
                 // ordering is not carried by the node — it is staged below as a SmartLink.
@@ -526,57 +525,57 @@ fn commit_holon(
     }
 }
 
-/// Stamps `OwnedBy → current HolonSpace` on a lineage-creating commit.
+/// Records `Holon ─OwnedBy→ HolonSpace` and its `Owns` inverse for a newly published lineage.
 ///
-/// Space membership is infrastructure-supplied, and this is the one place it can be supplied
-/// reliably. Staging can happen in a client transaction that has not yet been told which space
-/// it is bound to, whereas by the time a commit reaches the guest the local space anchor has
-/// always been resolved. Stamping here also keeps membership and publication together — the same
-/// coupling the global index it replaces got from being written during `PublishRoot`.
+/// Written here, in the node pass, rather than staged for the relationship pass. Membership is
+/// what whole-space discovery reads, so it has to hold whenever the node itself was published —
+/// and the relationship pass is skipped entirely when *any* staged holon fails to publish, which
+/// would otherwise leave the holons that did publish permanently undiscoverable. Authoring it
+/// beside `persist_holon` gives membership the same coupling to publication that
+/// `index_under_all_holon_nodes` had.
 ///
-/// Only lineage-creating commits stamp: a new version inherits the membership its lineage root
-/// already holds, and re-emitting it would make the space own every version separately.
+/// Only lineage-creating commits call this. A new version inherits the membership its lineage
+/// root already holds; re-emitting it would make the space own the root and every version after
+/// it separately.
 ///
-/// Idempotent, so a lineage that was already stamped upstream keeps its existing owner.
-fn stage_space_membership(
-    staged_holon: &mut StagedHolon,
+/// Both writes are idempotent (`put_smartlink` reports `AlreadyPresent`), so re-publishing a
+/// lineage that is already a member is a no-op.
+fn persist_space_membership(
     context: &Arc<TransactionContext>,
+    source_id: &LocalId,
+    source_key: Option<MapString>,
 ) -> Result<(), HolonError> {
-    let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
-
-    let already_owned = {
-        let collection_rc = staged_holon.get_staged_relationship(&owned_by)?;
-        let collection = collection_rc.read().map_err(|e| {
-            HolonError::FailedToAcquireLock(format!(
-                "Failed to acquire read lock on staged OwnedBy collection: {}",
-                e
-            ))
-        })?;
-        !collection.get_members().is_empty()
-    };
-    if already_owned {
-        return Ok(());
-    }
-
     // No space means nothing to belong to. Reachable only while the local space anchor is itself
-    // being established, which is the one lineage that must not be a member of its own space.
+    // being established — the one lineage that must not be a member of its own space.
     let Some(space_reference) = context.get_space_holon()? else {
         return Ok(());
     };
 
-    let space_key = space_reference.key()?.ok_or_else(|| {
-        HolonError::EmptyField("HolonSpace holon has no key; cannot record membership".to_string())
+    // Membership in a non-local space would need cross-space inverse propagation, which belongs
+    // at the outbound-proxy seam rather than here (the same boundary `require_local_target` draws).
+    let HolonId::Local(space_id) = space_reference.holon_id()? else {
+        return Ok(());
+    };
+
+    persist_smartlink(PreparedSmartLink {
+        source_id: source_id.clone(),
+        target_id: HolonId::Local(space_id.clone()),
+        relationship_name: CoreRelationshipTypeName::OwnedBy.as_relationship_name(),
+        canonical_key: canonical_key_from_optional_key(space_reference.key()?)?,
+        occurrence_id: None,
+        relationship_property_values: PropertyMap::new(),
+        target_property_cache_candidates: Vec::new(),
     })?;
 
-    // Carry the key on the reference: relationship commit fail-fasts on a target whose key
-    // cannot be resolved, and this answers it without re-fetching the space per staged holon.
-    let space_target = HolonReference::smart_with_key(
-        TransactionContextHandle::new(Arc::clone(context)),
-        space_reference.holon_id()?,
-        space_key.clone(),
-    );
-
-    staged_holon.add_related_holons_with_keys(owned_by, vec![(space_target, Some(space_key))])?;
+    persist_smartlink(PreparedSmartLink {
+        source_id: space_id,
+        target_id: HolonId::Local(source_id.clone()),
+        relationship_name: CoreRelationshipTypeName::Owns.as_relationship_name(),
+        canonical_key: canonical_key_from_optional_key(source_key)?,
+        occurrence_id: None,
+        relationship_property_values: PropertyMap::new(),
+        target_property_cache_candidates: Vec::new(),
+    })?;
 
     Ok(())
 }

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -436,6 +436,7 @@ fn commit_holon(
             StagedState::ForCreate => {
                 trace!("StagedState::ForCreate — publishing a new HolonNode lineage");
                 staged_holon.prepare_full_relationship_commit_scope()?;
+                stage_space_membership(staged_holon, context)?;
                 let stored = persist_holon(HolonWriteRequest::PublishRoot {
                     holon_node: staged_holon.into_node_model(),
                 })?;
@@ -467,7 +468,10 @@ fn commit_holon(
             StagedState::ForUpdateNewVersion => {
                 trace!("StagedState::ForUpdateNewVersion — publishing the next HolonNode version");
                 let predecessor_id = staged_holon.get_versioned_source_id()?;
-                staged_holon.prepare_full_relationship_commit_scope()?;
+                // Full replay, except space membership: the lineage already belongs to the
+                // space, and re-emitting `OwnedBy` here would make the space `Owns` both the
+                // lineage root and every version published after it.
+                staged_holon.prepare_new_version_relationship_commit_scope()?;
                 // Storage decides how a version is written: it resolves the lineage this
                 // predecessor belongs to and roots the new version there. Immediate-predecessor
                 // ordering is not carried by the node — it is staged below as a SmartLink.
@@ -520,6 +524,61 @@ fn commit_holon(
             holon_write
         )))
     }
+}
+
+/// Stamps `OwnedBy → current HolonSpace` on a lineage-creating commit.
+///
+/// Space membership is infrastructure-supplied, and this is the one place it can be supplied
+/// reliably. Staging can happen in a client transaction that has not yet been told which space
+/// it is bound to, whereas by the time a commit reaches the guest the local space anchor has
+/// always been resolved. Stamping here also keeps membership and publication together — the same
+/// coupling the global index it replaces got from being written during `PublishRoot`.
+///
+/// Only lineage-creating commits stamp: a new version inherits the membership its lineage root
+/// already holds, and re-emitting it would make the space own every version separately.
+///
+/// Idempotent, so a lineage that was already stamped upstream keeps its existing owner.
+fn stage_space_membership(
+    staged_holon: &mut StagedHolon,
+    context: &Arc<TransactionContext>,
+) -> Result<(), HolonError> {
+    let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+
+    let already_owned = {
+        let collection_rc = staged_holon.get_staged_relationship(&owned_by)?;
+        let collection = collection_rc.read().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire read lock on staged OwnedBy collection: {}",
+                e
+            ))
+        })?;
+        !collection.get_members().is_empty()
+    };
+    if already_owned {
+        return Ok(());
+    }
+
+    // No space means nothing to belong to. Reachable only while the local space anchor is itself
+    // being established, which is the one lineage that must not be a member of its own space.
+    let Some(space_reference) = context.get_space_holon()? else {
+        return Ok(());
+    };
+
+    let space_key = space_reference.key()?.ok_or_else(|| {
+        HolonError::EmptyField("HolonSpace holon has no key; cannot record membership".to_string())
+    })?;
+
+    // Carry the key on the reference: relationship commit fail-fasts on a target whose key
+    // cannot be resolved, and this answers it without re-fetching the space per staged holon.
+    let space_target = HolonReference::smart_with_key(
+        TransactionContextHandle::new(Arc::clone(context)),
+        space_reference.holon_id()?,
+        space_key.clone(),
+    );
+
+    staged_holon.add_related_holons_with_keys(owned_by, vec![(space_target, Some(space_key))])?;
+
+    Ok(())
 }
 
 fn stage_predecessor_relationship(

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -545,9 +545,16 @@ fn persist_space_membership(
     source_id: &LocalId,
     source_key: Option<MapString>,
 ) -> Result<(), HolonError> {
-    // No space means nothing to belong to. Reachable only while the local space anchor is itself
-    // being established — the one lineage that must not be a member of its own space.
+    // Every guest dance context is anchored to a persisted space before its body runs
+    // (`dance_adapter::init_guest_context` calls `ensure_local_holon_space`), and the anchor itself
+    // never reaches commit, so this branch should be unreachable. Skipping quietly would leave a
+    // published holon permanently undiscoverable with nothing to show for it, so say so.
     let Some(space_reference) = context.get_space_holon()? else {
+        warn!(
+            "No space holon bound to this transaction; {} was published without space membership \
+             and will not appear in whole-space discovery",
+            short_hex(source_id, 8)
+        );
         return Ok(());
     };
 
@@ -556,6 +563,13 @@ fn persist_space_membership(
     let HolonId::Local(space_id) = space_reference.holon_id()? else {
         return Ok(());
     };
+
+    // A space does not own itself (#642 §1). The anchor is exempt today because
+    // `create_local_space_holon` publishes it outside staging, so it never reaches commit at all —
+    // this makes the rule hold on its own terms rather than as a consequence of that routing.
+    if *source_id == space_id {
+        return Ok(());
+    }
 
     persist_smartlink(PreparedSmartLink {
         source_id: source_id.clone(),

--- a/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
@@ -19,7 +19,7 @@ use holons_guest_integrity::{
 use crate::get_holon_by_path;
 use crate::guest_shared_objects::commit_functions;
 use crate::persistence_layer::{
-    delete_holon_node, expand_all_from_source, expand_from_source, get_all_holon_ids, get_holon,
+    delete_holon_node, delete_smartlink, expand_all_from_source, expand_from_source, get_holon,
     index_local_holon_space, persist_holon, saved_holon_from_stored,
 };
 use base_types::MapString;
@@ -35,6 +35,7 @@ use holons_core::{
 use holons_integrity::LinkTypes;
 use holons_loader::HolonLoaderController;
 use integrity_core_types::{LocalId, PropertyMap, PropertyName, RelationshipName};
+use type_names::CoreRelationshipTypeName;
 
 pub struct GuestHolonService;
 
@@ -43,6 +44,13 @@ impl GuestHolonService {
         GuestHolonService
     }
 
+    /// Creates and anchors the local space holon.
+    ///
+    /// This path deliberately goes transient → `persist_holon` without passing through staging.
+    /// That is now load-bearing rather than incidental: space membership is stamped at staging
+    /// time, so bypassing staging is what keeps the anchor out of its own `Owns` collection.
+    /// Routing space creation through `stage_new_holon` would make the space own itself and put
+    /// it back into whole-space discovery results.
     fn create_local_space_holon(
         &self,
         context: &Arc<TransactionContext>,
@@ -160,6 +168,37 @@ impl GuestHolonService {
 
         Ok((key, reference))
     }
+
+    /// Retracts `local_id`'s space membership: its `OwnedBy` links and the reciprocal `Owns`
+    /// links naming it on each owning space.
+    ///
+    /// The space's inverse view is retracted first because that is the side whole-space
+    /// discovery reads; if only one direction could be retracted, it is the one that matters.
+    ///
+    /// Idempotent — `delete_smartlink` reports `AlreadyAbsent` rather than failing, so this is a
+    /// no-op for a holon that never acquired membership or whose membership is already gone.
+    fn retract_space_membership(local_id: &LocalId) -> Result<(), HolonError> {
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+        let owns = CoreRelationshipTypeName::Owns.as_relationship_name();
+
+        for membership in expand_from_source(local_id, &owned_by)? {
+            // Membership is a local-space relationship; a non-local owner is not something this
+            // guest can retract, and is left for the space that authored it.
+            let HolonId::Local(space_id) = &membership.target_id else {
+                continue;
+            };
+
+            for member_link in expand_from_source(space_id, &owns)? {
+                if member_link.target_id == HolonId::Local(local_id.clone()) {
+                    delete_smartlink(&member_link.smartlink_id)?;
+                }
+            }
+
+            delete_smartlink(&membership.smartlink_id)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl HolonServiceApi for GuestHolonService {
@@ -187,6 +226,12 @@ impl HolonServiceApi for GuestHolonService {
         let _stored = get_holon(local_id)?
             .ok_or_else(|| HolonError::HolonNotFound(format!("at id: {:?}", local_id.0)))?;
         // holon.is_deletable()?;
+
+        // Membership is carried by SmartLinks, and deleting an entry does not retract the links
+        // pointing at it, so a deleted holon would otherwise stay in its space's `Owns`
+        // collection and remain discoverable. Retract membership before the node goes away.
+        Self::retract_space_membership(local_id)?;
+
         delete_holon_node(try_action_hash_from_local_id(&local_id)?)
             .map(|_| ()) // Convert ActionHash to ()
             .map_err(|e| holon_error_from_wasm_error(e))
@@ -281,19 +326,30 @@ impl HolonServiceApi for GuestHolonService {
         Ok(collection)
     }
 
+    /// Retrieves the holons owned by the transaction's current `HolonSpace`.
+    ///
+    /// Whole-space discovery is ordinary graph traversal: every committed lineage carries
+    /// `OwnedBy → HolonSpace`, and commit materializes the reciprocal `Owns` SmartLink on the
+    /// space, so the space's `Owns` collection *is* the membership list. Members are lineage
+    /// roots, since membership is not re-emitted for later versions.
+    ///
+    /// The space anchor is not a member of its own collection; callers that need it use
+    /// `TransactionContext::get_space_holon()`.
     fn get_all_holons_internal(
         &self,
         context: &Arc<TransactionContext>,
     ) -> Result<HolonCollection, HolonError> {
-        let mut collection = HolonCollection::new_existing();
-        let holon_ids = get_all_holon_ids()?;
-        let mut holon_references = Vec::new();
-        for id in holon_ids {
-            holon_references.push(self.mint_smart_reference(context, id, None)?);
-        }
-        collection.add_references(holon_references)?;
+        // No space yet means nothing can belong to one. This is reachable before bootstrap has
+        // anchored the local space, where an empty membership list is the right answer.
+        let Some(space_reference) = context.get_space_holon()? else {
+            return Ok(HolonCollection::new_existing());
+        };
 
-        Ok(collection)
+        self.fetch_related_holons_internal(
+            context,
+            &space_reference.holon_id()?,
+            &CoreRelationshipTypeName::Owns.as_relationship_name(),
+        )
     }
 
     /// Execute a Holon import from a `HolonLoadSet`.

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -54,6 +54,8 @@ pub enum TransactionAction {
 
     // ── Lookup actions (LookupFacade) ────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
+    ///
+    /// The current HolonSpace's `Owns` members; the space anchor itself is not included.
     GetAllHolons,
 
     /// `get_staged_holon_by_base_key(key)` → `StagedReference`

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -56,6 +56,8 @@ pub enum TransactionActionWire {
 
     // ── Lookup actions ───────────────────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
+    ///
+    /// The current HolonSpace's `Owns` members; the space anchor itself is not included.
     GetAllHolons,
 
     /// `get_staged_holon_by_base_key(key)` → `StagedReference`

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -233,7 +233,9 @@ export function loadHolons(
 }
 
 /**
- * Return the full holon collection visible to the transaction.
+ * Return the holons owned by the transaction's current HolonSpace.
+ *
+ * These are the space's `Owns` members; the space holon itself is not one of them.
  */
 export function getAllHolons(
   txId: TxId,

--- a/schema-src/commands/schema.tdl
+++ b/schema-src/commands/schema.tdl
@@ -360,7 +360,7 @@ holon GetAllHolons.CommandType {
   type MetaCommandType.MetaHolonType
   extends CommandType.HolonType
   header {
-    description: "Returns all holons visible in the active transaction."
+    description: "Returns the holons owned by the active transaction's holon space."
     display_name: "Get All Holons Command"
     display_plural: "Get All Holons Commands"
     plural: "GetAllHolonsCommands"

--- a/shared_crates/holon_dance_builders/src/get_all_holons_dance.rs
+++ b/shared_crates/holon_dance_builders/src/get_all_holons_dance.rs
@@ -2,7 +2,7 @@ use base_types::MapString;
 use core_types::HolonError;
 use holons_core::dances::{DanceRequest, DanceType, RequestBody};
 
-/// Builds a DanceRequest for retrieving all holons from the persistent store
+/// Builds a DanceRequest for retrieving the holons owned by the current HolonSpace
 pub fn build_get_all_holons_dance_request() -> Result<DanceRequest, HolonError> {
     let body = RequestBody::new();
     Ok(DanceRequest::new(MapString("get_all_holons".to_string()), DanceType::Standalone, body))

--- a/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
@@ -21,9 +21,6 @@ use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 enum RelationshipCommitScope {
     #[default]
     Full,
-    /// `Full`, minus space membership. Used by version-producing commits: see
-    /// [`StagedHolon::relationship_collections_for_commit`].
-    FullExceptMembership,
     TouchedOnly,
 }
 
@@ -182,22 +179,19 @@ impl StagedHolon {
         Ok(self.staged_relationships.clone())
     }
 
-    /// Selects the relationship collections this commit should persist, in commit order.
+    /// Selects the relationship collections this commit should persist.
     ///
-    /// Two things about space membership are deliberate here.
+    /// Space membership is excluded from every scope. `OwnedBy` and its `Owns` inverse are
+    /// authored by storage when a lineage is published, not replayed from staged state, for two
+    /// reasons: the relationship pass is skipped whenever any staged holon fails to publish, so
+    /// membership written there would not survive a partial commit; and a version-producing
+    /// commit replays the full scope against the *new* version's id, which would make the space
+    /// own the lineage root and every version after it separately. Membership belongs to the
+    /// lineage, and is written exactly once, where the lineage begins.
     ///
-    /// **Under `Full`, `OwnedBy` is ordered first.** The relationship pass stops at a source
-    /// holon's first failing relationship, and a holon whose membership went unwritten is
-    /// persisted but undiscoverable — a split the global index this replaces could not produce,
-    /// because it indexed at publish time. Freeform relationships on undescribed holons fail
-    /// this way by design, so membership is written before anything that can fail.
-    ///
-    /// **Under `FullExceptMembership`, `OwnedBy` is withheld.** A version-producing commit
-    /// replays every staged relationship against the *new* version's id, so replaying membership
-    /// would add a second `Owns` member on the space for every version, and whole-space
-    /// discovery would report both the lineage root and its head. Membership belongs to the
-    /// lineage rather than to each version, so it stays anchored where the lineage began. It
-    /// remains in the staged map either way, so the reference layer still reports the owner.
+    /// A staged `OwnedBy` therefore has no effect on commit. It can still arrive here — cloning a
+    /// saved holon carries its persisted membership into the staged map — and is dropped rather
+    /// than re-anchored to the clone.
     pub fn relationship_collections_for_commit(
         &self,
     ) -> Result<Vec<(RelationshipName, Arc<RwLock<HolonCollection>>)>, HolonError> {
@@ -209,6 +203,7 @@ impl StagedHolon {
             RelationshipCommitScope::TouchedOnly => self
                 .touched_relationship_names
                 .iter()
+                .filter(|name| **name != owned_by)
                 .filter_map(|name| {
                     self.staged_relationships
                         .map
@@ -216,18 +211,7 @@ impl StagedHolon {
                         .map(|collection| (name.clone(), collection.clone()))
                 })
                 .collect(),
-            RelationshipCommitScope::Full => {
-                let mut pairs: Vec<_> = self
-                    .staged_relationships
-                    .map
-                    .iter()
-                    .map(|(name, collection)| (name.clone(), collection.clone()))
-                    .collect();
-                // Stable partition: membership first, every other relationship in map order.
-                pairs.sort_by_key(|(name, _)| *name != owned_by);
-                pairs
-            }
-            RelationshipCommitScope::FullExceptMembership => self
+            RelationshipCommitScope::Full => self
                 .staged_relationships
                 .map
                 .iter()
@@ -327,17 +311,6 @@ impl StagedHolon {
     pub fn prepare_full_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
         self.is_accessible(AccessType::Commit)?;
         self.relationship_commit_scope = RelationshipCommitScope::Full;
-        Ok(())
-    }
-
-    /// Full replay, except space membership — the scope for a version-producing commit.
-    ///
-    /// Set instead of [`Self::prepare_full_relationship_commit_scope`] because the scope is read
-    /// in the relationship pass, by which point this holon is already `Committed` and its
-    /// version-producing origin is no longer visible in its staged state.
-    pub fn prepare_new_version_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
-        self.is_accessible(AccessType::Commit)?;
-        self.relationship_commit_scope = RelationshipCommitScope::FullExceptMembership;
         Ok(())
     }
 
@@ -882,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn version_producing_commit_filter_withholds_space_membership_only() {
+    fn commit_filter_never_replays_space_membership() {
         let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
         let described_by = RelationshipName(MapString("DescribedBy".to_string()));
 
@@ -905,9 +878,8 @@ mod tests {
             Vec::new(),
         );
 
-        // A create replays membership, and replays it first so a later relationship failure
-        // cannot leave the holon persisted but undiscoverable. `DescribedBy` sorts ahead of
-        // `OwnedBy` in the staged map, so this ordering is not the map's doing.
+        // Membership is authored by storage when the lineage is published, so a staged copy —
+        // which cloning a saved holon produces — is never replayed, under either scope.
         staged.prepare_full_relationship_commit_scope().unwrap();
         let full_names = staged
             .relationship_collections_for_commit()
@@ -915,17 +887,18 @@ mod tests {
             .into_iter()
             .map(|(name, _)| name)
             .collect::<Vec<_>>();
-        assert_eq!(full_names, vec![owned_by.clone(), described_by.clone()]);
+        assert_eq!(full_names, vec![described_by.clone()]);
 
-        // A new version does not: membership stays anchored at the lineage root.
-        staged.prepare_new_version_relationship_commit_scope().unwrap();
-        let version_names = staged
+        staged.mark_relationship_touched(&owned_by);
+        staged.mark_relationship_touched(&described_by);
+        staged.prepare_touched_relationship_commit_scope().unwrap();
+        let touched_names = staged
             .relationship_collections_for_commit()
             .unwrap()
             .into_iter()
             .map(|(name, _)| name)
             .collect::<Vec<_>>();
 
-        assert_eq!(version_names, vec![described_by]);
+        assert_eq!(touched_names, vec![described_by]);
     }
 }

--- a/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
@@ -15,12 +15,15 @@ use core_types::{
     HolonError, HolonId, HolonNodeModel, LocalId, PropertyMap, PropertyName, PropertyValue,
     RelationshipName,
 };
-use type_names::CorePropertyTypeName;
+use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum RelationshipCommitScope {
     #[default]
     Full,
+    /// `Full`, minus space membership. Used by version-producing commits: see
+    /// [`StagedHolon::relationship_collections_for_commit`].
+    FullExceptMembership,
     TouchedOnly,
 }
 
@@ -179,10 +182,28 @@ impl StagedHolon {
         Ok(self.staged_relationships.clone())
     }
 
+    /// Selects the relationship collections this commit should persist, in commit order.
+    ///
+    /// Two things about space membership are deliberate here.
+    ///
+    /// **Under `Full`, `OwnedBy` is ordered first.** The relationship pass stops at a source
+    /// holon's first failing relationship, and a holon whose membership went unwritten is
+    /// persisted but undiscoverable — a split the global index this replaces could not produce,
+    /// because it indexed at publish time. Freeform relationships on undescribed holons fail
+    /// this way by design, so membership is written before anything that can fail.
+    ///
+    /// **Under `FullExceptMembership`, `OwnedBy` is withheld.** A version-producing commit
+    /// replays every staged relationship against the *new* version's id, so replaying membership
+    /// would add a second `Owns` member on the space for every version, and whole-space
+    /// discovery would report both the lineage root and its head. Membership belongs to the
+    /// lineage rather than to each version, so it stays anchored where the lineage began. It
+    /// remains in the staged map either way, so the reference layer still reports the owner.
     pub fn relationship_collections_for_commit(
         &self,
     ) -> Result<Vec<(RelationshipName, Arc<RwLock<HolonCollection>>)>, HolonError> {
         self.is_accessible(AccessType::Read)?;
+
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
 
         let pairs = match self.relationship_commit_scope {
             RelationshipCommitScope::TouchedOnly => self
@@ -195,10 +216,22 @@ impl StagedHolon {
                         .map(|collection| (name.clone(), collection.clone()))
                 })
                 .collect(),
-            RelationshipCommitScope::Full => self
+            RelationshipCommitScope::Full => {
+                let mut pairs: Vec<_> = self
+                    .staged_relationships
+                    .map
+                    .iter()
+                    .map(|(name, collection)| (name.clone(), collection.clone()))
+                    .collect();
+                // Stable partition: membership first, every other relationship in map order.
+                pairs.sort_by_key(|(name, _)| *name != owned_by);
+                pairs
+            }
+            RelationshipCommitScope::FullExceptMembership => self
                 .staged_relationships
                 .map
                 .iter()
+                .filter(|(name, _)| **name != owned_by)
                 .map(|(name, collection)| (name.clone(), collection.clone()))
                 .collect(),
         };
@@ -294,6 +327,17 @@ impl StagedHolon {
     pub fn prepare_full_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
         self.is_accessible(AccessType::Commit)?;
         self.relationship_commit_scope = RelationshipCommitScope::Full;
+        Ok(())
+    }
+
+    /// Full replay, except space membership — the scope for a version-producing commit.
+    ///
+    /// Set instead of [`Self::prepare_full_relationship_commit_scope`] because the scope is read
+    /// in the relationship pass, by which point this holon is already `Committed` and its
+    /// version-producing origin is no longer visible in its staged state.
+    pub fn prepare_new_version_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
+        self.is_accessible(AccessType::Commit)?;
+        self.relationship_commit_scope = RelationshipCommitScope::FullExceptMembership;
         Ok(())
     }
 
@@ -835,5 +879,53 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(filtered_names, vec![properties]);
+    }
+
+    #[test]
+    fn version_producing_commit_filter_withholds_space_membership_only() {
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+        let described_by = RelationshipName(MapString("DescribedBy".to_string()));
+
+        let mut relationships = BTreeMap::new();
+        relationships
+            .insert(owned_by.clone(), Arc::new(RwLock::new(HolonCollection::new_staged())));
+        relationships
+            .insert(described_by.clone(), Arc::new(RwLock::new(HolonCollection::new_staged())));
+
+        let mut staged = StagedHolon::from_parts(
+            MapInteger(1),
+            HolonState::Mutable,
+            StagedState::ForUpdateNewVersion,
+            ValidationState::ValidationRequired,
+            PropertyMap::new(),
+            StagedRelationshipMap { map: relationships },
+            None,
+            Some(LocalId(vec![1, 2, 3])),
+            BTreeSet::new(),
+            Vec::new(),
+        );
+
+        // A create replays membership, and replays it first so a later relationship failure
+        // cannot leave the holon persisted but undiscoverable. `DescribedBy` sorts ahead of
+        // `OwnedBy` in the staged map, so this ordering is not the map's doing.
+        staged.prepare_full_relationship_commit_scope().unwrap();
+        let full_names = staged
+            .relationship_collections_for_commit()
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+        assert_eq!(full_names, vec![owned_by.clone(), described_by.clone()]);
+
+        // A new version does not: membership stays anchored at the lineage root.
+        staged.prepare_new_version_relationship_commit_scope().unwrap();
+        let version_names = staged
+            .relationship_collections_for_commit()
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(version_names, vec![described_by]);
     }
 }

--- a/shared_crates/holons_core/src/dances/holon_dance_adapter.rs
+++ b/shared_crates/holons_core/src/dances/holon_dance_adapter.rs
@@ -86,7 +86,9 @@ pub fn delete_holon_dance(
     }
 }
 
-/// Get all holons from the persistent store
+/// Get the holons owned by the current HolonSpace.
+///
+/// Returns the space's `Owns` members — lineage roots, not the space anchor itself.
 ///
 /// *DanceRequest:*
 /// - dance_name: "get_all_holons"

--- a/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
+++ b/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
@@ -1,27 +1,15 @@
 use crate::descriptors::effective_relationship_declaration;
 use crate::reference_layer::HolonReference;
 use core_types::{HolonError, RelationshipName};
-use type_names::CoreRelationshipTypeName;
 
 /// Resolves the inverse relationship name for a declared relationship on `source_ref`.
 ///
 /// The declared descriptor must carry exactly one `HasInverse` target; commit uses
 /// that declared-side edge to materialize the reciprocal SmartLink.
-///
-/// `OwnedBy` is the one exception. Space membership is infrastructure-supplied — staging
-/// stamps it on every new lineage, before the holon has been given a `DescribedBy` and,
-/// during the first core-schema load, before the `OwnedBy` descriptor itself has been
-/// persisted. Routing it through the descriptor surface would therefore make ownership
-/// depend on schema load order and would break commit for undescribed holons, so its
-/// inverse is resolved structurally instead.
 pub fn resolve_inverse_relationship_name(
     source_ref: &HolonReference,
     forward_name: &RelationshipName,
 ) -> Result<RelationshipName, HolonError> {
-    if *forward_name == CoreRelationshipTypeName::OwnedBy.as_relationship_name() {
-        return Ok(CoreRelationshipTypeName::Owns.as_relationship_name());
-    }
-
     // Resolve the declared descriptor through the source holon's effective surface.
     let declared_descriptor = effective_relationship_declaration(source_ref, forward_name)?
         .try_into_declared_relationship_descriptor()?;
@@ -154,22 +142,6 @@ mod tests {
             resolve_inverse_relationship_name(&(&source).into(), &authored_by()),
             Err(HolonError::MissingDescribedBy { .. })
         ));
-        Ok(())
-    }
-
-    #[test]
-    fn owned_by_resolves_structurally_without_a_descriptor() -> Result<(), HolonError> {
-        // Space membership is stamped at staging time, before `DescribedBy` is attached and
-        // (on the first core-schema load) before the `OwnedBy` descriptor exists at all.
-        let context = build_context();
-        let source = new_test_holon(&context, "undescribed-source")?;
-
-        let inverse_name = resolve_inverse_relationship_name(
-            &(&source).into(),
-            &CoreRelationshipTypeName::OwnedBy.as_relationship_name(),
-        )?;
-
-        assert_eq!(inverse_name, CoreRelationshipTypeName::Owns.as_relationship_name());
         Ok(())
     }
 

--- a/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
+++ b/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
@@ -1,15 +1,27 @@
 use crate::descriptors::effective_relationship_declaration;
 use crate::reference_layer::HolonReference;
 use core_types::{HolonError, RelationshipName};
+use type_names::CoreRelationshipTypeName;
 
 /// Resolves the inverse relationship name for a declared relationship on `source_ref`.
 ///
 /// The declared descriptor must carry exactly one `HasInverse` target; commit uses
 /// that declared-side edge to materialize the reciprocal SmartLink.
+///
+/// `OwnedBy` is the one exception. Space membership is infrastructure-supplied — staging
+/// stamps it on every new lineage, before the holon has been given a `DescribedBy` and,
+/// during the first core-schema load, before the `OwnedBy` descriptor itself has been
+/// persisted. Routing it through the descriptor surface would therefore make ownership
+/// depend on schema load order and would break commit for undescribed holons, so its
+/// inverse is resolved structurally instead.
 pub fn resolve_inverse_relationship_name(
     source_ref: &HolonReference,
     forward_name: &RelationshipName,
 ) -> Result<RelationshipName, HolonError> {
+    if *forward_name == CoreRelationshipTypeName::OwnedBy.as_relationship_name() {
+        return Ok(CoreRelationshipTypeName::Owns.as_relationship_name());
+    }
+
     // Resolve the declared descriptor through the source holon's effective surface.
     let declared_descriptor = effective_relationship_declaration(source_ref, forward_name)?
         .try_into_declared_relationship_descriptor()?;
@@ -142,6 +154,22 @@ mod tests {
             resolve_inverse_relationship_name(&(&source).into(), &authored_by()),
             Err(HolonError::MissingDescribedBy { .. })
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn owned_by_resolves_structurally_without_a_descriptor() -> Result<(), HolonError> {
+        // Space membership is stamped at staging time, before `DescribedBy` is attached and
+        // (on the first core-schema load) before the `OwnedBy` descriptor exists at all.
+        let context = build_context();
+        let source = new_test_holon(&context, "undescribed-source")?;
+
+        let inverse_name = resolve_inverse_relationship_name(
+            &(&source).into(),
+            &CoreRelationshipTypeName::OwnedBy.as_relationship_name(),
+        )?;
+
+        assert_eq!(inverse_name, CoreRelationshipTypeName::Owns.as_relationship_name());
         Ok(())
     }
 

--- a/shared_crates/holons_core/src/reference_layer/holon_service_api.rs
+++ b/shared_crates/holons_core/src/reference_layer/holon_service_api.rs
@@ -59,7 +59,11 @@ pub trait HolonServiceApi: Debug + Any + Send + Sync {
         relationship_name: &RelationshipName,
     ) -> Result<HolonCollection, HolonError>;
 
-    /// Retrieves all persisted Holons, as a HolonCollection
+    /// Retrieves the holons owned by the current HolonSpace, as a HolonCollection.
+    ///
+    /// Membership is the space's `Owns` collection, so members are lineage roots and the space
+    /// anchor is not among them — callers needing the anchor use
+    /// `TransactionContext::get_space_holon()`.
     fn get_all_holons_internal(
         &self,
         context: &Arc<TransactionContext>,

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -372,7 +372,18 @@ impl ExecutionReference {
                         e
                     )
                 })?;
-                if Self::relationship_entries_with_members(&relationship_map)?.is_empty() {
+                // Space membership is infrastructure-supplied, not fixture-authored: every
+                // committed lineage acquires `OwnedBy` from its transaction context. It is
+                // therefore not "relationship content" for the purpose of deciding whether an
+                // undescribed holon needs a descriptor to be compared — the same reasoning that
+                // already tolerates commit-materialized inverse SmartLinks here.
+                let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+                let authored_entries: Vec<_> =
+                    Self::relationship_entries_with_members(&relationship_map)?
+                        .into_iter()
+                        .filter(|(name, _)| *name != owned_by)
+                        .collect();
+                if authored_entries.is_empty() {
                     return Ok(Vec::new());
                 }
                 return Err(format!(

--- a/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
+++ b/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
@@ -429,7 +429,10 @@ impl FixtureHolons {
                 // (e.g. by a schema load); they contribute to no fixture counts.
                 TestHolonState::SavedLookup => {}
                 TestHolonState::Abandoned => counts.staged -= 1,
-                TestHolonState::Deleted => counts.saved -= 1,
+                // A deleted holon is no longer a DB row. Its head no longer counts as Saved, so
+                // contributing nothing is the whole of its removal — subtracting again would
+                // charge the deletion twice.
+                TestHolonState::Deleted => {}
             }
         }
         counts
@@ -441,8 +444,12 @@ impl FixtureHolons {
     pub fn count_staged(&self) -> MapInteger {
         MapInteger(self.counts().staged)
     }
+    /// Saved holons the DB is expected to report.
+    ///
+    /// No allowance for the LocalHolonSpace anchor: whole-space discovery reads the space's
+    /// `Owns` members, and the anchor is not a member of its own collection.
     pub fn count_saved(&self) -> MapInteger {
-        MapInteger(self.counts().saved + 1) // Accounts for initial LocalHolonSpace
+        MapInteger(self.counts().saved)
     }
 }
 

--- a/tests/sweetests/src/harness/helpers/constants.rs
+++ b/tests/sweetests/src/harness/helpers/constants.rs
@@ -15,7 +15,8 @@ pub const PUBLISHER_KEY: &str = "Publishing Company";
 pub const BOOK_TO_PERSON_RELATIONSHIP: &str = "AuthoredBy";
 pub const PUBLISHED_BY: &str = "PublishedBy";
 pub const EDITOR_FOR: &str = "EditorFor";
-pub const ENSURE_DB_EMPTY: &str = "Ensuring DB is 'empty' (only contains initial LocalHolonSpace).";
+pub const ENSURE_DB_EMPTY: &str =
+    "Ensuring DB is empty (the LocalHolonSpace anchor is not one of its own Owns members).";
 pub const BOOK_DESCRIPTOR_KEY: &str = "Book.HolonType";
 pub const PERSON_DESCRIPTOR_KEY: &str = "Person.HolonType";
 pub const SCHEMA_TYPE_KEY: &str = "Schema.HolonType";

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -72,6 +72,7 @@ use fixture_cases::load_generated_core_schema_fixture::*;
 use fixture_cases::load_generated_query_schema_fixture::*;
 use fixture_cases::load_generated_validation_schema_fixture::*;
 use fixture_cases::load_holons_internal_fixture::*;
+use fixture_cases::partial_commit_membership_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
 use fixture_cases::simple_create_holon_fixture::*;
@@ -112,6 +113,7 @@ use holons_prelude::prelude::*;
 #[rstest]
 #[case::simple_undescribed_create_holon_test(simple_create_holon_fixture())]
 #[case::delete_holon(delete_holon_fixture())]
+#[case::partial_commit_membership_test(partial_commit_membership_fixture())]
 #[case::simple_abandon_staged_changes_test(simple_abandon_staged_changes_fixture())]
 #[case::simple_add_remove_properties_test(simple_add_remove_properties_fixture())]
 #[case::simple_add_related_holon_test(simple_add_remove_related_holons_fixture())]

--- a/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
@@ -67,9 +67,13 @@ pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
         Some("Attempting invalid delete...".to_string()),
     )?;
 
-    // TODO: more robust handling of the implication of deletes on links needs to be implemented before this step will work
-    // // ADD STEP:  ENSURE DATABASE COUNT
-    // test_case.add_ensure_database_count_step( fixture_holons.count_saved())?;
+    // ADD STEP:  ENSURE DATABASE COUNT
+    // A deleted holon must not remain discoverable: delete retracts its space membership, so
+    // `count_saved()` (which nets out the deletion) is the count whole-space discovery reports.
+    test_case.add_ensure_database_count_step(
+        fixture_holons.count_saved(),
+        Some("Deleted holon is no longer an owned member".to_string()),
+    )?;
 
     // Finalize
     test_case.finalize(&fixture_context, &fixture_holons)?;

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -123,7 +123,7 @@ pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, Holon
         Some("Commit described Book/Person instances".to_string()),
     )?;
 
-    // DB = fixture-saved holons (incl. space baseline) + loader-committed schema holons.
+    // DB = fixture-saved holons + loader-committed schema holons (no space anchor).
     let expected_db_count = MapInteger(
         fixture_holons.count_saved().0
             + CORE_SCHEMA_METRICS.committed

--- a/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Fixture Progression (combined)
 //!
-//! 1. **Empty bundle** → `UnprocessableEntity`; database remains baseline (only Space holon)
+//! 1. **Empty bundle** → `UnprocessableEntity`; database remains baseline (no owned holons)
 //! 2. **Nodes-only undescribed bundle** → staged, then skipped during default population
 //! 3. **Undescribed relationship bundle** → relationship staged, then skipped during default population
 //! 4. **Multi-bundle duplicate-key set** (same LoaderHolon key in two files) → `UnprocessableEntity`; DB unchanged
@@ -193,7 +193,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, mut fixture_bindings } =
         TestCaseInit::new(
             "Loader Incremental Fixture",
-            "1) Ensure DB starts with only the Space holon,\n\
+            "1) Ensure DB starts with no holons owned by the space,\n\
          2) Load a HolonLoadSet containing a single empty HolonLoaderBundle and assert the\n\
             loader short-circuits cleanly (no holons staged/committed, DB unchanged),\n\
          3) Load a nodes-only HolonLoadSet (Book/Person/Publisher LoaderHolons, no relationships)\n\
@@ -206,8 +206,8 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
             leaves the DB unchanged, and surfaces per-file provenance via error holons.\n",
         );
 
-    // A) Ensure DB starts with only the Space holon.
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    // A) Ensure DB starts with no owned holons.
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // B) Empty bundle → expect UnprocessableEntity and no DB change.
     let empty_bundle = build_empty_bundle(&fixture_context, "Bundle.Empty.1")?;
@@ -226,7 +226,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(0), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // C) Nodes-only undescribed bundle -> staged, then rejected before commit.
     let nodes_only_keys = &["Book.NodesOnly.1", "Person.NodesOnly.1", "Publisher.NodesOnly.1"];
@@ -247,7 +247,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(n_nodes as i64), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before declared-link load".to_string()),
@@ -277,7 +277,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(node_count as i64), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before duplicate-key load".to_string()),
@@ -333,7 +333,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // DB must remain unchanged after duplicate-key failure.
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // Finalize
     test_case.finalize(&fixture_context, &fixture_holons)?;

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -9,6 +9,7 @@ pub mod load_generated_query_schema_fixture;
 pub mod load_generated_validation_schema_fixture;
 pub mod load_holons_internal_fixture;
 pub mod load_inverse_oriented_book_person_instances_fixture;
+pub mod partial_commit_membership_fixture;
 pub mod setup_book_and_authors_fixture;
 pub mod simple_add_remove_properties_fixture;
 pub mod simple_add_remove_related_holons_fixture;

--- a/tests/sweetests/tests/fixture_cases/partial_commit_membership_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/partial_commit_membership_fixture.rs
@@ -1,0 +1,107 @@
+//! Regression fixture: a holon that publishes stays discoverable even when a sibling does not.
+//!
+//! Whole-space discovery reads the current space's `Owns` members, so a published holon that never
+//! acquired membership is persisted and permanently invisible. The commit's relationship pass is
+//! skipped outright whenever *any* staged holon fails to publish, which is precisely the case this
+//! fixture builds — so membership authored there would not survive it. Membership is instead
+//! authored in the node pass, beside `persist_holon`, and this pins that.
+//!
+//! Shape: two holons staged in one commit. One carries more properties than PVL permits, so its
+//! `PublishRoot` is rejected and the commit reports `Incomplete` before the relationship pass runs.
+//! The other publishes normally and must still be an owned member afterwards.
+
+use holons_prelude::prelude::*;
+use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
+use rstest::*;
+use std::collections::BTreeMap;
+
+/// One more than `shared_validation::MAX_PROPERTY_COUNT`, so `preflight_holon_node` rejects the
+/// node before it is authored. Any Pass 1 failure would do; this one needs no oversized payload.
+const OVER_PROPERTY_LIMIT: usize = 257;
+
+#[fixture]
+pub fn partial_commit_membership_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit {
+        mut test_case,
+        fixture_context,
+        mut fixture_holons,
+        fixture_bindings: _fixture_bindings,
+    } = TestCaseInit::new(
+        "Partial Commit Membership Testcase",
+        "Stage one publishable holon and one that PVL rejects, commit both, and assert the \
+         publishable one is still an owned member of the space after the relationship pass is \
+         skipped.",
+    );
+
+    // Start from an empty space so the count below is unambiguous.
+    test_case.add_ensure_database_count_step(
+        MapInteger(0),
+        Some("DB starts with no owned holons".to_string()),
+    )?;
+
+    // ── The holon that publishes ────────────────────────────────────────────────
+    let good_key = MapString("partial-commit:publishable".to_string());
+    let good_transient = fixture_context.mutation().new_holon(Some(good_key.clone()))?;
+    let mut good_properties = BTreeMap::new();
+    good_properties.insert("title".to_property_name(), "Publishable Holon".to_base_value());
+
+    let good_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        good_transient,
+        good_properties,
+        Some(good_key),
+        None,
+        Some("Creating the holon that will publish...".to_string()),
+    )?;
+    test_case.add_stage_holon_step(
+        &mut fixture_holons,
+        good_token,
+        None,
+        Some("Staging the holon that will publish...".to_string()),
+    )?;
+
+    // ── The holon that PVL rejects ──────────────────────────────────────────────
+    let bad_key = MapString("partial-commit:rejected".to_string());
+    let bad_transient = fixture_context.mutation().new_holon(Some(bad_key.clone()))?;
+    let mut bad_properties = BTreeMap::new();
+    for index in 0..OVER_PROPERTY_LIMIT {
+        bad_properties
+            .insert(format!("property-{index:03}").to_property_name(), "value".to_base_value());
+    }
+
+    let bad_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        bad_transient,
+        bad_properties,
+        Some(bad_key),
+        None,
+        Some("Creating the holon that exceeds the PVL property limit...".to_string()),
+    )?;
+    test_case.add_stage_holon_step(
+        &mut fixture_holons,
+        bad_token,
+        None,
+        Some("Staging the holon that will be rejected...".to_string()),
+    )?;
+
+    // Pass 1 fails for the over-limit holon, so the commit reports Incomplete and the
+    // relationship pass never runs.
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Incomplete,
+        None,
+        Some("Committing both; expect Incomplete".to_string()),
+    )?;
+
+    // The assertion this fixture exists for. A literal count rather than `count_saved()`: the
+    // fixture ledger advances every staged head to Saved on commit, which is right when only the
+    // relationship pass fails, but overcounts here because one holon never published at all.
+    test_case.add_ensure_database_count_step(
+        MapInteger(1),
+        Some("The published holon is still an owned member after a partial commit".to_string()),
+    )?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
@@ -1,6 +1,6 @@
 use crate::fixture_cases::setup_undescribed_book_author_steps_with_context;
 use holons_prelude::prelude::*;
-use holons_test::harness::helpers::PUBLISHED_BY;
+use holons_test::harness::helpers::{ENSURE_DB_EMPTY, PUBLISHED_BY};
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 use rstest::*;
 use std::collections::BTreeMap;
@@ -32,7 +32,7 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     // Ensure DB count //
     test_case.add_ensure_database_count_step(
         fixture_holons.count_saved(),
-        Some("Ensuring DB is 'empty' (only contains initial LocalHolonSpace).".to_string()),
+        Some(ENSURE_DB_EMPTY.to_string()),
     )?;
 
     // Use helper function to stage Book, 2 Person, 1 Publisher Holon and AUTHORED_BY relationship

--- a/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
@@ -25,7 +25,7 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
             "Clone from transient, staged, and saved; mutate staged clones; assert counts+content",
         );
 
-    // Assert DB starts with 1 (space Holon)
+    // Assert DB starts empty (the space anchor does not own itself)
     test_case.add_ensure_database_count_step(
         fixture_holons.count_saved(),
         Some(ENSURE_DB_EMPTY.to_string()),

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -13,7 +13,8 @@ use holons_test::harness::helpers::{
 // TODO: add/remove relationships
 
 /// Expected DB count once core + Book/Person schemas are loaded: fixture-saved
-/// holons (incl. the LocalHolonSpace baseline) plus the loader-committed schema holons.
+/// holons plus the loader-committed schema holons. The LocalHolonSpace anchor is not
+/// counted — it is not a member of its own `Owns` collection.
 fn schema_backed_db_count(fixture_holons: &FixtureHolons) -> MapInteger {
     MapInteger(
         fixture_holons.count_saved().0


### PR DESCRIPTION
## Summary

Whole-space discovery becomes ordinary graph traversal. Publishing a lineage writes
`Holon ─OwnedBy→ HolonSpace` and its `HolonSpace ─Owns→ Holon` inverse; `get_all_holons_internal`
reads that `Owns` collection instead of the `AllHolonNodes` path index. This is the
coordinator-owned replacement #631 §3 and §9 named as SL5b's precondition.

`GetAllHolons`, the legacy dance, the wire binding, and the TS SDK keep their contracts.

**One semantic change:** the `LocalHolonSpace` anchor is no longer in `GetAllHolons` results — it is
not a member of its own `Owns` collection (#642 §1, §9), so every DB count drops by one. Callers
that want the anchor use `TransactionContext::get_space_holon()`.

`AllHolonNodes` is still written and all of its tests still pass. Nothing reads it, which makes this
a reversible checkpoint rather than a cutover.

## Changes

**`commit_functions.rs`** — new `persist_space_membership`, called from `commit_holon`'s `ForCreate`
arm immediately after `persist_holon` returns. It writes the `OwnedBy` and `Owns` SmartLinks
directly through the existing `persist_smartlink`, in the node pass.

Membership is deliberately *not* staged for the relationship pass. See the first note below — this
is the load-bearing decision in the PR.

**`staged.rs`** — `relationship_collections_for_commit` excludes `OwnedBy` from every scope. Storage
authors membership; the coordinator never replays it. A staged `OwnedBy` can still arrive (cloning a
saved holon carries its persisted membership into the staged map) and is dropped rather than
re-anchored to the clone or to a new version.

**`guest_holon_service.rs`** — `get_all_holons_internal` resolves the space and delegates to the
existing `fetch_related_holons_internal` with `Owns`; no new traversal code. `delete_holon_internal`
gains `retract_space_membership`, deleting the `Owns` link on the space and the `OwnedBy` link on the
holon before the node delete. `create_local_space_holon` gains a comment recording that its staging
bypass is now load-bearing.

Reading through `fetch_related_holons_internal` is a small win: the old code built its collection
with `add_references` and no keys, whereas the `Owns` link's canonical key *is* the owned holon's
key — so the collection is now keyed from tag bytes with no hydration, which is what every
`get_by_key` consumer behind this call already wanted.

**Contract docs** — `holon_service_api.rs`, `holon_dance_adapter.rs`, `get_all_holons_dance.rs`,
`transaction_command.rs`, `transaction_wire.rs`, `map-sdk/.../transaction.ts`, and
`schema-src/commands/schema.tdl` (with the generated JSON regenerated — a one-line diff). All said
"all persisted holons".

**Fixtures** — `count_saved()` drops the `+ 1` for the anchor, carrying eight fixtures at once;
`load_holons_internal_fixture`'s five hardcoded `MapInteger(1)` baselines become `MapInteger(0)`;
`ENSURE_DB_EMPTY` and the inline "+1 for the space holon" comments corrected. New
`partial_commit_membership_fixture` — see Testing.

## Notable decisions

- **Membership is authored in the node pass, beside `persist_holon`.** This is where the design
  landed after two earlier attempts, and the reason matters. Membership is what whole-space
  discovery reads, so a holon that publishes without it is persisted and permanently invisible —
  something `AllHolonNodes` could not produce, because it indexed inside `PublishRoot`.

  Staging the edge for the relationship pass reintroduces exactly that split. The relationship pass
  is skipped outright whenever *any* staged holon fails to publish, so a commit of two holons where
  one is rejected leaves the other published and unowned, with nothing to repair it later. Ordering
  `OwnedBy` first within the pass — which an earlier revision of this PR did — narrows the window
  but does not close it. Writing membership beside the node write restores the coupling
  unconditionally.

- **The coordinator never replays membership.** Since storage authors it, replaying a staged copy
  can only do harm: a version-producing commit replays the full scope against the *new* version's
  id, which would make the space own the lineage root and every version after it separately (#642
  §8 rejects re-anchoring per version). Excluding `OwnedBy` from every scope is one filter and
  covers the version case, the clone case, and any future path that stages it.

-`resolve_inverse_relationship_name` never sees `OwnedBy`, so the descriptor
  short-circuit added for it is gone and the descriptor system is back to having no exceptions.

- **Deletion retracts membership both ways.** `delete_holon_node` deletes only the path link and the
  entry; SmartLinks survive it, which would leave deleted holons discoverable (#642 §9). The
  retraction lives in `delete_holon_internal`, not the persistence layer, which is deliberately
  descriptor-unaware.

- **A latent harness bug surfaced.** `FixtureHolons::counts()` charged a deleted holon `saved -= 1`
  *in addition to* its head no longer counting as `Saved`. The old anchor allowance cancelled it
  exactly, which is why it went unnoticed and why `delete_holon_fixture`'s post-delete assertion was
  commented out with a TODO. `Deleted` now contributes nothing and that assertion is enabled — it is
  how the retraction above is tested.

- **The saved-content comparator ignores `OwnedBy`.** `assert_saved_content_eq` refused to compare an
  undescribed actual holon carrying any relationship content, and every saved holon now carries
  membership. Infrastructure-supplied edges never appear in fixture snapshots — the same reasoning
  that already tolerates commit-materialized inverse SmartLinks there.

- `all_holon_nodes.rs` and its `mod.rs` wiring; `index_under_all_holon_nodes` and its `PublishRoot`
call; `ALL_HOLON_NODES_PATH`; `LinkTypes::AllHolonNodes` and its four dispatch arms; both validators,
the `AllHolonNodesDelete` rejection, and their re-exports; the `all_holon_nodes_delete_for_test`
probe and the `RootIndexLinkType::AllHolonNodes` variant; both `coordinator-surface.toml`
`[[export]]` blocks; and the `AllHolonNodes` tests and table legs. `mock_conductor.rs`'s liveness
probe calls the `get_all_holon_nodes` extern purely as a callability check and needs repointing.

- `validate_root_index_create` and the shared rejection variants stay — `LocalHolonSpace` still uses
them (#631 §9). Removing the enum variant renumbers `LocalHolonSpace` 1→0 and `SmartLink` 2→1 and so
changes the DNA hash: the same accepted consequence as SL5a, inert by construction since the enum is
the single source of truth for both the write and the read of every link.
## Testing

**The write and retract paths are both directly exercised**, which matters because discovery now
depends entirely on them:

- *Create.* Every `ensure_database_count` step pins membership exactly, now that the anchor
  allowance is gone: pre-commit steps assert the anchor is excluded, post-commit steps assert new and
  cloned lineages appear, and `stage_new_version_fixture` asserts a version adds no member.
- *Partial commit.* `partial_commit_membership_fixture` (new) stages two holons, one carrying more
  properties than PVL permits, so its `PublishRoot` is rejected and the commit reports `Incomplete`
  before the relationship pass runs. It then asserts the other holon is still an owned member. This
  is the case the earlier staged-membership design got wrong; the fixture was confirmed to fail
  against that design and pass against this one.
- *Delete.* `delete_holon_fixture`'s post-delete count assertion, re-enabled here, asserts the
  deleted holon is gone from `GetAllHolons` — the retraction's only test, and the reason the harness
  counting bug above had to be fixed.

**Not measured: the `Owns` fan-in cost.** Every inverse `Owns` link is based on the space holon, and
`put_smartlink` scans all live links on the base for conflict detection — so a 191-holon core-schema
load is ~O(n²) tag decodes against one base. Numbers on this branch: `dance_tests` 144.9s,
`holon_storage_tests` 68.8s, `pvl_validation_tests` 47.9s, `smartlink_tests` 19.1s. A before/after
comparison still needs a baseline run on the parent commit. This is the open SL3 candidate-scan cost,
now on a hot path; conflict-detection semantics were deliberately left alone.

**Environment note.** The three workspaces share one `target/`; running `cargo` outside
`nix develop` mixes rustc versions and the next nix-side build fails with `E0514` plus misleading
`cannot find type X` errors in untouched files. Also, `npm run sweet:test` skips the WASM rebuild and
the audit.

## Scope

Unchanged: `QueryExpression`, `QueryDance`, query planning (#642 §5); any new public whole-space
query API; key or type indexes; the core-schema JSON inputs beyond one regenerated command
description; `persistence_layer::smartlink` and the Tag v1 codec; `LocalHolonSpace` bootstrap
behavior; exact-version reads and Storage SL2 record behavior.

`OwnedBy` and `Owns` still set neither `IsDefinitional` nor `AllowsDuplicates` in the TDL. Nothing
reads them — storage authors membership directly and the coordinator never resolves it through
descriptor policy — so it is not blocking, but it is a trap for anyone who later routes ownership
through that policy.

Still open, unaffected: the `put_smartlink` candidate-scan cost (SL3), now more load-bearing than
before, and the reference-layer/storage disagreement over what "the same link" means (SL4).
