### PR TITLE
Command TRU1 — Reference-Layer-to-Command Exposure True-Up  

### DIFF
--- a/host/crates/map_commands_contract/src/command_lifecycle_policy.rs
+++ b/host/crates/map_commands_contract/src/command_lifecycle_policy.rs
@@ -31,7 +31,8 @@ impl CommandLifecyclePolicy {
     /// Read-only policy for holon-scoped commands.
     ///
     /// Holon reads do not require an open transaction because references from
-    /// committed transactions remain alive and accessible.
+    /// committed transactions remain alive and accessible through their bound
+    /// archived context.
     pub const fn holon_read_only() -> Self {
         Self {
             mutation: MutationClassification::ReadOnly,

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -17,7 +17,8 @@ use holons_client::SessionReceptor;
 use session_receptor::{RecoveryStore, TransactionRecoveryStore};
 
 use map_commands_contract::{
-    MapCommand, MapResult, SpaceCommand, TransactionAction, TransactionCommand,
+    HolonAction, HolonCommand, MapCommand, MapResult, ReadableHolonAction, SpaceCommand,
+    TransactionAction, TransactionCommand,
 };
 
 use crate::{ExecutionPolicy, Runtime, RuntimeSession};
@@ -403,16 +404,40 @@ async fn delete_holon_command_returns_none() {
 async fn commit_command_returns_reference() {
     let runtime = build_test_runtime();
     let tx_id = begin_tx(&runtime).await;
+    let context = runtime.session().get_transaction(&tx_id).expect("transaction should exist");
 
     let result = runtime
         .execute_command(
-            tx_cmd(&runtime, &tx_id, TransactionAction::Commit),
+            MapCommand::Transaction(TransactionCommand {
+                context: Arc::clone(&context),
+                action: TransactionAction::Commit,
+            }),
             ExecutionPolicy::default(),
         )
         .await
         .expect("commit command should succeed");
 
-    assert!(matches!(result, MapResult::Reference(HolonReference::Transient(_))));
+    let response = match result {
+        MapResult::Reference(HolonReference::Transient(response)) => response,
+        other => panic!("expected Transient reference, got {:?}", other),
+    };
+
+    let read_result = runtime
+        .execute_command(
+            MapCommand::Holon(HolonCommand {
+                context,
+                target: HolonReference::Transient(response),
+                action: HolonAction::Read(ReadableHolonAction::GetKey),
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("committed-context read of the commit response should succeed");
+
+    assert!(matches!(
+        read_result,
+        MapResult::Value(BaseValue::StringValue(MapString(value))) if value == "commit-response"
+    ));
 }
 
 // ── Undo/redo handler tests ─────────────────────────────────────────


### PR DESCRIPTION
# Summary

Implements the code-side lifecycle characterization for [#666](https://github.com/evomimic/map-holons/issues/666): a `HolonReference` returned by a successful commit remains readable through its bound archived transaction context.

This is a deliberately narrow Commands True-Up slice. The authoritative documentation reconciliation is tracked on the companion `map-dev-docs` branch `30-docs-complete-commands-true-up-documentation-reconciliation`.

## Changes

- Clarify that holon-scoped read-only Commands do not require an open transaction when a retained bound context is available.
- Specify that committed-transaction references resolve through their bound archived context.
- Extend the commit-command runtime test to:
  - retain the transaction context used for commit;
  - extract the transient reference returned by commit; and
  - perform a post-commit `GetKey` read through that retained context.
- Assert that the returned reference exposes the expected materialized value.

## Testing

- Pre-push `npm run fmt:check` passed.
- Manual verification reported:
  - hApp build passed
  - host build passed
  - `npm test` passed
  - `npm start` passed
  - uploader successfully staged and committed 480 holons, created 2,035 links, and reported 0 errors

## Scope notes

- This PR does not alter reference binding, transaction archival, wire payloads, or IPC result shapes.
- It does not introduce descriptor-read Commands, SDK handles, qualified-relationship transport, or legacy-surface migrations.
- It provides the regression coverage for the resolved read-after-commit policy; the broader #666 documentation and follow-up decomposition remain separate work.

Part of #666.