### PR TITLE
feat(dahn): SN - Phase 0 -- PR1 -- add read-only holon inspection adapter per Issue 668

### DIFF
--- a/host/crates/map_commands_contract/src/holon_command.rs
+++ b/host/crates/map_commands_contract/src/holon_command.rs
@@ -48,6 +48,13 @@ impl HolonAction {
             HolonAction::Read(ReadableHolonAction::GetVersionedKey) => "get_versioned_key",
             HolonAction::Read(ReadableHolonAction::GetPropertyValue { .. }) => "get_property_value",
             HolonAction::Read(ReadableHolonAction::GetRelatedHolons { .. }) => "get_related_holons",
+            HolonAction::Read(ReadableHolonAction::GetHolonDescriptor) => "get_holon_descriptor",
+            HolonAction::Read(ReadableHolonAction::GetAvailableProperties) => {
+                "get_available_properties"
+            }
+            HolonAction::Read(ReadableHolonAction::GetAvailableRelationships) => {
+                "get_available_relationships"
+            }
             HolonAction::Write(_) => "holon_write",
         }
     }
@@ -84,6 +91,15 @@ pub enum ReadableHolonAction {
 
     /// `ReadableHolon::related_holons(name)` → `HolonCollection`
     GetRelatedHolons { name: RelationshipName },
+
+    /// `ReadableHolon::holon_descriptor()` → descriptor reference.
+    GetHolonDescriptor,
+
+    /// `ReadableHolon::available_properties()` → ordered descriptor collection.
+    GetAvailableProperties,
+
+    /// `ReadableHolon::available_relationships()` → qualified descriptors.
+    GetAvailableRelationships,
 }
 
 /// Mutating holon actions.

--- a/host/crates/map_commands_contract/src/map_result.rs
+++ b/host/crates/map_commands_contract/src/map_result.rs
@@ -3,7 +3,30 @@ use core_types::HolonId;
 use holons_core::core_shared_objects::transactions::TxId;
 use holons_core::core_shared_objects::HolonCollection;
 use holons_core::dances::DanceResponse;
+use holons_core::descriptors::{QualifiedRelationship, RelationshipDescriptor};
 use holons_core::reference_layer::HolonReference;
+use std::fmt;
+
+/// A relationship descriptor together with its effective traversal direction.
+pub struct QualifiedRelationshipResult {
+    pub descriptor: RelationshipDescriptor,
+    pub direction: holons_core::descriptors::RelationshipDirection,
+}
+
+impl fmt::Debug for QualifiedRelationshipResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QualifiedRelationshipResult")
+            .field("direction", &self.direction)
+            .finish_non_exhaustive()
+    }
+}
+
+impl From<QualifiedRelationship> for QualifiedRelationshipResult {
+    fn from(relationship: QualifiedRelationship) -> Self {
+        Self { descriptor: relationship.descriptor, direction: relationship.descriptor_direction }
+    }
+}
 
 /// Domain-level result variants from command execution.
 ///
@@ -39,6 +62,9 @@ pub enum MapResult {
 
     /// Canonical plural command result carrier.
     Collection(HolonCollection),
+
+    /// Ordered lifecycle-valid relationship descriptors with their directions.
+    QualifiedRelationships(Vec<QualifiedRelationshipResult>),
 
     /// Universal scalar return — covers MapString, MapInteger, MapBoolean, PropertyValue.
     Value(BaseValue),

--- a/host/crates/map_commands_contract/src/tests.rs
+++ b/host/crates/map_commands_contract/src/tests.rs
@@ -51,6 +51,18 @@ fn holon_action_policies() {
         "CloneHolon creates a transient — mutating despite being a ReadableHolonAction"
     );
     assert_eq!(
+        HolonAction::Read(ReadableHolonAction::GetHolonDescriptor).policy(),
+        CommandLifecyclePolicy::holon_read_only()
+    );
+    assert_eq!(
+        HolonAction::Read(ReadableHolonAction::GetAvailableProperties).policy(),
+        CommandLifecyclePolicy::holon_read_only()
+    );
+    assert_eq!(
+        HolonAction::Read(ReadableHolonAction::GetAvailableRelationships).policy(),
+        CommandLifecyclePolicy::holon_read_only()
+    );
+    assert_eq!(
         HolonAction::Write(WritableHolonAction::WithPropertyValue {
             name: PropertyName(MapString::from("x")),
             value: BaseValue::StringValue(MapString::from("v")),

--- a/host/crates/map_commands_runtime/src/holon_handler.rs
+++ b/host/crates/map_commands_runtime/src/holon_handler.rs
@@ -1,6 +1,9 @@
 use base_types::{BaseValue, MapString};
 use core_types::HolonError;
+use holons_core::descriptors::Descriptor;
 use holons_core::reference_layer::{HolonReference, ReadableHolon, WritableHolon};
+use holons_core::{CollectionState, HolonCollection};
+use std::collections::BTreeMap;
 
 use map_commands_contract::{
     HolonAction, HolonCommand, MapResult, ReadableHolonAction, WritableHolonAction,
@@ -60,6 +63,24 @@ fn handle_read(
                 .clone();
             Ok(MapResult::Collection(collection))
         }
+        ReadableHolonAction::GetHolonDescriptor => {
+            Ok(MapResult::Reference(target.holon_descriptor()?.holon().clone()))
+        }
+        ReadableHolonAction::GetAvailableProperties => {
+            let members = target
+                .available_properties()?
+                .into_iter()
+                .map(|descriptor| descriptor.holon().clone())
+                .collect();
+            Ok(MapResult::Collection(HolonCollection::from_parts(
+                CollectionState::Fetched,
+                members,
+                BTreeMap::new(),
+            )))
+        }
+        ReadableHolonAction::GetAvailableRelationships => Ok(MapResult::QualifiedRelationships(
+            target.available_relationships()?.into_iter().map(Into::into).collect(),
+        )),
     }
 }
 

--- a/host/crates/map_commands_runtime/src/tests.rs
+++ b/host/crates/map_commands_runtime/src/tests.rs
@@ -139,6 +139,36 @@ fn tx_cmd(runtime: &Runtime, tx_id: &TxId, action: TransactionAction) -> MapComm
     MapCommand::Transaction(TransactionCommand { context, action })
 }
 
+fn minimally_described_transient(
+    runtime: &Runtime,
+    tx_id: &TxId,
+) -> (Arc<TransactionContext>, HolonReference) {
+    let context = runtime.session().get_transaction(tx_id).expect("transaction should exist");
+    let mut descriptor = context
+        .mutation()
+        .new_holon(Some(MapString::from("readable-type")))
+        .expect("create descriptor");
+    descriptor
+        .with_property_value("TypeName", "ReadableType")
+        .and_then(|descriptor| descriptor.with_property_value("IsAbstractType", false))
+        .and_then(|descriptor| descriptor.with_property_value("InstanceTypeKind", "Holon"))
+        .and_then(|descriptor| descriptor.with_property_value("AllowsAdditionalProperties", false))
+        .and_then(|descriptor| {
+            descriptor.with_property_value("AllowsAdditionalRelationships", false)
+        })
+        .expect("populate descriptor header");
+
+    let mut target = context
+        .mutation()
+        .new_holon(Some(MapString::from("readable-instance")))
+        .expect("create target");
+    target
+        .add_related_holons("DescribedBy", vec![HolonReference::Transient(descriptor)])
+        .expect("link target descriptor");
+
+    (context, HolonReference::Transient(target))
+}
+
 // ── Handler tests ───────────────────────────────────────────────────
 
 #[tokio::test]
@@ -200,6 +230,54 @@ async fn invalid_tx_id_returns_error() {
         }
         other => panic!("expected InvalidParameter error, got {:?}", other),
     }
+}
+
+#[tokio::test]
+async fn descriptor_discovery_reads_map_to_their_runtime_result_families() {
+    let runtime = build_test_runtime();
+    let tx_id = begin_tx(&runtime).await;
+    let (context, target) = minimally_described_transient(&runtime, &tx_id);
+
+    let descriptor = runtime
+        .execute_command(
+            MapCommand::Holon(HolonCommand {
+                context: Arc::clone(&context),
+                target: target.clone(),
+                action: HolonAction::Read(ReadableHolonAction::GetHolonDescriptor),
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("descriptor read should succeed");
+    assert!(matches!(descriptor, MapResult::Reference(_)));
+
+    let properties = runtime
+        .execute_command(
+            MapCommand::Holon(HolonCommand {
+                context: Arc::clone(&context),
+                target: target.clone(),
+                action: HolonAction::Read(ReadableHolonAction::GetAvailableProperties),
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("property discovery should succeed");
+    assert!(
+        matches!(properties, MapResult::Collection(collection) if collection.get_members().is_empty())
+    );
+
+    let relationships = runtime
+        .execute_command(
+            MapCommand::Holon(HolonCommand {
+                context,
+                target,
+                action: HolonAction::Read(ReadableHolonAction::GetAvailableRelationships),
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("relationship discovery should succeed");
+    assert!(matches!(relationships, MapResult::QualifiedRelationships(items) if items.is_empty()));
 }
 
 // ── Transaction lookup handler ─────────────────────────────────────

--- a/host/crates/map_commands_wire/src/holon_wire.rs
+++ b/host/crates/map_commands_wire/src/holon_wire.rs
@@ -49,10 +49,20 @@ pub enum ReadableHolonActionWire {
     GetVersionedKey,
 
     /// `property_value(name)` → `Option<PropertyValue>`
-    GetPropertyValue { name: PropertyName },
+    GetPropertyValue {
+        name: PropertyName,
+    },
 
     /// `related_holons(name)` → `HolonCollection`
-    GetRelatedHolons { name: RelationshipName },
+    GetRelatedHolons {
+        name: RelationshipName,
+    },
+
+    GetHolonDescriptor,
+
+    GetAvailableProperties,
+
+    GetAvailableRelationships,
 }
 
 /// Wire-level write (mutating) holon actions.
@@ -113,6 +123,13 @@ impl ReadableHolonActionWire {
             }
             ReadableHolonActionWire::GetRelatedHolons { name } => {
                 ReadableHolonAction::GetRelatedHolons { name }
+            }
+            ReadableHolonActionWire::GetHolonDescriptor => ReadableHolonAction::GetHolonDescriptor,
+            ReadableHolonActionWire::GetAvailableProperties => {
+                ReadableHolonAction::GetAvailableProperties
+            }
+            ReadableHolonActionWire::GetAvailableRelationships => {
+                ReadableHolonAction::GetAvailableRelationships
             }
         }
     }

--- a/host/crates/map_commands_wire/src/result_wire.rs
+++ b/host/crates/map_commands_wire/src/result_wire.rs
@@ -2,6 +2,7 @@ use base_types::BaseValue;
 use core_types::HolonId;
 use holons_boundary::{DanceResponseWire, HolonCollectionWire, HolonReferenceWire};
 use holons_core::core_shared_objects::transactions::TxId;
+use holons_core::descriptors::{Descriptor, RelationshipDirection};
 use serde::{Deserialize, Serialize};
 
 use map_commands_contract::MapResult;
@@ -41,6 +42,9 @@ pub enum MapResultWire {
     /// Canonical plural command result carrier at the IPC boundary.
     Collection(HolonCollectionWire),
 
+    /// Ordered lifecycle-valid relationship descriptors and their directions.
+    QualifiedRelationships(Vec<QualifiedRelationshipWire>),
+
     /// Universal scalar return.
     Value(BaseValue),
 
@@ -49,6 +53,29 @@ pub enum MapResultWire {
 
     /// Transitional dance-result exception retained at the IPC boundary.
     DanceResponse(DanceResponseWire),
+}
+
+/// Wire-safe qualified relationship discovery result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QualifiedRelationshipWire {
+    pub descriptor: HolonReferenceWire,
+    pub direction: RelationshipDirectionWire,
+}
+
+/// Direction of a relationship descriptor relative to its declared edge.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum RelationshipDirectionWire {
+    Declared,
+    Inverse,
+}
+
+impl From<RelationshipDirection> for RelationshipDirectionWire {
+    fn from(direction: RelationshipDirection) -> Self {
+        match direction {
+            RelationshipDirection::Declared => Self::Declared,
+            RelationshipDirection::Inverse => Self::Inverse,
+        }
+    }
 }
 
 impl From<MapResult> for MapResultWire {
@@ -65,11 +92,47 @@ impl From<MapResult> for MapResultWire {
                 MapResultWire::References(refs.iter().map(HolonReferenceWire::from).collect())
             }
             MapResult::Collection(c) => MapResultWire::Collection(HolonCollectionWire::from(&c)),
+            MapResult::QualifiedRelationships(relationships) => {
+                MapResultWire::QualifiedRelationships(
+                    relationships
+                        .iter()
+                        .map(|relationship| QualifiedRelationshipWire {
+                            descriptor: HolonReferenceWire::from(relationship.descriptor.holon()),
+                            direction: relationship.direction.into(),
+                        })
+                        .collect(),
+                )
+            }
             MapResult::Value(v) => MapResultWire::Value(v),
             MapResult::HolonId(id) => MapResultWire::HolonId(id),
             MapResult::DanceResponse(r) => {
                 MapResultWire::DanceResponse(DanceResponseWire::from(&r))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QualifiedRelationshipWire, RelationshipDirectionWire};
+    use holons_boundary::{HolonReferenceWire, TransientReferenceWire};
+    use serde_json::{from_str, to_string};
+
+    #[test]
+    fn qualified_relationship_wire_round_trips_direction_with_its_descriptor() {
+        let relationship = QualifiedRelationshipWire {
+            descriptor: HolonReferenceWire::Transient(TransientReferenceWire::new(
+                holons_core::core_shared_objects::transactions::TxId::from_str("7")
+                    .expect("valid transaction id"),
+                core_types::TemporaryId(uuid::Uuid::nil()),
+            )),
+            direction: RelationshipDirectionWire::Inverse,
+        };
+
+        let serialized = to_string(&relationship).expect("serialize qualified relationship");
+        let decoded: QualifiedRelationshipWire =
+            from_str(&serialized).expect("deserialize qualified relationship");
+
+        assert_eq!(decoded, relationship);
     }
 }

--- a/host/map-sdk/src/internal/commands/holon.ts
+++ b/host/map-sdk/src/internal/commands/holon.ts
@@ -6,6 +6,7 @@ import {
   expectNone,
   expectOptionalReference,
   expectOptionalValue,
+  expectQualifiedRelationships,
   expectReference,
   expectValue,
 } from '../result-decoders';
@@ -21,6 +22,7 @@ import type {
   TxId,
   WritableHolonActionWire,
   HolonCollectionWire,
+  QualifiedRelationshipWire,
 } from '../wire-types';
 
 // ===========================================
@@ -210,6 +212,39 @@ export function readRelatedHolons(
       },
     },
     expectCollection,
+    options,
+  );
+}
+
+/** Return the target's effective descriptor reference. */
+export function readHolonDescriptor(
+  txId: TxId,
+  target: HolonReferenceWire,
+  options?: RequestOptionsOverrides,
+): Promise<HolonReferenceWire> {
+  return runHolonCommand(txId, target, { Read: 'GetHolonDescriptor' }, expectReference, options);
+}
+
+/** Return ordered effective property descriptor references. */
+export function readAvailableProperties(
+  txId: TxId,
+  target: HolonReferenceWire,
+  options?: RequestOptionsOverrides,
+): Promise<HolonCollectionWire> {
+  return runHolonCommand(txId, target, { Read: 'GetAvailableProperties' }, expectCollection, options);
+}
+
+/** Return lifecycle-valid relationship descriptor references and directions. */
+export function readAvailableRelationships(
+  txId: TxId,
+  target: HolonReferenceWire,
+  options?: RequestOptionsOverrides,
+): Promise<QualifiedRelationshipWire[]> {
+  return runHolonCommand(
+    txId,
+    target,
+    { Read: 'GetAvailableRelationships' },
+    expectQualifiedRelationships,
     options,
   );
 }

--- a/host/map-sdk/src/internal/result-decoders.ts
+++ b/host/map-sdk/src/internal/result-decoders.ts
@@ -6,6 +6,7 @@ import type {
   HolonId,
   HolonReferenceWire,
   MapResultWire,
+  QualifiedRelationshipWire,
   TxId,
 } from './wire-types';
 
@@ -146,6 +147,21 @@ export function expectCollection(result: MapResultWire): HolonCollectionWire {
   }
 
   throw unexpectedResultVariant('Collection', result);
+}
+
+/** Decode a `MapResultWire::QualifiedRelationships` payload. */
+export function expectQualifiedRelationships(
+  result: MapResultWire,
+): QualifiedRelationshipWire[] {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'QualifiedRelationships' in result
+  ) {
+    return result.QualifiedRelationships;
+  }
+
+  throw unexpectedResultVariant('QualifiedRelationships', result);
 }
 
 /**

--- a/host/map-sdk/src/internal/wire-types/commands.ts
+++ b/host/map-sdk/src/internal/wire-types/commands.ts
@@ -109,6 +109,9 @@ export type ReadableHolonActionWire =
   | 'GetPredecessor'
   | 'GetKey'
   | 'GetVersionedKey'
+  | 'GetHolonDescriptor'
+  | 'GetAvailableProperties'
+  | 'GetAvailableRelationships'
   | { GetPropertyValue: { name: PropertyName } }
   | { GetRelatedHolons: { name: RelationshipName } };
 
@@ -148,6 +151,9 @@ const READABLE_HOLON_UNIT_ACTIONS = new Set<ReadableHolonActionWire>([
   'GetPredecessor',
   'GetKey',
   'GetVersionedKey',
+  'GetHolonDescriptor',
+  'GetAvailableProperties',
+  'GetAvailableRelationships',
 ]);
 
 const TRANSACTION_UNIT_ACTIONS = new Set([

--- a/host/map-sdk/src/internal/wire-types/results.ts
+++ b/host/map-sdk/src/internal/wire-types/results.ts
@@ -14,6 +14,23 @@ import {
   isRecord,
 } from './references';
 
+export type RelationshipDirectionWire = 'Declared' | 'Inverse';
+
+export interface QualifiedRelationshipWire {
+  descriptor: HolonReferenceWire;
+  direction: RelationshipDirectionWire;
+}
+
+function isQualifiedRelationshipWire(
+  value: unknown,
+): value is QualifiedRelationshipWire {
+  return (
+    isRecord(value) &&
+    isHolonReferenceWire(value['descriptor']) &&
+    (value['direction'] === 'Declared' || value['direction'] === 'Inverse')
+  );
+}
+
 // ===========================================
 // Result Payload Types
 // ===========================================
@@ -35,6 +52,7 @@ export type MapResultWire =
   | { Reference: HolonReferenceWire }
   | { References: HolonReferenceWire[] }
   | { Collection: HolonCollectionWire }
+  | { QualifiedRelationships: QualifiedRelationshipWire[] }
   | { Value: BaseValue }
   | { HolonId: HolonId }
   | { DanceResponse: DanceResponseWire };
@@ -59,6 +77,9 @@ export function isMapResultWire(value: unknown): value is MapResultWire {
       value.References.every(isHolonReferenceWire)) ||
     (hasSingleKey(value, 'Collection') &&
       isHolonCollectionWire(value.Collection)) ||
+    (hasSingleKey(value, 'QualifiedRelationships') &&
+      Array.isArray(value.QualifiedRelationships) &&
+      value.QualifiedRelationships.every(isQualifiedRelationshipWire)) ||
     (hasSingleKey(value, 'Value') && isBaseValue(value.Value)) ||
     (hasSingleKey(value, 'HolonId') && isHolonId(value.HolonId)) ||
     (hasSingleKey(value, 'DanceResponse') &&

--- a/host/map-sdk/src/sdk/core-names.ts
+++ b/host/map-sdk/src/sdk/core-names.ts
@@ -1,0 +1,11 @@
+/**
+ * MAP Core property names depended on by public SDK descriptor handles.
+ *
+ * This mirrors the deliberate Core-name dependencies in Rust without making
+ * TypeScript infer descriptor semantics from arbitrary storage fields.
+ */
+export const CorePropertyName = {
+  TypeName: 'TypeName',
+  PropertyName: 'PropertyName',
+  RelationshipName: 'RelationshipName',
+} as const;

--- a/host/map-sdk/src/sdk/descriptors.ts
+++ b/host/map-sdk/src/sdk/descriptors.ts
@@ -1,0 +1,107 @@
+import type { BaseValue, PropertyName, RelationshipName } from './types';
+import { extractString } from './types';
+import type { HolonReference } from './references';
+
+const DESCRIPTOR_HANDLE_CONSTRUCTION = Symbol('DescriptorHandleConstruction');
+
+/** Opaque SDK handle for a holon type descriptor. */
+export class HolonDescriptorHandle {
+  #reference: HolonReference;
+
+  constructor(
+    reference: HolonReference,
+    token: typeof DESCRIPTOR_HANDLE_CONSTRUCTION,
+  ) {
+    if (token !== DESCRIPTOR_HANDLE_CONSTRUCTION) {
+      throw new TypeError('HolonDescriptorHandle cannot be constructed directly');
+    }
+
+    this.#reference = reference;
+  }
+
+  async typeName(): Promise<string> {
+    return requiredString(this.#reference.propertyValue('TypeName'), 'TypeName');
+  }
+}
+
+/** Opaque SDK handle for an effective property descriptor. */
+export class PropertyDescriptorHandle {
+  #reference: HolonReference;
+
+  constructor(
+    reference: HolonReference,
+    token: typeof DESCRIPTOR_HANDLE_CONSTRUCTION,
+  ) {
+    if (token !== DESCRIPTOR_HANDLE_CONSTRUCTION) {
+      throw new TypeError('PropertyDescriptorHandle cannot be constructed directly');
+    }
+
+    this.#reference = reference;
+  }
+
+  async propertyName(): Promise<PropertyName> {
+    return requiredString(this.#reference.propertyValue('PropertyName'), 'PropertyName');
+  }
+}
+
+/** Opaque SDK handle for an effective relationship descriptor. */
+export class RelationshipDescriptorHandle {
+  #reference: HolonReference;
+
+  constructor(
+    reference: HolonReference,
+    token: typeof DESCRIPTOR_HANDLE_CONSTRUCTION,
+  ) {
+    if (token !== DESCRIPTOR_HANDLE_CONSTRUCTION) {
+      throw new TypeError('RelationshipDescriptorHandle cannot be constructed directly');
+    }
+
+    this.#reference = reference;
+  }
+
+  async relationshipName(): Promise<RelationshipName> {
+    return requiredString(
+      this.#reference.propertyValue('RelationshipName'),
+      'RelationshipName',
+    );
+  }
+}
+
+export type RelationshipDirection = 'declared' | 'inverse';
+
+/** A lifecycle-valid relationship descriptor together with its direction. */
+export interface AvailableRelationshipHandle {
+  readonly descriptor: RelationshipDescriptorHandle;
+  readonly direction: RelationshipDirection;
+}
+
+export function createHolonDescriptorHandle(
+  reference: HolonReference,
+): HolonDescriptorHandle {
+  return new HolonDescriptorHandle(reference, DESCRIPTOR_HANDLE_CONSTRUCTION);
+}
+
+export function createPropertyDescriptorHandle(
+  reference: HolonReference,
+): PropertyDescriptorHandle {
+  return new PropertyDescriptorHandle(reference, DESCRIPTOR_HANDLE_CONSTRUCTION);
+}
+
+export function createRelationshipDescriptorHandle(
+  reference: HolonReference,
+): RelationshipDescriptorHandle {
+  return new RelationshipDescriptorHandle(reference, DESCRIPTOR_HANDLE_CONSTRUCTION);
+}
+
+async function requiredString(
+  value: Promise<BaseValue | null>,
+  property: string,
+): Promise<string> {
+  const resolved = await value;
+
+  if (resolved === null) {
+    throw new TypeError(`Descriptor is missing required ${property} property`);
+  }
+
+  return extractString(resolved);
+}

--- a/host/map-sdk/src/sdk/descriptors.ts
+++ b/host/map-sdk/src/sdk/descriptors.ts
@@ -1,6 +1,7 @@
 import type { BaseValue, PropertyName, RelationshipName } from './types';
 import { extractString } from './types';
 import type { HolonReference } from './references';
+import { CorePropertyName } from './core-names';
 
 const DESCRIPTOR_HANDLE_CONSTRUCTION = Symbol('DescriptorHandleConstruction');
 
@@ -20,7 +21,10 @@ export class HolonDescriptorHandle {
   }
 
   async typeName(): Promise<string> {
-    return requiredString(this.#reference.propertyValue('TypeName'), 'TypeName');
+    return requiredString(
+      this.#reference.propertyValue(CorePropertyName.TypeName),
+      CorePropertyName.TypeName,
+    );
   }
 }
 
@@ -40,7 +44,10 @@ export class PropertyDescriptorHandle {
   }
 
   async propertyName(): Promise<PropertyName> {
-    return requiredString(this.#reference.propertyValue('PropertyName'), 'PropertyName');
+    return requiredString(
+      this.#reference.propertyValue(CorePropertyName.PropertyName),
+      CorePropertyName.PropertyName,
+    );
   }
 }
 
@@ -61,8 +68,8 @@ export class RelationshipDescriptorHandle {
 
   async relationshipName(): Promise<RelationshipName> {
     return requiredString(
-      this.#reference.propertyValue('RelationshipName'),
-      'RelationshipName',
+      this.#reference.propertyValue(CorePropertyName.RelationshipName),
+      CorePropertyName.RelationshipName,
     );
   }
 }

--- a/host/map-sdk/src/sdk/index.ts
+++ b/host/map-sdk/src/sdk/index.ts
@@ -1,4 +1,5 @@
 export { HolonCollection } from './collection';
+export { CorePropertyName } from './core-names';
 export {
   HolonDescriptorHandle,
   PropertyDescriptorHandle,

--- a/host/map-sdk/src/sdk/index.ts
+++ b/host/map-sdk/src/sdk/index.ts
@@ -1,4 +1,13 @@
 export { HolonCollection } from './collection';
+export {
+  HolonDescriptorHandle,
+  PropertyDescriptorHandle,
+  RelationshipDescriptorHandle,
+} from './descriptors';
+export type {
+  AvailableRelationshipHandle,
+  RelationshipDirection,
+} from './descriptors';
 export { MapClient } from './client';
 export {
   HolonReference,

--- a/host/map-sdk/src/sdk/references.ts
+++ b/host/map-sdk/src/sdk/references.ts
@@ -8,6 +8,14 @@ import type {
 } from '../internal/wire-types/references';
 import { HolonCollection } from './collection';
 import {
+  createHolonDescriptorHandle,
+  createPropertyDescriptorHandle,
+  createRelationshipDescriptorHandle,
+  type AvailableRelationshipHandle,
+  type HolonDescriptorHandle,
+  type PropertyDescriptorHandle,
+} from './descriptors';
+import {
   type BaseValue,
   extractString,
   type HolonId,
@@ -85,6 +93,38 @@ export class HolonReference implements WritableHolon {
       name,
     );
     return new HolonCollection(txId, collection);
+  }
+
+  async holonDescriptor(): Promise<HolonDescriptorHandle> {
+    const txId = txIdFor(this);
+    const wireRef = await internalHolon.readHolonDescriptor(txId, wireRefFor(this));
+    return createHolonDescriptorHandle(createHolonReference(txId, wireRef));
+  }
+
+  async availableProperties(): Promise<ReadonlyArray<PropertyDescriptorHandle>> {
+    const txId = txIdFor(this);
+    const collection = await internalHolon.readAvailableProperties(txId, wireRefFor(this));
+    return Object.freeze(
+      collection.members.map((member) =>
+        createPropertyDescriptorHandle(createHolonReference(txId, member)),
+      ),
+    );
+  }
+
+  async availableRelationships(): Promise<ReadonlyArray<AvailableRelationshipHandle>> {
+    const txId = txIdFor(this);
+    const relationships = await internalHolon.readAvailableRelationships(
+      txId,
+      wireRefFor(this),
+    );
+    return Object.freeze(
+      relationships.map(({ descriptor, direction }) => ({
+        descriptor: createRelationshipDescriptorHandle(
+          createHolonReference(txId, descriptor),
+        ),
+        direction: direction === 'Declared' ? ('declared' as const) : ('inverse' as const),
+      })),
+    );
   }
 
   withPropertyValue(name: PropertyName, value: BaseValue): Promise<void> {

--- a/host/map-sdk/src/sdk/types.ts
+++ b/host/map-sdk/src/sdk/types.ts
@@ -13,6 +13,11 @@ import type {
 } from '../internal/wire-types/commands';
 import type { HolonCollection } from './collection';
 import type { HolonReference, TransientHolonReference } from './references';
+import type {
+  AvailableRelationshipHandle,
+  HolonDescriptorHandle,
+  PropertyDescriptorHandle,
+} from './descriptors';
 
 export type {
   BaseValue,
@@ -73,6 +78,9 @@ export interface ReadableHolon {
   versionedKey(): Promise<string>;
   propertyValue(name: PropertyName): Promise<BaseValue | null>;
   relatedHolons(name: RelationshipName): Promise<HolonCollection>;
+  holonDescriptor(): Promise<HolonDescriptorHandle>;
+  availableProperties(): Promise<ReadonlyArray<PropertyDescriptorHandle>>;
+  availableRelationships(): Promise<ReadonlyArray<AvailableRelationshipHandle>>;
 }
 
 /**

--- a/host/map-sdk/tests/commands/holon.test.ts
+++ b/host/map-sdk/tests/commands/holon.test.ts
@@ -5,6 +5,9 @@ import {
   cloneHolon,
   predecessor,
   readHolonId,
+  readAvailableProperties,
+  readAvailableRelationships,
+  readHolonDescriptor,
   readKey,
   readPropertyValue,
   readRelatedHolons,
@@ -100,6 +103,8 @@ const collection: HolonCollectionWire = {
   },
 };
 
+const qualifiedRelationships = [{ descriptor, direction: 'Declared' as const }];
+
 function expectHolonRequest(
   action: HolonActionWire,
   options: RequestOptions = defaultOptions,
@@ -190,6 +195,30 @@ const holonCases: HolonCase<unknown>[] = [
     okResult: { Collection: collection },
     expected: collection,
     wrongResult: { References: [transientReference] },
+  },
+  {
+    name: 'readHolonDescriptor',
+    run: () => readHolonDescriptor(txId, target),
+    action: { Read: 'GetHolonDescriptor' },
+    okResult: { Reference: descriptor },
+    expected: descriptor,
+    wrongResult: { Collection: collection },
+  },
+  {
+    name: 'readAvailableProperties',
+    run: () => readAvailableProperties(txId, target),
+    action: { Read: 'GetAvailableProperties' },
+    okResult: { Collection: collection },
+    expected: collection,
+    wrongResult: { References: [descriptor] },
+  },
+  {
+    name: 'readAvailableRelationships',
+    run: () => readAvailableRelationships(txId, target),
+    action: { Read: 'GetAvailableRelationships' },
+    okResult: { QualifiedRelationships: qualifiedRelationships },
+    expected: qualifiedRelationships,
+    wrongResult: { Collection: collection },
   },
   {
     name: 'withPropertyValue',

--- a/host/map-sdk/tests/sdk/exports.test.ts
+++ b/host/map-sdk/tests/sdk/exports.test.ts
@@ -27,6 +27,7 @@ describe('public SDK exports', () => {
     expect(sdk.HolonReference).toBeDefined();
     expect(sdk.TransientHolonReference).toBeDefined();
     expect(sdk.HolonCollection).toBeDefined();
+    expect(sdk.CorePropertyName).toBeDefined();
     expect(sdk.HolonDescriptorHandle).toBeDefined();
     expect(sdk.PropertyDescriptorHandle).toBeDefined();
     expect(sdk.RelationshipDescriptorHandle).toBeDefined();
@@ -37,6 +38,7 @@ describe('public SDK exports', () => {
     expect(sdk.extractString).toBeDefined();
     expect(sdk.extractNumber).toBeDefined();
     expect(sdk.extractBytes).toBeDefined();
+    expect(sdk.CorePropertyName.TypeName).toBe('TypeName');
   });
 
   it('does not expose internal wire or transport-layer exports', () => {

--- a/host/map-sdk/tests/sdk/exports.test.ts
+++ b/host/map-sdk/tests/sdk/exports.test.ts
@@ -27,6 +27,9 @@ describe('public SDK exports', () => {
     expect(sdk.HolonReference).toBeDefined();
     expect(sdk.TransientHolonReference).toBeDefined();
     expect(sdk.HolonCollection).toBeDefined();
+    expect(sdk.HolonDescriptorHandle).toBeDefined();
+    expect(sdk.PropertyDescriptorHandle).toBeDefined();
+    expect(sdk.RelationshipDescriptorHandle).toBeDefined();
     expect(sdk.MapError).toBeDefined();
     expect(sdk.TransportError).toBeDefined();
     expect(sdk.MalformedResponseError).toBeDefined();

--- a/host/map-sdk/tests/sdk/references.test.ts
+++ b/host/map-sdk/tests/sdk/references.test.ts
@@ -12,6 +12,9 @@ const {
   cloneHolonMock,
   predecessorMock,
   readHolonIdMock,
+  readAvailablePropertiesMock,
+  readAvailableRelationshipsMock,
+  readHolonDescriptorMock,
   readKeyMock,
   readPropertyValueMock,
   readRelatedHolonsMock,
@@ -26,6 +29,9 @@ const {
   cloneHolonMock: vi.fn(),
   predecessorMock: vi.fn(),
   readHolonIdMock: vi.fn(),
+  readAvailablePropertiesMock: vi.fn(),
+  readAvailableRelationshipsMock: vi.fn(),
+  readHolonDescriptorMock: vi.fn(),
   readKeyMock: vi.fn(),
   readPropertyValueMock: vi.fn(),
   readRelatedHolonsMock: vi.fn(),
@@ -42,6 +48,9 @@ vi.mock('../../src/internal/commands/holon', () => ({
   cloneHolon: cloneHolonMock,
   predecessor: predecessorMock,
   readHolonId: readHolonIdMock,
+  readAvailableProperties: readAvailablePropertiesMock,
+  readAvailableRelationships: readAvailableRelationshipsMock,
+  readHolonDescriptor: readHolonDescriptorMock,
   readKey: readKeyMock,
   readPropertyValue: readPropertyValueMock,
   readRelatedHolons: readRelatedHolonsMock,
@@ -54,6 +63,11 @@ vi.mock('../../src/internal/commands/holon', () => ({
 }));
 
 import { HolonCollection } from '../../src/sdk/collection';
+import {
+  HolonDescriptorHandle,
+  PropertyDescriptorHandle,
+  RelationshipDescriptorHandle,
+} from '../../src/sdk/descriptors';
 import {
   createHolonReference,
   createTransientHolonReference,
@@ -112,6 +126,17 @@ const relatedCollection: HolonCollectionWire = {
   },
 };
 
+const descriptorCollection: HolonCollectionWire = {
+  state: 'Fetched',
+  members: [smartReference, stagedReference],
+  keyed_index: {},
+};
+
+const qualifiedRelationships = [
+  { descriptor: smartReference, direction: 'Declared' as const },
+  { descriptor: stagedReference, direction: 'Inverse' as const },
+];
+
 function stagedHandle(): HolonReference {
   return createHolonReference(txId, stagedReference);
 }
@@ -130,6 +155,9 @@ describe('HolonReference', () => {
     cloneHolonMock.mockReset();
     predecessorMock.mockReset();
     readHolonIdMock.mockReset();
+    readAvailablePropertiesMock.mockReset();
+    readAvailableRelationshipsMock.mockReset();
+    readHolonDescriptorMock.mockReset();
     readKeyMock.mockReset();
     readPropertyValueMock.mockReset();
     readRelatedHolonsMock.mockReset();
@@ -227,6 +255,31 @@ describe('HolonReference', () => {
     expect(collection).toBeInstanceOf(HolonCollection);
     expect(collection.members[0]).toBeInstanceOf(TransientHolonReference);
     expect(collection.members[1]).toBeInstanceOf(HolonReference);
+  });
+
+  it('wraps descriptor discovery results in typed public handles', async () => {
+    readHolonDescriptorMock.mockResolvedValue(smartReference);
+    readAvailablePropertiesMock.mockResolvedValue(descriptorCollection);
+    readAvailableRelationshipsMock.mockResolvedValue(qualifiedRelationships);
+
+    const reference = stagedHandle();
+    const descriptor = await reference.holonDescriptor();
+    const properties = await reference.availableProperties();
+    const relationships = await reference.availableRelationships();
+
+    expect(readHolonDescriptorMock).toHaveBeenCalledWith(txId, stagedReference);
+    expect(readAvailablePropertiesMock).toHaveBeenCalledWith(txId, stagedReference);
+    expect(readAvailableRelationshipsMock).toHaveBeenCalledWith(txId, stagedReference);
+    expect(descriptor).toBeInstanceOf(HolonDescriptorHandle);
+    expect(properties).toHaveLength(2);
+    expect(properties[0]).toBeInstanceOf(PropertyDescriptorHandle);
+    expect(properties[1]).toBeInstanceOf(PropertyDescriptorHandle);
+    expect(relationships.map((relationship) => relationship.direction)).toEqual([
+      'declared',
+      'inverse',
+    ]);
+    expect(relationships[0]?.descriptor).toBeInstanceOf(RelationshipDescriptorHandle);
+    expect(relationships[1]?.descriptor).toBeInstanceOf(RelationshipDescriptorHandle);
   });
 
   it('delegates property mutation methods with the expected arguments', async () => {

--- a/host/ui/src/dahn/boundaries/dependency-seam.test.ts
+++ b/host/ui/src/dahn/boundaries/dependency-seam.test.ts
@@ -22,14 +22,15 @@ describe('DAHN dependency seam', () => {
     expect(readText('contract-checks.ts')).toContain("from './deps'");
   });
 
-  it('uses MAP SDK holon handles instead of declaring DAHN-local descriptor handles', () => {
+  it('uses MAP SDK descriptor handles through a DAHN-owned read-only view contract', () => {
     const holonViewSource = readText('contracts/holon-view.ts');
     const actionsSource = readText('contracts/actions.ts');
     const dahnIndexSource = readText('index.ts');
 
-    expect(holonViewSource).toContain(
-      'export type HolonViewAccess = HolonReference',
-    );
+    expect(holonViewSource).toContain('export interface HolonViewAccess');
+    expect(holonViewSource).toContain('HolonDescriptorHandle');
+    expect(holonViewSource).toContain('PropertyDescriptorHandle');
+    expect(holonViewSource).toContain('RelationshipName');
     expect(holonViewSource).not.toContain('interface ValueTypeDescriptorHandle');
     expect(holonViewSource).not.toContain('interface PropertyDescriptorHandle');
     expect(holonViewSource).not.toContain(

--- a/host/ui/src/dahn/boundaries/exports.test.ts
+++ b/host/ui/src/dahn/boundaries/exports.test.ts
@@ -9,6 +9,7 @@ describe('DAHN export surface', () => {
     expect(dahn.DEFAULT_DAHN_THEME).toBeDefined();
     expect(dahn.DefaultThemeRegistry).toBeDefined();
     expect(dahn.registerBuiltInVisualizers).toBeDefined();
+    expect(dahn.DahnHolonView).toBeDefined();
   });
 
   it('does not leak obvious transport-facing concepts through the DAHN root export surface', () => {

--- a/host/ui/src/dahn/contract-checks.ts
+++ b/host/ui/src/dahn/contract-checks.ts
@@ -1,4 +1,4 @@
-import { DefaultDahnRuntime } from './index';
+import { DahnHolonView, DefaultDahnRuntime } from './index';
 import type {
   ActionNode,
   CanvasApi,
@@ -35,7 +35,7 @@ const target: DahnTarget = {
   reference: holonReference,
 };
 
-const holonAccess: HolonViewAccess = holonReference;
+const holonAccess: HolonViewAccess = new DahnHolonView(holonReference);
 
 const canvasDescriptor: CanvasDescriptor = {
   id: 'dahn-2d-minimal',

--- a/host/ui/src/dahn/contracts/holon-view.ts
+++ b/host/ui/src/dahn/contracts/holon-view.ts
@@ -1,11 +1,32 @@
 import type { ActionNode } from './actions';
-import type { HolonReference } from '../deps';
+import type {
+  AvailableRelationshipHandle,
+  BaseValue,
+  HolonCollection,
+  HolonDescriptorHandle,
+  HolonId,
+  PropertyDescriptorHandle,
+  PropertyName,
+  RelationshipName,
+} from '../deps';
 
 /**
- * DAHN uses the public SDK's bound holon handle directly rather than defining a
- * parallel DAHN-owned holon access surface.
+ * Read-only DAHN view over one bound MAP holon reference.
+ *
+ * All operations are live reads through the public SDK; this interface neither
+ * caches MAP state nor exposes mutation methods.
  */
-export type HolonViewAccess = HolonReference;
+export interface HolonViewAccess {
+  holonId(): Promise<HolonId>;
+  key(): Promise<string | null>;
+  versionedKey(): Promise<string>;
+  propertyValue(name: PropertyName): Promise<BaseValue | null>;
+  descriptor(): Promise<HolonDescriptorHandle>;
+  availableProperties(): Promise<ReadonlyArray<PropertyDescriptorHandle>>;
+  availableRelationships(): Promise<ReadonlyArray<AvailableRelationshipHandle>>;
+  expandRelationship(name: RelationshipName): Promise<HolonCollection>;
+}
+
 
 /**
  * Composite object passed from the access adapter into the runtime.

--- a/host/ui/src/dahn/deps/index.ts
+++ b/host/ui/src/dahn/deps/index.ts
@@ -1,8 +1,12 @@
 export type {
   BaseValue,
+  AvailableRelationshipHandle,
   HolonCollection,
+  HolonDescriptorHandle,
   HolonId,
   HolonReference,
   PropertyName,
+  PropertyDescriptorHandle,
+  RelationshipDescriptorHandle,
   RelationshipName,
 } from './map-sdk';

--- a/host/ui/src/dahn/deps/map-sdk.ts
+++ b/host/ui/src/dahn/deps/map-sdk.ts
@@ -9,16 +9,21 @@ export type {
   ContentSet,
   FileData,
   HolonCollection,
+  HolonDescriptorHandle,
   HolonId,
   HolonReference,
+  PropertyDescriptorHandle,
   ReadableHolon,
+  RelationshipDescriptorHandle,
   PropertyName,
   RelationshipName,
+  AvailableRelationshipHandle,
 } from '../../../../map-sdk/src';
 
 export {
   MapClient,
   MapTransaction,
+  MapError,
   extractNumber,
   extractString,
 } from '../../../../map-sdk/src';

--- a/host/ui/src/dahn/index.ts
+++ b/host/ui/src/dahn/index.ts
@@ -8,6 +8,7 @@ export type {
   HolonViewAccess,
   HolonViewContext,
 } from './contracts/holon-view';
+export { DahnHolonView } from './map-adapter/dahn-holon-view';
 export type {
   SelectorFunction,
   SelectorInput,

--- a/host/ui/src/dahn/map-adapter/dahn-holon-view.test.ts
+++ b/host/ui/src/dahn/map-adapter/dahn-holon-view.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { HolonReference } from '../deps';
+import { DahnHolonView } from './dahn-holon-view';
+
+describe('DahnHolonView', () => {
+  it('provides a read-only view that delegates live reads to the public SDK handle', async () => {
+    const reference = {
+      holonId: vi.fn().mockResolvedValue({ Local: [1] }),
+      key: vi.fn().mockResolvedValue('alpha'),
+      versionedKey: vi.fn().mockResolvedValue('alpha@1'),
+      propertyValue: vi.fn().mockResolvedValue({ StringValue: 'value' }),
+      holonDescriptor: vi.fn().mockResolvedValue({}),
+      availableProperties: vi.fn().mockResolvedValue([]),
+      availableRelationships: vi.fn().mockResolvedValue([]),
+      relatedHolons: vi.fn().mockResolvedValue({ members: [] }),
+    } as unknown as HolonReference;
+    const view = new DahnHolonView(reference);
+
+    await expect(view.key()).resolves.toBe('alpha');
+    await expect(view.propertyValue('Title')).resolves.toEqual({ StringValue: 'value' });
+    await expect(view.expandRelationship('Contains')).resolves.toEqual({ members: [] });
+
+    expect(reference.key).toHaveBeenCalledOnce();
+    expect(reference.propertyValue).toHaveBeenCalledWith('Title');
+    expect(reference.relatedHolons).toHaveBeenCalledWith('Contains');
+    expect('withPropertyValue' in view).toBe(false);
+  });
+
+  it('propagates SDK errors without wrapping them', async () => {
+    const error = new Error('MAP unavailable');
+    const reference = {
+      key: vi.fn().mockRejectedValue(error),
+    } as unknown as HolonReference;
+
+    await expect(new DahnHolonView(reference).key()).rejects.toBe(error);
+  });
+});

--- a/host/ui/src/dahn/map-adapter/dahn-holon-view.test.ts
+++ b/host/ui/src/dahn/map-adapter/dahn-holon-view.test.ts
@@ -5,24 +5,34 @@ import { DahnHolonView } from './dahn-holon-view';
 
 describe('DahnHolonView', () => {
   it('provides a read-only view that delegates live reads to the public SDK handle', async () => {
+    const descriptor = {};
+    const properties = [{}];
+    const relationships = [{ descriptor: {}, direction: 'declared' as const }];
+    const related = { members: [] };
     const reference = {
       holonId: vi.fn().mockResolvedValue({ Local: [1] }),
       key: vi.fn().mockResolvedValue('alpha'),
       versionedKey: vi.fn().mockResolvedValue('alpha@1'),
       propertyValue: vi.fn().mockResolvedValue({ StringValue: 'value' }),
-      holonDescriptor: vi.fn().mockResolvedValue({}),
-      availableProperties: vi.fn().mockResolvedValue([]),
-      availableRelationships: vi.fn().mockResolvedValue([]),
-      relatedHolons: vi.fn().mockResolvedValue({ members: [] }),
+      holonDescriptor: vi.fn().mockResolvedValue(descriptor),
+      availableProperties: vi.fn().mockResolvedValue(properties),
+      availableRelationships: vi.fn().mockResolvedValue(relationships),
+      relatedHolons: vi.fn().mockResolvedValue(related),
     } as unknown as HolonReference;
     const view = new DahnHolonView(reference);
 
     await expect(view.key()).resolves.toBe('alpha');
     await expect(view.propertyValue('Title')).resolves.toEqual({ StringValue: 'value' });
-    await expect(view.expandRelationship('Contains')).resolves.toEqual({ members: [] });
+    await expect(view.descriptor()).resolves.toBe(descriptor);
+    await expect(view.availableProperties()).resolves.toBe(properties);
+    await expect(view.availableRelationships()).resolves.toBe(relationships);
+    await expect(view.expandRelationship('Contains')).resolves.toBe(related);
 
     expect(reference.key).toHaveBeenCalledOnce();
     expect(reference.propertyValue).toHaveBeenCalledWith('Title');
+    expect(reference.holonDescriptor).toHaveBeenCalledOnce();
+    expect(reference.availableProperties).toHaveBeenCalledOnce();
+    expect(reference.availableRelationships).toHaveBeenCalledOnce();
     expect(reference.relatedHolons).toHaveBeenCalledWith('Contains');
     expect('withPropertyValue' in view).toBe(false);
   });

--- a/host/ui/src/dahn/map-adapter/dahn-holon-view.ts
+++ b/host/ui/src/dahn/map-adapter/dahn-holon-view.ts
@@ -1,0 +1,54 @@
+import type {
+  AvailableRelationshipHandle,
+  BaseValue,
+  HolonCollection,
+  HolonDescriptorHandle,
+  HolonId,
+  HolonReference,
+  PropertyDescriptorHandle,
+  PropertyName,
+  RelationshipName,
+} from '../deps';
+import type { HolonViewAccess } from '../contracts/holon-view';
+
+/**
+ * Read-only DAHN view of one transaction-bound MAP holon reference.
+ *
+ * SDK errors intentionally propagate unchanged so DAHN never owns a parallel
+ * lifecycle or error taxonomy.
+ */
+export class DahnHolonView implements HolonViewAccess {
+  constructor(private readonly reference: HolonReference) {}
+
+  holonId(): Promise<HolonId> {
+    return this.reference.holonId();
+  }
+
+  key(): Promise<string | null> {
+    return this.reference.key();
+  }
+
+  versionedKey(): Promise<string> {
+    return this.reference.versionedKey();
+  }
+
+  propertyValue(name: PropertyName): Promise<BaseValue | null> {
+    return this.reference.propertyValue(name);
+  }
+
+  descriptor(): Promise<HolonDescriptorHandle> {
+    return this.reference.holonDescriptor();
+  }
+
+  availableProperties(): Promise<ReadonlyArray<PropertyDescriptorHandle>> {
+    return this.reference.availableProperties();
+  }
+
+  availableRelationships(): Promise<ReadonlyArray<AvailableRelationshipHandle>> {
+    return this.reference.availableRelationships();
+  }
+
+  expandRelationship(name: RelationshipName): Promise<HolonCollection> {
+    return this.reference.relatedHolons(name);
+  }
+}


### PR DESCRIPTION
# Summary

Implements Issue #668: Space Navigator Phase 0 PR 1 — DAHN TypeScript MAP Adapter.

DAHN now has a read-only `DahnHolonView` wrapper around a single bound public-SDK `HolonReference`. The slice exposes generic inspection without transferring materialized holons, descriptor storage fields, or TypeScript-owned descriptor semantics.

Closes #668

## Changes

- Add read-only Command, wire, runtime, and SDK support for:
  - holon descriptor lookup;
  - effective property discovery;
  - lifecycle-valid relationship discovery.
- Return effective properties through the existing `HolonCollection` transport and decode them as ordered typed property-descriptor handles.
- Add a dedicated qualified-relationship result that preserves descriptor identity and declared/inverse direction.
- Add opaque nominal SDK handles for holon, property, and relationship descriptors.
- Add `DahnHolonView`, a read-only DAHN-facing wrapper around one transaction-bound `HolonReference`.
- Preserve public SDK error behavior and retained-context read semantics without DAHN lifecycle prechecks or semantic caching.
- Extend focused contract, wire, SDK, and DAHN boundary tests.

## Design boundaries preserved

- Rust remains the owner of descriptor inheritance, effective-property computation, lifecycle filtering, and relationship availability.
- DAHN receives opaque typed handles rather than descriptor DTOs or storage fields.
- Relationship expansion accepts `RelationshipName`; qualified direction remains discovery metadata.
- No Canvas geometry, visualizer selection, editing, transaction controls, Dance discovery, or command-menu scope is included.

## Validation

- `cargo fmt --manifest-path host/Cargo.toml --all --check`
- Focused `map_commands_contract` and `map_commands_wire` tests
- `npm run typecheck -w map-sdk`
- `npm run web:typecheck -w map-host`
- hApp and host builds
- `npm start`
- `npm test`