### PR TITLE
642 - SL5b-V2 — Ownership-based whole-space discovery

### DIFF
--- a/generated/json-imports/commands/schema.json
+++ b/generated/json-imports/commands/schema.json
@@ -896,7 +896,7 @@
         "TypeNamePlural": "GetAllHolonsCommands",
         "DisplayName": "Get All Holons Command",
         "DisplayNamePlural": "Get All Holons Commands",
-        "Description": "Returns all holons visible in the active transaction."
+        "Description": "Returns the holons owned by the active transaction's holon space."
       },
       "relationships": [
         {

--- a/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/guest_holon_service.rs
@@ -19,8 +19,8 @@ use holons_guest_integrity::{
 use crate::get_holon_by_path;
 use crate::guest_shared_objects::commit_functions;
 use crate::persistence_layer::{
-    delete_holon_node, delete_smartlink, expand_all_from_source, expand_from_source,
-    get_all_holon_ids, get_holon, index_local_holon_space, persist_holon, saved_holon_from_stored,
+    delete_holon_node, delete_smartlink, expand_all_from_source, expand_from_source, get_holon,
+    index_local_holon_space, persist_holon, saved_holon_from_stored,
 };
 use base_types::MapString;
 use core_types::{HolonError, HolonId, HolonWriteRequest, SmartLink};
@@ -326,19 +326,30 @@ impl HolonServiceApi for GuestHolonService {
         Ok(collection)
     }
 
+    /// Retrieves the holons owned by the transaction's current `HolonSpace`.
+    ///
+    /// Whole-space discovery is ordinary graph traversal: every committed lineage carries
+    /// `OwnedBy → HolonSpace`, and commit materializes the reciprocal `Owns` SmartLink on the
+    /// space, so the space's `Owns` collection *is* the membership list. Members are lineage
+    /// roots, since membership is not re-emitted for later versions.
+    ///
+    /// The space anchor is not a member of its own collection; callers that need it use
+    /// `TransactionContext::get_space_holon()`.
     fn get_all_holons_internal(
         &self,
         context: &Arc<TransactionContext>,
     ) -> Result<HolonCollection, HolonError> {
-        let mut collection = HolonCollection::new_existing();
-        let holon_ids = get_all_holon_ids()?;
-        let mut holon_references = Vec::new();
-        for id in holon_ids {
-            holon_references.push(self.mint_smart_reference(context, id, None)?);
-        }
-        collection.add_references(holon_references)?;
+        // No space yet means nothing can belong to one. This is reachable before bootstrap has
+        // anchored the local space, where an empty membership list is the right answer.
+        let Some(space_reference) = context.get_space_holon()? else {
+            return Ok(HolonCollection::new_existing());
+        };
 
-        Ok(collection)
+        self.fetch_related_holons_internal(
+            context,
+            &space_reference.holon_id()?,
+            &CoreRelationshipTypeName::Owns.as_relationship_name(),
+        )
     }
 
     /// Execute a Holon import from a `HolonLoadSet`.

--- a/host/crates/map_commands_contract/src/transaction_command.rs
+++ b/host/crates/map_commands_contract/src/transaction_command.rs
@@ -54,6 +54,8 @@ pub enum TransactionAction {
 
     // ── Lookup actions (LookupFacade) ────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
+    ///
+    /// The current HolonSpace's `Owns` members; the space anchor itself is not included.
     GetAllHolons,
 
     /// `get_staged_holon_by_base_key(key)` → `StagedReference`

--- a/host/crates/map_commands_wire/src/transaction_wire.rs
+++ b/host/crates/map_commands_wire/src/transaction_wire.rs
@@ -56,6 +56,8 @@ pub enum TransactionActionWire {
 
     // ── Lookup actions ───────────────────────────────────────────────
     /// `get_all_holons()` → `HolonCollection`
+    ///
+    /// The current HolonSpace's `Owns` members; the space anchor itself is not included.
     GetAllHolons,
 
     /// `get_staged_holon_by_base_key(key)` → `StagedReference`

--- a/host/map-sdk/src/internal/commands/transaction.ts
+++ b/host/map-sdk/src/internal/commands/transaction.ts
@@ -233,7 +233,9 @@ export function loadHolons(
 }
 
 /**
- * Return the full holon collection visible to the transaction.
+ * Return the holons owned by the transaction's current HolonSpace.
+ *
+ * These are the space's `Owns` members; the space holon itself is not one of them.
  */
 export function getAllHolons(
   txId: TxId,

--- a/schema-src/commands/schema.tdl
+++ b/schema-src/commands/schema.tdl
@@ -360,7 +360,7 @@ holon GetAllHolons.CommandType {
   type MetaCommandType.MetaHolonType
   extends CommandType.HolonType
   header {
-    description: "Returns all holons visible in the active transaction."
+    description: "Returns the holons owned by the active transaction's holon space."
     display_name: "Get All Holons Command"
     display_plural: "Get All Holons Commands"
     plural: "GetAllHolonsCommands"

--- a/shared_crates/holon_dance_builders/src/get_all_holons_dance.rs
+++ b/shared_crates/holon_dance_builders/src/get_all_holons_dance.rs
@@ -2,7 +2,7 @@ use base_types::MapString;
 use core_types::HolonError;
 use holons_core::dances::{DanceRequest, DanceType, RequestBody};
 
-/// Builds a DanceRequest for retrieving all holons from the persistent store
+/// Builds a DanceRequest for retrieving the holons owned by the current HolonSpace
 pub fn build_get_all_holons_dance_request() -> Result<DanceRequest, HolonError> {
     let body = RequestBody::new();
     Ok(DanceRequest::new(MapString("get_all_holons".to_string()), DanceType::Standalone, body))

--- a/shared_crates/holons_core/src/dances/holon_dance_adapter.rs
+++ b/shared_crates/holons_core/src/dances/holon_dance_adapter.rs
@@ -86,7 +86,9 @@ pub fn delete_holon_dance(
     }
 }
 
-/// Get all holons from the persistent store
+/// Get the holons owned by the current HolonSpace.
+///
+/// Returns the space's `Owns` members — lineage roots, not the space anchor itself.
 ///
 /// *DanceRequest:*
 /// - dance_name: "get_all_holons"

--- a/shared_crates/holons_core/src/reference_layer/holon_service_api.rs
+++ b/shared_crates/holons_core/src/reference_layer/holon_service_api.rs
@@ -59,7 +59,11 @@ pub trait HolonServiceApi: Debug + Any + Send + Sync {
         relationship_name: &RelationshipName,
     ) -> Result<HolonCollection, HolonError>;
 
-    /// Retrieves all persisted Holons, as a HolonCollection
+    /// Retrieves the holons owned by the current HolonSpace, as a HolonCollection.
+    ///
+    /// Membership is the space's `Owns` collection, so members are lineage roots and the space
+    /// anchor is not among them — callers needing the anchor use
+    /// `TransactionContext::get_space_holon()`.
     fn get_all_holons_internal(
         &self,
         context: &Arc<TransactionContext>,

--- a/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
+++ b/tests/sweetests/src/harness/fixtures_support/fixture_holons.rs
@@ -1,5 +1,5 @@
 use crate::harness::fixtures_support::{TestHolonState, TestReference};
-use base_types::MapInteger;
+use base_types::{MapInteger, MapString};
 use core_types::{HolonError, TemporaryId};
 use derive_new::new;
 use holons_core::HolonReference;
@@ -359,9 +359,28 @@ impl FixtureHolons {
     /// Mint tokens with expected state Saved.
     /// Returned tokens are *only* used for resolution of expected during the execution, and never passed to an add step.
     pub fn commit(&mut self) -> Result<Vec<TestReference>, HolonError> {
+        self.commit_excluding_keys(&[])
+    }
+
+    /// Advances staged heads to Saved, except for holons whose key is listed in `unsaved_keys`.
+    ///
+    /// Ordinary `commit()` assumes every staged holon publishes, which is true even for an
+    /// `Incomplete` commit whose *relationship* pass failed. It is not true when a holon fails to
+    /// publish in the node pass: that holon stays staged and the transaction stays open, so its
+    /// fixture head must stay staged too, or later steps resolve a Saved realization that was
+    /// never recorded.
+    pub fn commit_excluding_keys(
+        &mut self,
+        unsaved_keys: &[MapString],
+    ) -> Result<Vec<TestReference>, HolonError> {
         let mut saved_tokens = Vec::new();
 
         for holon in self.holons.clone().values() {
+            let head_key = holon.head_snapshot.snapshot().key().unwrap_or(None);
+            if head_key.is_some_and(|key| unsaved_keys.contains(&key)) {
+                debug!("Holon is expected not to publish, leaving it staged: {:#?}", holon);
+                continue;
+            }
             match holon.head_snapshot.state() {
                 TestHolonState::Staged => {
                     let snapshot = holon.head_snapshot.snapshot().clone().clone_holon()?;
@@ -429,7 +448,10 @@ impl FixtureHolons {
                 // (e.g. by a schema load); they contribute to no fixture counts.
                 TestHolonState::SavedLookup => {}
                 TestHolonState::Abandoned => counts.staged -= 1,
-                TestHolonState::Deleted => counts.saved -= 1,
+                // A deleted holon is no longer a DB row. Its head no longer counts as Saved, so
+                // contributing nothing is the whole of its removal — subtracting again would
+                // charge the deletion twice.
+                TestHolonState::Deleted => {}
             }
         }
         counts
@@ -441,8 +463,12 @@ impl FixtureHolons {
     pub fn count_staged(&self) -> MapInteger {
         MapInteger(self.counts().staged)
     }
+    /// Saved holons the DB is expected to report.
+    ///
+    /// No allowance for the LocalHolonSpace anchor: whole-space discovery reads the space's
+    /// `Owns` members, and the anchor is not a member of its own collection.
     pub fn count_saved(&self) -> MapInteger {
-        MapInteger(self.counts().saved + 1) // Accounts for initial LocalHolonSpace
+        MapInteger(self.counts().saved)
     }
 }
 

--- a/tests/sweetests/src/harness/helpers/constants.rs
+++ b/tests/sweetests/src/harness/helpers/constants.rs
@@ -15,7 +15,8 @@ pub const PUBLISHER_KEY: &str = "Publishing Company";
 pub const BOOK_TO_PERSON_RELATIONSHIP: &str = "AuthoredBy";
 pub const PUBLISHED_BY: &str = "PublishedBy";
 pub const EDITOR_FOR: &str = "EditorFor";
-pub const ENSURE_DB_EMPTY: &str = "Ensuring DB is 'empty' (only contains initial LocalHolonSpace).";
+pub const ENSURE_DB_EMPTY: &str =
+    "Ensuring DB is empty (the LocalHolonSpace anchor is not one of its own Owns members).";
 pub const BOOK_DESCRIPTOR_KEY: &str = "Book.HolonType";
 pub const PERSON_DESCRIPTOR_KEY: &str = "Person.HolonType";
 pub const SCHEMA_TYPE_KEY: &str = "Schema.HolonType";

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -531,6 +531,32 @@ impl DancesTestCase {
         Ok(())
     }
 
+    /// Commit step for a commit in which some staged holons are expected not to publish.
+    ///
+    /// `unsaved_keys` names the holons whose node write is expected to fail, so their fixture heads
+    /// stay staged and remain resolvable for repair steps afterwards. Ordinary
+    /// [`Self::add_commit_step`] assumes every staged holon publishes.
+    pub fn add_commit_step_expecting_unsaved(
+        &mut self,
+        fixture_holons: &mut FixtureHolons,
+        unsaved_keys: &[MapString],
+        expected_status: ExpectedCommitStatus,
+        expected_error: Option<HolonErrorKind>,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description = description.unwrap_or_else(|| "Commit".to_string());
+        let saved_tokens = fixture_holons.commit_excluding_keys(unsaved_keys)?;
+        self.steps.push(DanceTestStep::Commit {
+            saved_tokens,
+            expected_status,
+            expected_error,
+            description,
+        });
+
+        Ok(())
+    }
+
     // Special step that creates a new 'freshly minted' TransientReference,
     // i.e. the first snapshot for a FixtureHolon.
     pub fn add_new_holon_step(

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -74,6 +74,7 @@ use fixture_cases::load_generated_core_schema_fixture::*;
 use fixture_cases::load_generated_query_schema_fixture::*;
 use fixture_cases::load_generated_validation_schema_fixture::*;
 use fixture_cases::load_holons_internal_fixture::*;
+use fixture_cases::partial_commit_membership_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
 use fixture_cases::simple_create_holon_fixture::*;
@@ -115,6 +116,7 @@ use holons_prelude::prelude::*;
 #[rstest]
 #[case::simple_undescribed_create_holon_test(simple_create_holon_fixture())]
 #[case::delete_holon(delete_holon_fixture())]
+#[case::partial_commit_membership_test(partial_commit_membership_fixture())]
 #[case::simple_abandon_staged_changes_test(simple_abandon_staged_changes_fixture())]
 #[case::simple_add_remove_properties_test(simple_add_remove_properties_fixture())]
 #[case::simple_add_related_holon_test(simple_add_remove_related_holons_fixture())]

--- a/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
@@ -67,9 +67,13 @@ pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
         Some("Attempting invalid delete...".to_string()),
     )?;
 
-    // TODO: more robust handling of the implication of deletes on links needs to be implemented before this step will work
-    // // ADD STEP:  ENSURE DATABASE COUNT
-    // test_case.add_ensure_database_count_step( fixture_holons.count_saved())?;
+    // ADD STEP:  ENSURE DATABASE COUNT
+    // A deleted holon must not remain discoverable: delete retracts its space membership, so
+    // `count_saved()` (which nets out the deletion) is the count whole-space discovery reports.
+    test_case.add_ensure_database_count_step(
+        fixture_holons.count_saved(),
+        Some("Deleted holon is no longer an owned member".to_string()),
+    )?;
 
     // Finalize
     test_case.finalize(&fixture_context, &fixture_holons)?;

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -123,7 +123,7 @@ pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, Holon
         Some("Commit described Book/Person instances".to_string()),
     )?;
 
-    // DB = fixture-saved holons (incl. space baseline) + loader-committed schema holons.
+    // DB = fixture-saved holons + loader-committed schema holons (no space anchor).
     let expected_db_count = MapInteger(
         fixture_holons.count_saved().0
             + CORE_SCHEMA_METRICS.committed

--- a/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Fixture Progression (combined)
 //!
-//! 1. **Empty bundle** → `UnprocessableEntity`; database remains baseline (only Space holon)
+//! 1. **Empty bundle** → `UnprocessableEntity`; database remains baseline (no owned holons)
 //! 2. **Nodes-only undescribed bundle** → staged, then skipped during default population
 //! 3. **Undescribed relationship bundle** → relationship staged, then skipped during default population
 //! 4. **Multi-bundle duplicate-key set** (same LoaderHolon key in two files) → `UnprocessableEntity`; DB unchanged
@@ -193,7 +193,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, mut fixture_bindings } =
         TestCaseInit::new(
             "Loader Incremental Fixture",
-            "1) Ensure DB starts with only the Space holon,\n\
+            "1) Ensure DB starts with no holons owned by the space,\n\
          2) Load a HolonLoadSet containing a single empty HolonLoaderBundle and assert the\n\
             loader short-circuits cleanly (no holons staged/committed, DB unchanged),\n\
          3) Load a nodes-only HolonLoadSet (Book/Person/Publisher LoaderHolons, no relationships)\n\
@@ -206,8 +206,8 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
             leaves the DB unchanged, and surfaces per-file provenance via error holons.\n",
         );
 
-    // A) Ensure DB starts with only the Space holon.
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    // A) Ensure DB starts with no owned holons.
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // B) Empty bundle → expect UnprocessableEntity and no DB change.
     let empty_bundle = build_empty_bundle(&fixture_context, "Bundle.Empty.1")?;
@@ -226,7 +226,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(0), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // C) Nodes-only undescribed bundle -> staged, then rejected before commit.
     let nodes_only_keys = &["Book.NodesOnly.1", "Person.NodesOnly.1", "Publisher.NodesOnly.1"];
@@ -247,7 +247,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(n_nodes as i64), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before declared-link load".to_string()),
@@ -277,7 +277,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(node_count as i64), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before duplicate-key load".to_string()),
@@ -333,7 +333,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // DB must remain unchanged after duplicate-key failure.
-    test_case.add_ensure_database_count_step(MapInteger(1), None)?;
+    test_case.add_ensure_database_count_step(MapInteger(0), None)?;
 
     // Finalize
     test_case.finalize(&fixture_context, &fixture_holons)?;

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -9,6 +9,7 @@ pub mod load_generated_query_schema_fixture;
 pub mod load_generated_validation_schema_fixture;
 pub mod load_holons_internal_fixture;
 pub mod load_inverse_oriented_book_person_instances_fixture;
+pub mod partial_commit_membership_fixture;
 pub mod setup_book_and_authors_fixture;
 pub mod simple_add_remove_properties_fixture;
 pub mod simple_add_remove_related_holons_fixture;

--- a/tests/sweetests/tests/fixture_cases/partial_commit_membership_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/partial_commit_membership_fixture.rs
@@ -1,0 +1,143 @@
+//! Membership across an incomplete commit and the follow-up that completes it.
+//!
+//! A Pass 1 failure does not finalize the transaction: `should_transition_from_commit_response`
+//! returns `false` for `Incomplete`, so the transaction stays open and its nursery is retained.
+//! A holon that did publish is held as a staged holon in `Committed(saved_id)` state, and its
+//! relationships are persisted by the *next* complete commit, which reaches it through that
+//! retained staged reference.
+//!
+//! Whole-space discovery is a finalized persisted-membership view, not the recovery surface for a
+//! partially completed transaction, so this fixture asserts both halves of that contract:
+//!
+//! 1. After `Incomplete`, the published holon is **not** yet an owned member — `GetAllHolons` does
+//!    not expose unfinished transaction state.
+//! 2. After the follow-up complete commit, it **is**.
+//!
+//! Assertion 2 is also what proves the holon stayed addressable through its staged reference:
+//! nothing else can write its membership. Pass 1 treats it as `NoAction` (already `Committed`), so
+//! the only route to its `OwnedBy` collection is `RelationshipCommitSource::from_committed_staged_holon`
+//! resolving the reference the nursery retained. Had that been dropped, the count would stay 0.
+//!
+//! Shape: two holons staged together. One carries more properties than PVL permits, so its
+//! `PublishRoot` is rejected and the commit reports `Incomplete` before the relationship pass runs.
+//! It is then abandoned and the transaction committed again.
+
+use holons_prelude::prelude::*;
+use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
+use rstest::*;
+use std::collections::BTreeMap;
+
+/// One more than `shared_validation::MAX_PROPERTY_COUNT`, so `preflight_holon_node` rejects the
+/// node before it is authored. Any Pass 1 failure would do; this one needs no oversized payload.
+const OVER_PROPERTY_LIMIT: usize = 257;
+
+#[fixture]
+pub fn partial_commit_membership_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit {
+        mut test_case,
+        fixture_context,
+        mut fixture_holons,
+        fixture_bindings: _fixture_bindings,
+    } = TestCaseInit::new(
+        "Partial Commit Membership Testcase",
+        "Stage one publishable holon and one that PVL rejects; assert the publishable one is not \
+         an owned member while the commit is Incomplete, and becomes one once the transaction is \
+         completed.",
+    );
+
+    // Start from an empty space so the counts below are unambiguous.
+    test_case.add_ensure_database_count_step(
+        MapInteger(0),
+        Some("DB starts with no owned holons".to_string()),
+    )?;
+
+    // ── The holon that publishes ────────────────────────────────────────────────
+    let good_key = MapString("partial-commit:publishable".to_string());
+    let good_transient = fixture_context.mutation().new_holon(Some(good_key.clone()))?;
+    let mut good_properties = BTreeMap::new();
+    good_properties.insert("title".to_property_name(), "Publishable Holon".to_base_value());
+
+    let good_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        good_transient,
+        good_properties,
+        Some(good_key),
+        None,
+        Some("Creating the holon that will publish...".to_string()),
+    )?;
+    test_case.add_stage_holon_step(
+        &mut fixture_holons,
+        good_token,
+        None,
+        Some("Staging the holon that will publish...".to_string()),
+    )?;
+
+    // ── The holon that PVL rejects ──────────────────────────────────────────────
+    let bad_key = MapString("partial-commit:rejected".to_string());
+    let bad_transient = fixture_context.mutation().new_holon(Some(bad_key.clone()))?;
+    let mut bad_properties = BTreeMap::new();
+    for index in 0..OVER_PROPERTY_LIMIT {
+        bad_properties
+            .insert(format!("property-{index:03}").to_property_name(), "value".to_base_value());
+    }
+
+    let bad_token = test_case.add_new_holon_step(
+        &mut fixture_holons,
+        bad_transient,
+        bad_properties,
+        Some(bad_key.clone()),
+        None,
+        Some("Creating the holon that exceeds the PVL property limit...".to_string()),
+    )?;
+    let bad_staged_token = test_case.add_stage_holon_step(
+        &mut fixture_holons,
+        bad_token,
+        None,
+        Some("Staging the holon that will be rejected...".to_string()),
+    )?;
+
+    // Pass 1 fails for the over-limit holon, so the commit reports Incomplete and the
+    // relationship pass never runs.
+    test_case.add_commit_step_expecting_unsaved(
+        &mut fixture_holons,
+        &[bad_key.clone()],
+        ExpectedCommitStatus::Incomplete,
+        None,
+        Some("Committing both; expect Incomplete".to_string()),
+    )?;
+
+    // The transaction is not finished, so its published holon is not yet an owned member. A
+    // literal count rather than `count_saved()`: the fixture ledger advances every staged head to
+    // Saved on commit, which is right once the transaction completes but not while it is open.
+    test_case.add_ensure_database_count_step(
+        MapInteger(0),
+        Some("Incomplete commit is not exposed through whole-space discovery".to_string()),
+    )?;
+
+    // Repair the transaction by abandoning the holon that could not be published.
+    test_case.add_abandon_staged_changes_step(
+        &mut fixture_holons,
+        bad_staged_token,
+        None,
+        Some("Abandoning the rejected holon".to_string()),
+    )?;
+
+    // Pass 1 now reports NoAction for the already-published holon and Abandoned for the other, so
+    // the commit completes and the relationship pass persists membership from the retained
+    // staged reference.
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Committing again; expect Complete".to_string()),
+    )?;
+
+    test_case.add_ensure_database_count_step(
+        MapInteger(1),
+        Some("Completing the transaction makes the published holon an owned member".to_string()),
+    )?;
+
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
@@ -1,6 +1,6 @@
 use crate::fixture_cases::setup_undescribed_book_author_steps_with_context;
 use holons_prelude::prelude::*;
-use holons_test::harness::helpers::PUBLISHED_BY;
+use holons_test::harness::helpers::{ENSURE_DB_EMPTY, PUBLISHED_BY};
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 use rstest::*;
 use std::collections::BTreeMap;
@@ -32,7 +32,7 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     // Ensure DB count //
     test_case.add_ensure_database_count_step(
         fixture_holons.count_saved(),
-        Some("Ensuring DB is 'empty' (only contains initial LocalHolonSpace).".to_string()),
+        Some(ENSURE_DB_EMPTY.to_string()),
     )?;
 
     // Use helper function to stage Book, 2 Person, 1 Publisher Holon and AUTHORED_BY relationship

--- a/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
@@ -25,7 +25,7 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
             "Clone from transient, staged, and saved; mutate staged clones; assert counts+content",
         );
 
-    // Assert DB starts with 1 (space Holon)
+    // Assert DB starts empty (the space anchor does not own itself)
     test_case.add_ensure_database_count_step(
         fixture_holons.count_saved(),
         Some(ENSURE_DB_EMPTY.to_string()),

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -13,7 +13,8 @@ use holons_test::harness::helpers::{
 // TODO: add/remove relationships
 
 /// Expected DB count once core + Book/Person schemas are loaded: fixture-saved
-/// holons (incl. the LocalHolonSpace baseline) plus the loader-committed schema holons.
+/// holons plus the loader-committed schema holons. The LocalHolonSpace anchor is not
+/// counted — it is not a member of its own `Owns` collection.
 fn schema_backed_db_count(fixture_holons: &FixtureHolons) -> MapInteger {
     MapInteger(
         fixture_holons.count_saved().0


### PR DESCRIPTION


stacks on v1

## What it does

`get_all_holons_internal` reads the current space's `Owns` collection instead of the
`AllHolonNodes` index. `GetAllHolons`, the dance, the wire binding, and the TS SDK keep their
contracts. **One semantic change: the `LocalHolonSpace` anchor is no longer in the results**, so
every DB count drops by one.

## Changes

| File | Change |
| --- | --- |
| `guest_holon_service.rs` | `get_all_holons_internal` resolves the space and delegates to the existing `fetch_related_holons_internal` with `Owns`; empty collection when no space is bound. `get_all_holon_ids` import dropped — the index now has no reader. |
| `fixture_holons.rs` | `count_saved()` drops the `+ 1` anchor allowance (carries eight fixtures); `counts()` stops double-charging a `Deleted` holon; `commit_excluding_keys`. |
| `adders.rs` | `add_commit_step_expecting_unsaved` — `add_commit_step` advances *every* staged head to `Saved`, which is wrong when a holon fails to publish. |
| `constants.rs` + 6 count fixtures | corrected baselines and wording; `load_holons_internal_fixture`'s five `MapInteger(1)` → `MapInteger(0)`. |
| `delete_holon_fixture.rs` | post-delete count assertion **enabled** — it had been commented out with a TODO since it was written. |
| 7 contract docs + `schema.json` | all said "all persisted holons"; now the space's `Owns` members, anchor excluded. Generated JSON is a one-line diff. |
| `partial_commit_membership_fixture.rs` (new) | see below. |

## Tests

`partial_commit_membership_fixture` pins the discovery contract for an unfinished transaction:
stage two holons, one over `MAX_PROPERTY_COUNT` so its `PublishRoot` is rejected → commit
`Incomplete`, **count 0**; abandon it, commit again `Complete`, **count 1**. The second assertion is
also what proves the published holon stayed addressable through its retained staged reference —
nothing else can write its membership.

Every other count assertion became *exact* rather than approximate once the anchor allowance was
gone, so the existing fixtures now pin membership directly.

Full `npm run sweetest` exit 0: **64 tests** (dance_tests 21, up from V1's 20), 0 failed, 2 ignored,
audit passed. `holons_core` 315. All three workspace checks clean. `map-sdk` 245 tests + `tsc
--noEmit` — proof the wire contract did not move.

## Three notes

1. **Two files are touched by both slices and were merged, not overwritten.**
   `guest_holon_service.rs` (V1's `retract_space_membership` + V2's reader) and `adders.rs` (V1's
   two membership steps + V2's commit step). Both slices' code verified present in each.

2. **V1's files are not re-touched** — `commit_functions.rs`, `staged.rs`, `inverse_resolution.rs`,
   `execution_reference.rs`, `space_membership_fixture.rs` are absent from this diff, so V2's PR
   shows only V2 once V1 merges.

3. **The delete assertion could only be enabled here.** Under `AllHolonNodes` a deleted holon stayed
   indexed forever — worse, `GetAllHolons` *errored* after a delete, because resolving the dead
   entry fails. V2 fixes that by construction; V1's harness bug fix (`counts()`) is what makes the
   expected number correct.

## Open

Legacy count semantics changed: the anchor is no longer returned. Contained to sweetest fixtures —
no TS SDK test asserts a count and no production consumer counts results — but it is a real contract
change, and the reason this slice stands alone.

Lookup-by-key consumers (loader saved index, `errors.rs`) still fetch the whole collection to find
one holon. Unchanged here, and not a future query strategy — the stand-in #642 §9 already flags.
