### PR TITLE
642 - SL5b-V1 — Holon space membership

### DIFF
--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -445,7 +445,12 @@ fn commit_holon(
                     short_hex(&stored.version_metadata.version_id, 8)
                 );
 
-                staged_holon.to_committed(stored.version_metadata.version_id)?;
+                let new_local_id = stored.version_metadata.version_id;
+                // Staged after publication rather than before it, so the new lineage's own id is
+                // available to the self-ownership check.
+                stage_space_membership(staged_holon, context, &new_local_id)?;
+
+                staged_holon.to_committed(new_local_id)?;
                 Ok(CommitOutcome::Saved)
             }
 
@@ -467,7 +472,10 @@ fn commit_holon(
             StagedState::ForUpdateNewVersion => {
                 trace!("StagedState::ForUpdateNewVersion — publishing the next HolonNode version");
                 let predecessor_id = staged_holon.get_versioned_source_id()?;
-                staged_holon.prepare_full_relationship_commit_scope()?;
+                // Full replay, except space membership: the lineage already belongs to the
+                // space, and re-emitting `OwnedBy` here would make the space `Owns` both the
+                // lineage root and every version published after it.
+                staged_holon.prepare_new_version_relationship_commit_scope()?;
                 // Storage decides how a version is written: it resolves the lineage this
                 // predecessor belongs to and roots the new version there. Immediate-predecessor
                 // ordering is not carried by the node — it is staged below as a SmartLink.
@@ -520,6 +528,75 @@ fn commit_holon(
             holon_write
         )))
     }
+}
+
+/// Stamps `OwnedBy → current HolonSpace` on a lineage-creating commit.
+///
+/// Space membership is infrastructure-supplied, and this is the one place it can be supplied
+/// reliably. Staging can happen in a client transaction that has not yet been told which space
+/// it is bound to, whereas by the time a commit reaches the guest the local space anchor has
+/// always been resolved. Stamping here also keeps membership and publication together — the same
+/// coupling the global index it replaces got from being written during `PublishRoot`.
+///
+/// Only lineage-creating commits stamp: a new version inherits the membership its lineage root
+/// already holds, and re-emitting it would make the space own every version separately.
+///
+/// Idempotent, so a lineage that was already stamped upstream keeps its existing owner.
+fn stage_space_membership(
+    staged_holon: &mut StagedHolon,
+    context: &Arc<TransactionContext>,
+    source_id: &LocalId,
+) -> Result<(), HolonError> {
+    let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+
+    let already_owned = {
+        let collection_rc = staged_holon.get_staged_relationship(&owned_by)?;
+        let collection = collection_rc.read().map_err(|e| {
+            HolonError::FailedToAcquireLock(format!(
+                "Failed to acquire read lock on staged OwnedBy collection: {}",
+                e
+            ))
+        })?;
+        !collection.get_members().is_empty()
+    };
+    if already_owned {
+        return Ok(());
+    }
+
+    // Every guest dance context is anchored to a persisted space before its body runs
+    // (`dance_adapter::init_guest_context` calls `ensure_local_holon_space`), and the anchor itself
+    // never reaches commit, so this branch should be unreachable. Skipping quietly would leave a
+    // published lineage with no route into whole-space discovery, so say so.
+    let Some(space_reference) = context.get_space_holon()? else {
+        warn!(
+            "No space holon bound to this transaction; {} was published without space membership",
+            short_hex(source_id, 8)
+        );
+        return Ok(());
+    };
+
+    // A space does not own itself (#642 §1). The anchor is exempt today because
+    // `create_local_space_holon` publishes it outside staging, so it never reaches commit at all —
+    // this makes the rule hold on its own terms rather than as a consequence of that routing.
+    if space_reference.holon_id()? == HolonId::Local(source_id.clone()) {
+        return Ok(());
+    }
+
+    let space_key = space_reference.key()?.ok_or_else(|| {
+        HolonError::EmptyField("HolonSpace holon has no key; cannot record membership".to_string())
+    })?;
+
+    // Carry the key on the reference: relationship commit fail-fasts on a target whose key
+    // cannot be resolved, and this answers it without re-fetching the space per staged holon.
+    let space_target = HolonReference::smart_with_key(
+        TransactionContextHandle::new(Arc::clone(context)),
+        space_reference.holon_id()?,
+        space_key.clone(),
+    );
+
+    staged_holon.add_related_holons_with_keys(owned_by, vec![(space_target, Some(space_key))])?;
+
+    Ok(())
 }
 
 fn stage_predecessor_relationship(

--- a/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
@@ -19,8 +19,8 @@ use holons_guest_integrity::{
 use crate::get_holon_by_path;
 use crate::guest_shared_objects::commit_functions;
 use crate::persistence_layer::{
-    delete_holon_node, expand_all_from_source, expand_from_source, get_all_holon_ids, get_holon,
-    index_local_holon_space, persist_holon, saved_holon_from_stored,
+    delete_holon_node, delete_smartlink, expand_all_from_source, expand_from_source,
+    get_all_holon_ids, get_holon, index_local_holon_space, persist_holon, saved_holon_from_stored,
 };
 use base_types::MapString;
 use core_types::{HolonError, HolonId, HolonWriteRequest, SmartLink};
@@ -35,6 +35,7 @@ use holons_core::{
 use holons_integrity::LinkTypes;
 use holons_loader::HolonLoaderController;
 use integrity_core_types::{LocalId, PropertyMap, PropertyName, RelationshipName};
+use type_names::CoreRelationshipTypeName;
 
 pub struct GuestHolonService;
 
@@ -43,6 +44,13 @@ impl GuestHolonService {
         GuestHolonService
     }
 
+    /// Creates and anchors the local space holon.
+    ///
+    /// This path deliberately goes transient → `persist_holon` without passing through staging.
+    /// That is now load-bearing rather than incidental: space membership is stamped at staging
+    /// time, so bypassing staging is what keeps the anchor out of its own `Owns` collection.
+    /// Routing space creation through `stage_new_holon` would make the space own itself and put
+    /// it back into whole-space discovery results.
     fn create_local_space_holon(
         &self,
         context: &Arc<TransactionContext>,
@@ -160,6 +168,37 @@ impl GuestHolonService {
 
         Ok((key, reference))
     }
+
+    /// Retracts `local_id`'s space membership: its `OwnedBy` links and the reciprocal `Owns`
+    /// links naming it on each owning space.
+    ///
+    /// The space's inverse view is retracted first because that is the side whole-space
+    /// discovery reads; if only one direction could be retracted, it is the one that matters.
+    ///
+    /// Idempotent — `delete_smartlink` reports `AlreadyAbsent` rather than failing, so this is a
+    /// no-op for a holon that never acquired membership or whose membership is already gone.
+    fn retract_space_membership(local_id: &LocalId) -> Result<(), HolonError> {
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+        let owns = CoreRelationshipTypeName::Owns.as_relationship_name();
+
+        for membership in expand_from_source(local_id, &owned_by)? {
+            // Membership is a local-space relationship; a non-local owner is not something this
+            // guest can retract, and is left for the space that authored it.
+            let HolonId::Local(space_id) = &membership.target_id else {
+                continue;
+            };
+
+            for member_link in expand_from_source(space_id, &owns)? {
+                if member_link.target_id == HolonId::Local(local_id.clone()) {
+                    delete_smartlink(&member_link.smartlink_id)?;
+                }
+            }
+
+            delete_smartlink(&membership.smartlink_id)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl HolonServiceApi for GuestHolonService {
@@ -187,6 +226,12 @@ impl HolonServiceApi for GuestHolonService {
         let _stored = get_holon(local_id)?
             .ok_or_else(|| HolonError::HolonNotFound(format!("at id: {:?}", local_id.0)))?;
         // holon.is_deletable()?;
+
+        // Membership is carried by SmartLinks, and deleting an entry does not retract the links
+        // pointing at it, so a deleted holon would otherwise stay in its space's `Owns`
+        // collection and remain discoverable. Retract membership before the node goes away.
+        Self::retract_space_membership(local_id)?;
+
         delete_holon_node(try_action_hash_from_local_id(&local_id)?)
             .map(|_| ()) // Convert ActionHash to ()
             .map_err(|e| holon_error_from_wasm_error(e))

--- a/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
@@ -15,12 +15,15 @@ use core_types::{
     HolonError, HolonId, HolonNodeModel, LocalId, PropertyMap, PropertyName, PropertyValue,
     RelationshipName,
 };
-use type_names::CorePropertyTypeName;
+use type_names::{CorePropertyTypeName, CoreRelationshipTypeName};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum RelationshipCommitScope {
     #[default]
     Full,
+    /// `Full`, minus space membership. Used by version-producing commits: see
+    /// [`StagedHolon::relationship_collections_for_commit`].
+    FullExceptMembership,
     TouchedOnly,
 }
 
@@ -179,10 +182,28 @@ impl StagedHolon {
         Ok(self.staged_relationships.clone())
     }
 
+    /// Selects the relationship collections this commit should persist, in commit order.
+    ///
+    /// Two things about space membership are deliberate here.
+    ///
+    /// **Under `Full`, `OwnedBy` is ordered first.** The relationship pass stops at a source
+    /// holon's first failing relationship, and a holon whose membership went unwritten is
+    /// persisted but undiscoverable — a split the global index this replaces could not produce,
+    /// because it indexed at publish time. Freeform relationships on undescribed holons fail
+    /// this way by design, so membership is written before anything that can fail.
+    ///
+    /// **Under `FullExceptMembership`, `OwnedBy` is withheld.** A version-producing commit
+    /// replays every staged relationship against the *new* version's id, so replaying membership
+    /// would add a second `Owns` member on the space for every version, and whole-space
+    /// discovery would report both the lineage root and its head. Membership belongs to the
+    /// lineage rather than to each version, so it stays anchored where the lineage began. It
+    /// remains in the staged map either way, so the reference layer still reports the owner.
     pub fn relationship_collections_for_commit(
         &self,
     ) -> Result<Vec<(RelationshipName, Arc<RwLock<HolonCollection>>)>, HolonError> {
         self.is_accessible(AccessType::Read)?;
+
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
 
         let pairs = match self.relationship_commit_scope {
             RelationshipCommitScope::TouchedOnly => self
@@ -195,10 +216,22 @@ impl StagedHolon {
                         .map(|collection| (name.clone(), collection.clone()))
                 })
                 .collect(),
-            RelationshipCommitScope::Full => self
+            RelationshipCommitScope::Full => {
+                let mut pairs: Vec<_> = self
+                    .staged_relationships
+                    .map
+                    .iter()
+                    .map(|(name, collection)| (name.clone(), collection.clone()))
+                    .collect();
+                // Stable partition: membership first, every other relationship in map order.
+                pairs.sort_by_key(|(name, _)| *name != owned_by);
+                pairs
+            }
+            RelationshipCommitScope::FullExceptMembership => self
                 .staged_relationships
                 .map
                 .iter()
+                .filter(|(name, _)| **name != owned_by)
                 .map(|(name, collection)| (name.clone(), collection.clone()))
                 .collect(),
         };
@@ -294,6 +327,17 @@ impl StagedHolon {
     pub fn prepare_full_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
         self.is_accessible(AccessType::Commit)?;
         self.relationship_commit_scope = RelationshipCommitScope::Full;
+        Ok(())
+    }
+
+    /// Full replay, except space membership — the scope for a version-producing commit.
+    ///
+    /// Set instead of [`Self::prepare_full_relationship_commit_scope`] because the scope is read
+    /// in the relationship pass, by which point this holon is already `Committed` and its
+    /// version-producing origin is no longer visible in its staged state.
+    pub fn prepare_new_version_relationship_commit_scope(&mut self) -> Result<(), HolonError> {
+        self.is_accessible(AccessType::Commit)?;
+        self.relationship_commit_scope = RelationshipCommitScope::FullExceptMembership;
         Ok(())
     }
 
@@ -835,5 +879,53 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(filtered_names, vec![properties]);
+    }
+
+    #[test]
+    fn version_producing_commit_filter_withholds_space_membership_only() {
+        let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+        let described_by = RelationshipName(MapString("DescribedBy".to_string()));
+
+        let mut relationships = BTreeMap::new();
+        relationships
+            .insert(owned_by.clone(), Arc::new(RwLock::new(HolonCollection::new_staged())));
+        relationships
+            .insert(described_by.clone(), Arc::new(RwLock::new(HolonCollection::new_staged())));
+
+        let mut staged = StagedHolon::from_parts(
+            MapInteger(1),
+            HolonState::Mutable,
+            StagedState::ForUpdateNewVersion,
+            ValidationState::ValidationRequired,
+            PropertyMap::new(),
+            StagedRelationshipMap { map: relationships },
+            None,
+            Some(LocalId(vec![1, 2, 3])),
+            BTreeSet::new(),
+            Vec::new(),
+        );
+
+        // A create replays membership, and replays it first so a later relationship failure
+        // cannot leave the holon persisted but undiscoverable. `DescribedBy` sorts ahead of
+        // `OwnedBy` in the staged map, so this ordering is not the map's doing.
+        staged.prepare_full_relationship_commit_scope().unwrap();
+        let full_names = staged
+            .relationship_collections_for_commit()
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+        assert_eq!(full_names, vec![owned_by.clone(), described_by.clone()]);
+
+        // A new version does not: membership stays anchored at the lineage root.
+        staged.prepare_new_version_relationship_commit_scope().unwrap();
+        let version_names = staged
+            .relationship_collections_for_commit()
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(version_names, vec![described_by]);
     }
 }

--- a/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
+++ b/shared_crates/holons_core/src/descriptors/inverse_resolution.rs
@@ -1,15 +1,27 @@
 use crate::descriptors::effective_relationship_declaration;
 use crate::reference_layer::HolonReference;
 use core_types::{HolonError, RelationshipName};
+use type_names::CoreRelationshipTypeName;
 
 /// Resolves the inverse relationship name for a declared relationship on `source_ref`.
 ///
 /// The declared descriptor must carry exactly one `HasInverse` target; commit uses
 /// that declared-side edge to materialize the reciprocal SmartLink.
+///
+/// `OwnedBy` is the one exception. Space membership is infrastructure-supplied — staging
+/// stamps it on every new lineage, before the holon has been given a `DescribedBy` and,
+/// during the first core-schema load, before the `OwnedBy` descriptor itself has been
+/// persisted. Routing it through the descriptor surface would therefore make ownership
+/// depend on schema load order and would break commit for undescribed holons, so its
+/// inverse is resolved structurally instead.
 pub fn resolve_inverse_relationship_name(
     source_ref: &HolonReference,
     forward_name: &RelationshipName,
 ) -> Result<RelationshipName, HolonError> {
+    if *forward_name == CoreRelationshipTypeName::OwnedBy.as_relationship_name() {
+        return Ok(CoreRelationshipTypeName::Owns.as_relationship_name());
+    }
+
     // Resolve the declared descriptor through the source holon's effective surface.
     let declared_descriptor = effective_relationship_declaration(source_ref, forward_name)?
         .try_into_declared_relationship_descriptor()?;
@@ -142,6 +154,22 @@ mod tests {
             resolve_inverse_relationship_name(&(&source).into(), &authored_by()),
             Err(HolonError::MissingDescribedBy { .. })
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn owned_by_resolves_structurally_without_a_descriptor() -> Result<(), HolonError> {
+        // Space membership is stamped at staging time, before `DescribedBy` is attached and
+        // (on the first core-schema load) before the `OwnedBy` descriptor exists at all.
+        let context = build_context();
+        let source = new_test_holon(&context, "undescribed-source")?;
+
+        let inverse_name = resolve_inverse_relationship_name(
+            &(&source).into(),
+            &CoreRelationshipTypeName::OwnedBy.as_relationship_name(),
+        )?;
+
+        assert_eq!(inverse_name, CoreRelationshipTypeName::Owns.as_relationship_name());
         Ok(())
     }
 

--- a/tests/sweetests/src/harness/execution_support/execution_reference.rs
+++ b/tests/sweetests/src/harness/execution_support/execution_reference.rs
@@ -372,7 +372,18 @@ impl ExecutionReference {
                         e
                     )
                 })?;
-                if Self::relationship_entries_with_members(&relationship_map)?.is_empty() {
+                // Space membership is infrastructure-supplied, not fixture-authored: every
+                // committed lineage acquires `OwnedBy` from its transaction context. It is
+                // therefore not "relationship content" for the purpose of deciding whether an
+                // undescribed holon needs a descriptor to be compared — the same reasoning that
+                // already tolerates commit-materialized inverse SmartLinks here.
+                let owned_by = CoreRelationshipTypeName::OwnedBy.as_relationship_name();
+                let authored_entries: Vec<_> =
+                    Self::relationship_entries_with_members(&relationship_map)?
+                        .into_iter()
+                        .filter(|(name, _)| *name != owned_by)
+                        .collect();
+                if authored_entries.is_empty() {
                     return Ok(Vec::new());
                 }
                 return Err(format!(

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -40,8 +40,8 @@
 use super::test_case::DancesTestCase;
 use crate::{
     harness::fixtures_support::TestReference, DanceTestStep, ExpectedCommitStatus,
-    ExpectedLoadStatus, ExpectedSnapshot, FixtureHolons, SourceSnapshot, TestHolonState,
-    TestSessionState, SAVED_LOOKUP_STUB_MARKER,
+    ExpectedLoadStatus, ExpectedSnapshot, FixtureHolons, SourceSnapshot,
+    SpaceMembershipExpectation, TestHolonState, TestSessionState, SAVED_LOOKUP_STUB_MARKER,
 };
 use holons_boundary::SerializableHolonPool;
 use holons_core::{
@@ -292,6 +292,53 @@ impl DancesTestCase {
             "Verify graph-only and version-producing relationship anchoring".to_string()
         });
         self.steps.push(DanceTestStep::VerifyRelationshipAnchoring { description });
+
+        Ok(())
+    }
+
+    /// Asserts holon space membership through ordinary relationship traversal.
+    ///
+    /// `anchor_token` is any saved holon that belongs to the space; the space is reached by
+    /// following its `OwnedBy`. `expected_member_keys` is the exact set the space should own.
+    ///
+    /// Deliberately independent of `GetAllHolons`, which still reads the `AllHolonNodes` index —
+    /// and which cannot even be called after a delete, since the index still lists the deleted
+    /// holon and resolving it fails.
+    pub fn add_verify_space_membership_step(
+        &mut self,
+        anchor_token: TestReference,
+        expected_member_keys: Vec<MapString>,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Verify holon space membership".to_string());
+        self.steps.push(DanceTestStep::VerifySpaceMembership {
+            anchor_token,
+            expected: SpaceMembershipExpectation::ExactKeys(expected_member_keys),
+            description,
+        });
+
+        Ok(())
+    }
+
+    /// Asserts only how many holons the current space owns.
+    ///
+    /// For schema-backed fixtures, where the loader commits members the fixture never named.
+    pub fn add_verify_space_membership_count_step(
+        &mut self,
+        anchor_token: TestReference,
+        expected_member_count: MapInteger,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description =
+            description.unwrap_or_else(|| "Verify holon space membership count".to_string());
+        self.steps.push(DanceTestStep::VerifySpaceMembership {
+            anchor_token,
+            expected: SpaceMembershipExpectation::ExactCount(expected_member_count),
+            description,
+        });
 
         Ok(())
     }

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -133,6 +133,11 @@ pub enum DanceTestStep {
     VerifyRelationshipAnchoring {
         description: String,
     },
+    VerifySpaceMembership {
+        anchor_token: TestReference,
+        expected: SpaceMembershipExpectation,
+        description: String,
+    },
     VerifyCoreSchemaDescriptorSubtypes {
         description: String,
     },
@@ -200,6 +205,17 @@ pub enum DanceTestStep {
         expected_error: Option<HolonErrorKind>,
         description: String,
     },
+}
+
+/// What a `VerifySpaceMembership` step asserts about the current space's `Owns` collection.
+///
+/// `ExactKeys` is the precise assertion, usable when the fixture owns every holon in the space.
+/// `ExactCount` is for schema-backed fixtures, where naming ~200 loader-committed members would
+/// swamp the assertion it is trying to make.
+#[derive(Clone, Debug)]
+pub enum SpaceMembershipExpectation {
+    ExactKeys(Vec<MapString>),
+    ExactCount(MapInteger),
 }
 
 impl core::fmt::Display for DanceTestStep {
@@ -305,6 +321,14 @@ impl core::fmt::Display for DanceTestStep {
             DanceTestStep::VerifyRelationshipAnchoring { description } => {
                 write!(f, "{description}")
             }
+            DanceTestStep::VerifySpaceMembership { expected, description, .. } => match expected {
+                SpaceMembershipExpectation::ExactKeys(keys) => {
+                    write!(f, "{description} (expecting exactly {} member(s))", keys.len())
+                }
+                SpaceMembershipExpectation::ExactCount(count) => {
+                    write!(f, "{description} (expecting {} member(s))", count.0)
+                }
+            },
             DanceTestStep::VerifyCoreSchemaDescriptorSubtypes { description } => {
                 write!(f, "{description}")
             }

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -58,6 +58,7 @@ use execution_steps::new_holon_executor::execute_new_holon;
 use execution_steps::query_relationships_executor::execute_query_relationships;
 use execution_steps::remove_properties_executor::execute_remove_properties;
 use execution_steps::remove_related_holon_executor::execute_remove_related_holons;
+use execution_steps::space_membership_executor::execute_verify_space_membership;
 use execution_steps::stage_new_from_clone_executor::execute_stage_new_from_clone;
 use execution_steps::stage_new_holon_executor::execute_stage_new_holon;
 use execution_steps::stage_new_version_executor::execute_stage_new_version;
@@ -76,6 +77,7 @@ use fixture_cases::load_holons_internal_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
 use fixture_cases::simple_create_holon_fixture::*;
+use fixture_cases::space_membership_fixture::*;
 use fixture_cases::stage_new_from_clone_fixture::*;
 use fixture_cases::stage_new_version_fixture::*;
 use fixture_cases::transaction_lifecycle_fixture::*;
@@ -118,6 +120,7 @@ use holons_prelude::prelude::*;
 #[case::simple_add_related_holon_test(simple_add_remove_related_holons_fixture())]
 #[case::ergonomic_add_remove_properties_test(ergonomic_add_remove_properties_fixture())]
 #[case::ergonomic_add_remove_related_holons_test(ergonomic_add_remove_related_holons_fixture())]
+#[case::space_membership_test(space_membership_fixture())]
 #[case::stage_new_from_clone_test(stage_new_from_clone_fixture())]
 #[case::stage_new_version_test(stage_new_version_fixture())]
 #[case::load_holons_internal_test(loader_incremental_fixture())]
@@ -276,6 +279,14 @@ async fn run_dance_test_case(mut test_case: DancesTestCase) {
             }
             DanceTestStep::VerifyRelationshipAnchoring { .. } => {
                 execute_verify_relationship_anchoring(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifySpaceMembership { anchor_token, expected, .. } => {
+                execute_verify_space_membership(
+                    &mut test_execution_state,
+                    anchor_token.clone(),
+                    expected.clone(),
+                )
+                .await
             }
             DanceTestStep::VerifyCoreSchemaDescriptorSubtypes { .. } => {
                 execute_verify_core_schema_descriptor_subtypes(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/mod.rs
+++ b/tests/sweetests/tests/execution_steps/mod.rs
@@ -17,6 +17,7 @@ pub mod print_database_executor;
 pub mod query_relationships_executor;
 pub mod remove_properties_executor;
 pub mod remove_related_holon_executor;
+pub mod space_membership_executor;
 pub mod stage_new_from_clone_executor;
 pub mod stage_new_holon_executor;
 pub mod stage_new_version_executor;

--- a/tests/sweetests/tests/execution_steps/space_membership_executor.rs
+++ b/tests/sweetests/tests/execution_steps/space_membership_executor.rs
@@ -1,0 +1,134 @@
+use holons_prelude::prelude::*;
+use holons_test::{ResolveBy, SpaceMembershipExpectation, TestExecutionState, TestReference};
+use pretty_assertions::assert_eq;
+use tracing::info;
+use type_names::CoreRelationshipTypeName;
+
+/// Verifies holon space membership by traversing the persisted relationship graph.
+///
+/// No index is involved at any point. The space is reached by following `anchor_token`'s
+/// `OwnedBy`, so this asserts the membership graph on its own terms — `GetAllHolons` still reads
+/// `AllHolonNodes` here, and cannot even be called after a delete, because the index still lists
+/// the deleted holon and resolving it fails.
+///
+/// Both directions are checked, because commit writes them as a pair and a half-written pair is
+/// the failure worth catching:
+///
+/// - the space's `Owns` collection holds exactly `expected_member_keys`, and
+/// - every member's `OwnedBy` points back at that same space, with cardinality 1.
+///
+/// The two sides are read differently, and deliberately. `OwnedBy` is a *declared* name, so
+/// `related_holons` resolves it on an undescribed holon. `Owns` is its *inverse*, and the space
+/// anchor carries no `DescribedBy` for that resolution to go through — a targeted
+/// `related_holons(Owns)` comes back empty even when the link is present. `all_related_holons` is
+/// descriptor-unaware and expands the SmartLinks directly, which is what this assertion wants.
+pub async fn execute_verify_space_membership(
+    state: &mut TestExecutionState,
+    anchor_token: TestReference,
+    expected: SpaceMembershipExpectation,
+) {
+    let context =
+        state.open_assertion_context("verify_space_membership").await.unwrap_or_else(|error| {
+            panic!("verify_space_membership: failed to open assertion transaction: {error:?}")
+        });
+
+    // Reach the space by following the anchor's own membership edge.
+    let anchor: HolonReference = state
+        .resolve_execution_reference(&context, ResolveBy::Expected, &anchor_token)
+        .expect("verify_space_membership: failed to resolve the anchor holon");
+
+    let anchor_owners = anchor
+        .related_holons(CoreRelationshipTypeName::OwnedBy)
+        .expect("verify_space_membership: failed to read the anchor's OwnedBy");
+    let space_reference = {
+        let owners = anchor_owners.read().expect("verify_space_membership: OwnedBy read lock");
+        let members = owners.get_members();
+        assert_eq!(
+            1,
+            members.len(),
+            "the anchor holon must have exactly one owner, got {}",
+            members.len()
+        );
+        members[0].clone()
+    };
+
+    let space_id = space_reference.holon_id().expect("verify_space_membership: space holon_id");
+
+    // ---- space --Owns--> members -------------------------------------------------------------
+    let owns_name = CoreRelationshipTypeName::Owns.as_relationship_name();
+    let space_relationships = space_reference
+        .all_related_holons()
+        .expect("verify_space_membership: failed to read the space's relationships")
+        .iter();
+
+    let members: Vec<HolonReference> = space_relationships
+        .into_iter()
+        .find(|(name, _)| *name == owns_name)
+        .map(|(_, collection)| {
+            collection
+                .read()
+                .expect("verify_space_membership: Owns read lock")
+                .get_members()
+                .to_vec()
+        })
+        .unwrap_or_default();
+
+    match &expected {
+        SpaceMembershipExpectation::ExactKeys(expected_member_keys) => {
+            let mut actual_keys: Vec<String> = members
+                .iter()
+                .map(|member| {
+                    member
+                        .key()
+                        .expect("verify_space_membership: failed to read an Owns member key")
+                        .expect("verify_space_membership: an Owns member has no key")
+                        .0
+                })
+                .collect();
+            actual_keys.sort();
+
+            let mut expected_keys: Vec<String> =
+                expected_member_keys.iter().map(|key| key.0.clone()).collect();
+            expected_keys.sort();
+
+            assert_eq!(
+                expected_keys, actual_keys,
+                "space Owns membership did not match expectations"
+            );
+        }
+        SpaceMembershipExpectation::ExactCount(expected_member_count) => {
+            assert_eq!(
+                expected_member_count.0,
+                members.len() as i64,
+                "space Owns membership count did not match expectations"
+            );
+        }
+    }
+
+    // ---- each member --OwnedBy--> the same space ---------------------------------------------
+    for member in &members {
+        let member_key = member.key().unwrap().unwrap();
+
+        let owned_by_collection =
+            member.related_holons(CoreRelationshipTypeName::OwnedBy).unwrap_or_else(|error| {
+                panic!("verify_space_membership: OwnedBy read failed for {member_key:?}: {error:?}")
+            });
+        let owned_by =
+            owned_by_collection.read().expect("verify_space_membership: OwnedBy read lock");
+        let owners = owned_by.get_members();
+
+        assert_eq!(
+            1,
+            owners.len(),
+            "expected exactly one owner for {member_key:?} (OwnedBy is 1..1), got {}",
+            owners.len()
+        );
+        assert_eq!(
+            space_id,
+            owners[0].holon_id().expect("verify_space_membership: owner holon_id"),
+            "{member_key:?} is owned by a different holon than the current space",
+        );
+    }
+
+    info!("Success! Space membership matched for {} member(s)", members.len());
+}

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -13,6 +13,7 @@ pub mod setup_book_and_authors_fixture;
 pub mod simple_add_remove_properties_fixture;
 pub mod simple_add_remove_related_holons_fixture;
 pub mod simple_create_holon_fixture;
+pub mod space_membership_fixture;
 pub mod stage_new_from_clone_fixture;
 pub mod stage_new_version_fixture;
 pub mod transaction_lifecycle_fixture;

--- a/tests/sweetests/tests/fixture_cases/space_membership_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/space_membership_fixture.rs
@@ -1,0 +1,108 @@
+//! Holon space membership across the holon lifecycle (Storage SL5b-V1).
+//!
+//! Every published lineage acquires `OwnedBy → current HolonSpace`, and commit materializes the
+//! reciprocal `Owns` SmartLink on the space. This fixture pins that across the three lifecycle
+//! events this fixture can reach without a loaded schema:
+//!
+//! - **create** — a committed holon becomes a member, and an independent clone becomes a member in
+//!   its own right;
+//! - **delete** — membership is retracted in both directions.
+//!
+//! Assertions go through `VerifySpaceMembership`, which traverses `Owns` / `OwnedBy` directly.
+//! `GetAllHolons` is deliberately not used: it still reads the `AllHolonNodes` index at this
+//! point, so asserting through it would prove nothing about the membership graph.
+
+use holons_prelude::prelude::*;
+use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
+use rstest::*;
+use std::collections::BTreeMap;
+
+#[fixture]
+pub fn space_membership_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit {
+        mut test_case,
+        fixture_context,
+        mut fixture_holons,
+        fixture_bindings: _fixture_bindings,
+    } = TestCaseInit::new(
+        "Holon Space Membership Testcase",
+        "Assert OwnedBy/Owns membership is created on publication, inherited (not duplicated) by \
+         a new version, and retracted on delete — all through ordinary relationship traversal.",
+    );
+
+    // ── Create ─────────────────────────────────────────────────────────────────
+    let book_key = MapString("membership:book".to_string());
+    let book_transient = fixture_context.mutation().new_holon(Some(book_key.clone()))?;
+    let mut book_properties = BTreeMap::new();
+    book_properties.insert("title".to_property_name(), "Owned Book".to_base_value());
+
+    let book_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        book_transient,
+        book_properties,
+        Some(book_key.clone()),
+        None,
+        Some("Creating book holon...".to_string()),
+    )?;
+    let staged_book = test_case.add_stage_holon_step(
+        &mut fixture_holons,
+        book_token,
+        None,
+        Some("Staging book holon...".to_string()),
+    )?;
+    test_case.add_commit_step(&mut fixture_holons, ExpectedCommitStatus::Complete, None, None)?;
+
+    test_case.add_verify_space_membership_step(
+        staged_book.clone(),
+        vec![book_key.clone()],
+        Some("Publishing a lineage makes it an owned member".to_string()),
+    )?;
+
+    // ── Independent clone — a new lineage, owned in its own right ──────────────
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin new transaction before cloning".to_string()),
+    )?;
+    let clone_key = MapString("membership:book-clone".to_string());
+    let cloned_book = test_case.add_stage_new_from_clone_step(
+        &mut fixture_holons,
+        staged_book.clone(),
+        clone_key.clone(),
+        None,
+        Some("Cloning the book into an independent lineage...".to_string()),
+    )?;
+    test_case.add_commit_step(&mut fixture_holons, ExpectedCommitStatus::Complete, None, None)?;
+
+    test_case.add_verify_space_membership_step(
+        staged_book.clone(),
+        vec![book_key.clone(), clone_key.clone()],
+        Some("An independent clone is owned in its own right".to_string()),
+    )?;
+
+    // The version-producing leg lives in `stage_new_version_fixture` instead: staging a new
+    // version stages `Predecessor`, whose inverse is resolved through the source holon's
+    // `DescribedBy`, so it requires a described holon. That fixture is schema-backed; this one is
+    // deliberately not, so that membership is shown to work without any schema loaded.
+
+    // ── Delete — membership retracted in both directions ───────────────────────
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin new transaction before delete".to_string()),
+    )?;
+    test_case.add_delete_holon_step(
+        &mut fixture_holons,
+        cloned_book,
+        None,
+        Some("Deleting the cloned holon...".to_string()),
+    )?;
+
+    test_case.add_verify_space_membership_step(
+        staged_book,
+        vec![book_key],
+        Some("Deleting a holon retracts its membership".to_string()),
+    )?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}


### PR DESCRIPTION

## Summary

Every published lineage acquires `OwnedBy → current HolonSpace`; commit materializes the `Owns`
inverse on the space. Membership is queryable by ordinary traversal. **`GetAllHolons` is untouched**
— it still reads `AllHolonNodes`. No consumer-visible behavior change.

## Changes

| File | Change |
| --- | --- |
| `commit_functions.rs` | `stage_space_membership`, called from `commit_holon`'s `ForCreate` arm *after* `persist_holon` so the new lineage's id is available to the self-ownership guard. Warns rather than skipping silently when no space is bound. |
| `staged.rs` | `RelationshipCommitScope::FullExceptMembership` + setter, so a version-producing commit doesn't re-anchor membership; `OwnedBy` ordered first under `Full` so a failing user relationship can't preempt it. |
| `inverse_resolution.rs` | `OwnedBy → Owns` short-circuit. `resolve_inverse` goes through the source's `DescribedBy`, which undescribed holons and the first core-schema load don't have. |
| `guest_holon_service.rs` | `retract_space_membership` on delete. **Reader left on `AllHolonNodes`** — the repoint is V2. |
| `execution_reference.rs` | `assert_saved_content_eq` treats `OwnedBy` as infrastructure-supplied, not fixture-authored. |
| harness (`test_steps`, `adders`, `dance_tests`, 2 new files) | `VerifySpaceMembership` step + executor + `space_membership_fixture`. |

## Tests

`space_membership_fixture` asserts create, independent clone, and delete — exact member keys, both
directions (`Owns` on the space, `OwnedBy` back to it). Confirmed to fail with the stamp disabled.

Full `npm run sweetest` exit 0: 63 tests, 0 failed, 2 ignored, audit passed. `holons_core` 315.
All three workspace checks clean.

**Self-containment check passes:** zero churn in the count fixtures, `constants.rs`, or any
contract/SDK/TDL doc. All of that is V2.

## Three notes

1. **Version leg deferred.** Staging a new version stages `Predecessor`, whose inverse resolves
   through `DescribedBy` — so version-producing commits need a *described* holon, and this fixture
   is deliberately schema-free. `add_verify_space_membership_count_step` exists for schema-backed
   fixtures; wiring it into `stage_new_version_fixture` would close this. The `staged.rs` unit test
   covers the mechanism meanwhile.

2. **Two pre-existing bugs found, not caused by V1.** `related_holons(Owns)` on the space returns
   empty even when the link exists (inverse name, anchor has no `DescribedBy`); `all_related_holons()`
   finds it. And `GetAllHolons` *errors* after a delete, because the index still lists the deleted
   holon — the same limitation that had `delete_holon_fixture`'s assertion commented out. V2 fixes
   the second by construction. The executor sidesteps both by deriving the space from a member's
   `OwnedBy`.


## Open

The `Owns` fan-in cost is still unmeasured — every inverse link is based on the space holon, and
`put_smartlink` scans that base, so a 191-holon schema load is ~O(n²) tag decodes. Belongs to V1
since this is where the writes are introduced. Baseline by checking out the parent commit, not by
stashing.
