### PR TITLE
feat(schema): refine DAHN visualizer and Space Navigator schema bound…

### DIFF
--- a/generated/json-imports/dahn/schema.json
+++ b/generated/json-imports/dahn/schema.json
@@ -1,0 +1,1167 @@
+{
+  "holons": [
+    {
+      "key": "MAP DAHN Schema-v0.1.0",
+      "type": "Schema.HolonType",
+      "properties": {
+        "SchemaName": "MAP DAHN Schema-v0.1.0",
+        "Description": "Non-Core MAP schema for first-class Visualizer Holons, their executable realizations, and type-based applicability. Capability taxonomies, compatibility/release contracts, Visualizer Commons stewardship, and dynamic acquisition are deliberately deferred."
+      },
+      "relationships": [
+        {
+          "name": "DependsOn",
+          "target": [
+            {
+              "$ref": "MAP Core Schema-v0.0.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "MetaVisualizerType.MetaHolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "MetaVisualizerType",
+        "TypeNamePlural": "MetaVisualizerTypes",
+        "DisplayName": "Meta Visualizer Type",
+        "DisplayNamePlural": "Meta Visualizer Types",
+        "Description": "Meta-type for Visualizer Holon Type descriptors. It identifies the descriptor family whose instances are DAHN Visualizer Holons and provides a semantic target for Visualizer-role composition and discovery."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MetaHolonType.MetaTypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "Visualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "Visualizer",
+        "TypeNamePlural": "Visualizers",
+        "DisplayName": "Visualizer",
+        "DisplayNamePlural": "Visualizers",
+        "Description": "Abstract family anchor for DAHN Visualizer Holon Types. Ordinary Visualizer Holons must be described by concrete descendants; their semantic identity is distinct from executable implementation identities.",
+        "IsAbstractType": true,
+        "DefinesInstanceTypeKind": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(Visualizer.HolonType)-[ImplementedBy]->(VisualizerImplementation.HolonType)"
+            },
+            {
+              "$ref": "(Visualizer.HolonType)-[ApplicableToType]->(HolonType.TypeDescriptor)"
+            },
+            {
+              "$ref": "(Visualizer.HolonType)-[UsesLayout]->(Layout.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "CanvasVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "CanvasVisualizer",
+        "TypeNamePlural": "CanvasVisualizers",
+        "DisplayName": "Canvas Visualizer",
+        "DisplayNamePlural": "Canvas Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that compose a canvas experience."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "NodeVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "NodeVisualizer",
+        "TypeNamePlural": "NodeVisualizers",
+        "DisplayName": "Node Visualizer",
+        "DisplayNamePlural": "Node Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent individual holons."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "CollectionVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "CollectionVisualizer",
+        "TypeNamePlural": "CollectionVisualizers",
+        "DisplayName": "Collection Visualizer",
+        "DisplayNamePlural": "Collection Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent holon collections."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "PropertyVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "PropertyVisualizer",
+        "TypeNamePlural": "PropertyVisualizers",
+        "DisplayName": "Property Visualizer",
+        "DisplayNamePlural": "Property Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent properties."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ValueVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "ValueVisualizer",
+        "TypeNamePlural": "ValueVisualizers",
+        "DisplayName": "Value Visualizer",
+        "DisplayNamePlural": "Value Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent values."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ActionVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "ActionVisualizer",
+        "TypeNamePlural": "ActionVisualizers",
+        "DisplayName": "Action Visualizer",
+        "DisplayNamePlural": "Action Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent actions."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "GraphVisualizer.HolonType",
+      "type": "MetaVisualizerType.MetaHolonType",
+      "properties": {
+        "TypeName": "GraphVisualizer",
+        "TypeNamePlural": "GraphVisualizers",
+        "DisplayName": "Graph Visualizer",
+        "DisplayNamePlural": "Graph Visualizers",
+        "Description": "Concrete Visualizer Holon Type for visualizers that represent graph-oriented views."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementation.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "VisualizerImplementation",
+        "TypeNamePlural": "VisualizerImplementations",
+        "DisplayName": "Visualizer Implementation",
+        "DisplayNamePlural": "Visualizer Implementations",
+        "Description": "Concrete semantic identity for one executable realization of a Visualizer Holon. Its runtime and stable implementation key support static resolution without making a client registry semantic authority. Acquisition, compatibility, and implementation-private behavior are deferred."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceProperties",
+          "target": [
+            {
+              "$ref": "VisualizerImplementationRuntime.PropertyType"
+            },
+            {
+              "$ref": "VisualizerImplementationKey.PropertyType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "Layout.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "Layout",
+        "TypeNamePlural": "Layouts",
+        "DisplayName": "Layout",
+        "DisplayNamePlural": "Layouts",
+        "Description": "First-class semantic layout identity used by a Visualizer for its internal composition. Layouts organize semantic VisualizerSlots only in this first cut; slot ordering, horizontal and vertical flow, nesting, grouping, grid, stack and overlay, gaps and padding, alignment, sizing, responsive variants, and compression variants are deferred."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(Layout.HolonType)-[HasSlot]->(VisualizerSlot.HolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerSlot.HolonType",
+      "type": "MetaHolonType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "VisualizerSlot",
+        "TypeNamePlural": "VisualizerSlots",
+        "DisplayName": "Visualizer Slot",
+        "DisplayNamePlural": "Visualizer Slots",
+        "Description": "Semantic role-bearing location within a Layout that declares one or more accepted Visualizer Holon Type roles. This is not runtime child occupancy; runtime occupancy, slot naming, layout policies, and selection constraints are deferred."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "InstanceRelationships",
+          "target": [
+            {
+              "$ref": "(VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(Visualizer.HolonType)-[ImplementedBy]->(VisualizerImplementation.HolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "ImplementedBy",
+        "TypeNamePlural": "ImplementedByRelationships",
+        "DisplayName": "ImplementedBy Relationship",
+        "DisplayNamePlural": "ImplementedBy Relationships",
+        "Description": "Relates a Visualizer Holon to one or more executable realization identities without making any realization the Visualizer's durable semantic identity.",
+        "DeletionSemantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "VisualizerImplementation.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(VisualizerImplementation.HolonType)-[ImplementsVisualizer]->(Visualizer.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(VisualizerImplementation.HolonType)-[ImplementsVisualizer]->(Visualizer.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "ImplementsVisualizer",
+        "TypeNamePlural": "ImplementsVisualizerRelationships",
+        "DisplayName": "ImplementsVisualizer Relationship",
+        "DisplayNamePlural": "ImplementsVisualizer Relationships",
+        "Description": "Inverse of ImplementedBy. Each first-cut VisualizerImplementation realizes exactly one Visualizer Holon.",
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "VisualizerImplementation.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ExactlyOne.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(Visualizer.HolonType)-[ApplicableToType]->(HolonType.TypeDescriptor)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "ApplicableToType",
+        "TypeNamePlural": "ApplicableToTypeRelationships",
+        "DisplayName": "ApplicableToType Relationship",
+        "DisplayNamePlural": "ApplicableToType Relationships",
+        "Description": "Declares a subject Holon Type against which a selector evaluates a Visualizer Holon's applicability using the subject's direct descriptor and type lineage. A target of HolonType.TypeDescriptor means any ordinary subject described by a Holon Type, not descriptor holons as subjects. Additional applicability dimensions remain additive schema work.",
+        "DeletionSemantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(HolonType.TypeDescriptor)-[HasApplicableVisualizer]->(Visualizer.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(HolonType.TypeDescriptor)-[HasApplicableVisualizer]->(Visualizer.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "HasApplicableVisualizer",
+        "TypeNamePlural": "HasApplicableVisualizerRelationships",
+        "DisplayName": "HasApplicableVisualizer Relationship",
+        "DisplayNamePlural": "HasApplicableVisualizer Relationships",
+        "Description": "Inverse of ApplicableToType, exposing the Visualizer Holons applicable to a Holon Type.",
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(Visualizer.HolonType)-[UsesLayout]->(Layout.HolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "UsesLayout",
+        "TypeNamePlural": "UsesLayoutRelationships",
+        "DisplayName": "UsesLayout Relationship",
+        "DisplayNamePlural": "UsesLayout Relationships",
+        "Description": "Associates a Visualizer Holon with at most one semantic Layout for its internal composition, without encoding pixel geometry or global placement.",
+        "DeletionSemantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "Layout.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(Layout.HolonType)-[LayoutUsedBy]->(Visualizer.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrOne.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(Layout.HolonType)-[LayoutUsedBy]->(Visualizer.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "LayoutUsedBy",
+        "TypeNamePlural": "LayoutUsedByRelationships",
+        "DisplayName": "LayoutUsedBy Relationship",
+        "DisplayNamePlural": "LayoutUsedBy Relationships",
+        "Description": "Inverse of UsesLayout, exposing Visualizer Holons that use a semantic Layout.",
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "Layout.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "Visualizer.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(Layout.HolonType)-[HasSlot]->(VisualizerSlot.HolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "HasSlot",
+        "TypeNamePlural": "HasSlotRelationships",
+        "DisplayName": "HasSlot Relationship",
+        "DisplayNamePlural": "HasSlot Relationships",
+        "Description": "Declares the semantic VisualizerSlots that a Layout organizes.",
+        "DeletionSemantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "Layout.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "VisualizerSlot.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(VisualizerSlot.HolonType)-[SlotForLayout]->(Layout.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(VisualizerSlot.HolonType)-[SlotForLayout]->(Layout.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "SlotForLayout",
+        "TypeNamePlural": "SlotForLayoutRelationships",
+        "DisplayName": "SlotForLayout Relationship",
+        "DisplayNamePlural": "SlotForLayout Relationships",
+        "Description": "Inverse of HasSlot. Each first-cut VisualizerSlot belongs to exactly one Layout.",
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "VisualizerSlot.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "Layout.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ExactlyOne.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType)",
+      "type": "MetaDeclaredRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "AcceptsVisualizerType",
+        "TypeNamePlural": "AcceptsVisualizerTypeRelationships",
+        "DisplayName": "AcceptsVisualizerType Relationship",
+        "DisplayNamePlural": "AcceptsVisualizerType Relationships",
+        "Description": "Declares one or more Visualizer Holon Type roles accepted by a semantic slot. Its cardinality applies to accepted role declarations, not runtime child occupancy; runtime-selected Visualizer occupancy belongs to an experience occurrence and is not persisted in the Layout.",
+        "DeletionSemantic": "Allow"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "DeclaredRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "VisualizerSlot.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "MetaVisualizerType.MetaHolonType"
+            }
+          ]
+        },
+        {
+          "name": "HasInverse",
+          "target": [
+            {
+              "$ref": "(MetaVisualizerType.MetaHolonType)-[AcceptedByVisualizerSlot]->(VisualizerSlot.HolonType)"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "OneOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "(MetaVisualizerType.MetaHolonType)-[AcceptedByVisualizerSlot]->(VisualizerSlot.HolonType)",
+      "type": "MetaInverseRelationshipType.MetaRelationshipType",
+      "properties": {
+        "TypeName": "AcceptedByVisualizerSlot",
+        "TypeNamePlural": "AcceptedByVisualizerSlotRelationships",
+        "DisplayName": "AcceptedByVisualizerSlot Relationship",
+        "DisplayNamePlural": "AcceptedByVisualizerSlot Relationships",
+        "Description": "Inverse of AcceptsVisualizerType, exposing the semantic slots that accept a Visualizer Holon Type role.",
+        "DeletionSemantic": "Block"
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "InverseRelationshipType.RelationshipType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "SourceType",
+          "target": [
+            {
+              "$ref": "MetaVisualizerType.MetaHolonType"
+            }
+          ]
+        },
+        {
+          "name": "TargetType",
+          "target": [
+            {
+              "$ref": "VisualizerSlot.HolonType"
+            }
+          ]
+        },
+        {
+          "name": "Constraints",
+          "target": [
+            {
+              "$ref": "ZeroOrMore.CardinalityConstraint"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementationRuntime.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "VisualizerImplementationRuntime",
+        "TypeNamePlural": "VisualizerImplementationRuntimes",
+        "DisplayName": "visualizer_implementation_runtime",
+        "DisplayNamePlural": "visualizer_implementation_runtimes",
+        "Description": "Runtime in which a VisualizerImplementation is executable; the initial runtime set is intentionally small and extensible.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "VisualizerImplementationRuntime.MapEnumValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementationKey.PropertyType",
+      "type": "MetaPropertyType.MetaTypeDescriptor",
+      "properties": {
+        "TypeName": "VisualizerImplementationKey",
+        "TypeNamePlural": "VisualizerImplementationKeys",
+        "DisplayName": "visualizer_implementation_key",
+        "DisplayNamePlural": "visualizer_implementation_keys",
+        "Description": "Stable symbolic key by which a statically bundled runtime may resolve a VisualizerImplementation to executable code.",
+        "IsValueRequired": true
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "PropertyType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "ValueType",
+          "target": [
+            {
+              "$ref": "MapStringValueType.StringValueType"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementationRuntime.MapEnumValueType",
+      "type": "MetaEnumValueType.MetaValueType",
+      "properties": {
+        "TypeName": "VisualizerImplementationRuntime",
+        "TypeNamePlural": "VisualizerImplementationRuntimes",
+        "DisplayName": "Visualizer Implementation Runtime",
+        "DisplayNamePlural": "Visualizer Implementation Runtimes",
+        "Description": "Initial execution runtime variants supported by VisualizerImplementation identities; future runtime variants may be added without changing semantic Visualizer identity."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumValueType.EnumValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        },
+        {
+          "name": "Variants",
+          "target": [
+            {
+              "$ref": "VisualizerImplementationRuntime.MapEnumValueType.TypeScript"
+            },
+            {
+              "$ref": "VisualizerImplementationRuntime.MapEnumValueType.Rust"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementationRuntime.MapEnumValueType.TypeScript",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "TypeScript",
+        "TypeNamePlural": "TypeScript",
+        "DisplayName": "TypeScript",
+        "DisplayNamePlural": "TypeScript",
+        "Description": "A TypeScript implementation bundled with a DAHN client."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "VisualizerImplementationRuntime.MapEnumValueType.Rust",
+      "type": "MetaEnumVariantValueType.MetaValueType",
+      "properties": {
+        "TypeName": "Rust",
+        "TypeNamePlural": "Rust",
+        "DisplayName": "Rust",
+        "DisplayNamePlural": "Rust",
+        "Description": "A Rust implementation available to the MAP host runtime."
+      },
+      "relationships": [
+        {
+          "name": "Extends",
+          "target": [
+            {
+              "$ref": "MapEnumVariantValueType.EnumVariantValueType"
+            }
+          ]
+        },
+        {
+          "name": "ComponentOf",
+          "target": [
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/generated/json-imports/space-navigator/schema.json
+++ b/generated/json-imports/space-navigator/schema.json
@@ -1,0 +1,102 @@
+{
+  "holons": [
+    {
+      "key": "MAP Space Navigator Schema-v0.1.0",
+      "type": "Schema.HolonType",
+      "properties": {
+        "SchemaName": "MAP Space Navigator Schema-v0.1.0",
+        "Description": "Non-Core MAP schema for the Space Navigator's statically bundled fallback Visualizer Holons and their locally resolvable implementation identities. These static mappings resolve semantic VisualizerImplementation Holons; they do not create TypeScript-only Visualizer identities. TableCollectionVisualizer intentionally omits ApplicableToType because shape-based collection applicability is deferred."
+      },
+      "relationships": [
+        {
+          "name": "DependsOn",
+          "target": [
+            {
+              "$ref": "MAP Core Schema-v0.0.7"
+            },
+            {
+              "$ref": "MAP DAHN Schema-v0.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "SpaceNavigator.CanvasVisualizer",
+      "type": "CanvasVisualizer.HolonType",
+      "properties": {},
+      "relationships": [
+        {
+          "name": "ImplementedBy",
+          "target": [
+            {
+              "$ref": "SpaceNavigatorTypeScript.VisualizerImplementation"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "GenericHolonNodeVisualizer.NodeVisualizer",
+      "type": "NodeVisualizer.HolonType",
+      "properties": {},
+      "relationships": [
+        {
+          "name": "ApplicableToType",
+          "target": [
+            {
+              "$ref": "HolonType.TypeDescriptor"
+            }
+          ]
+        },
+        {
+          "name": "ImplementedBy",
+          "target": [
+            {
+              "$ref": "GenericHolonNodeTypeScript.VisualizerImplementation"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "TableCollectionVisualizer.CollectionVisualizer",
+      "type": "CollectionVisualizer.HolonType",
+      "properties": {},
+      "relationships": [
+        {
+          "name": "ImplementedBy",
+          "target": [
+            {
+              "$ref": "TableCollectionTypeScript.VisualizerImplementation"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "SpaceNavigatorTypeScript.VisualizerImplementation",
+      "type": "VisualizerImplementation.HolonType",
+      "properties": {
+        "VisualizerImplementationKey": "dahn.space-navigator",
+        "VisualizerImplementationRuntime": "TypeScript"
+      }
+    },
+    {
+      "key": "GenericHolonNodeTypeScript.VisualizerImplementation",
+      "type": "VisualizerImplementation.HolonType",
+      "properties": {
+        "VisualizerImplementationKey": "dahn.generic-holon-node",
+        "VisualizerImplementationRuntime": "TypeScript"
+      }
+    },
+    {
+      "key": "TableCollectionTypeScript.VisualizerImplementation",
+      "type": "VisualizerImplementation.HolonType",
+      "properties": {
+        "VisualizerImplementationKey": "dahn.table-collection",
+        "VisualizerImplementationRuntime": "TypeScript"
+      }
+    }
+  ]
+}

--- a/schema-src/dahn/schema.tdl
+++ b/schema-src/dahn/schema.tdl
@@ -1,0 +1,392 @@
+schema "MAP DAHN Schema-v0.1.0" {
+  depends_on "MAP Core Schema-v0.0.7"
+  header {
+    description: "Non-Core MAP schema for first-class Visualizer Holons, their executable realizations, and type-based applicability. Capability taxonomies, compatibility/release contracts, Visualizer Commons stewardship, and dynamic acquisition are deliberately deferred."
+  }
+}
+
+holon MetaVisualizerType.MetaHolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends MetaHolonType.MetaTypeDescriptor
+  header {
+    description: "Meta-type for Visualizer Holon Type descriptors. It identifies the descriptor family whose instances are DAHN Visualizer Holons and provides a semantic target for Visualizer-role composition and discovery."
+    display_name: "Meta Visualizer Type"
+    display_plural: "Meta Visualizer Types"
+    plural: "MetaVisualizerTypes"
+  }
+}
+
+abstract holon Visualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends HolonType.TypeDescriptor
+  DefinesInstanceTypeKind true
+  header {
+    description: "Abstract family anchor for DAHN Visualizer Holon Types. Ordinary Visualizer Holons must be described by concrete descendants; their semantic identity is distinct from executable implementation identities."
+    display_name: "Visualizer"
+    display_plural: "Visualizers"
+    plural: "Visualizers"
+  }
+  relationships {
+    InstanceRelationships -> [
+      (Visualizer.HolonType)-[ImplementedBy]->(VisualizerImplementation.HolonType),
+      (Visualizer.HolonType)-[ApplicableToType]->(HolonType.TypeDescriptor),
+      (Visualizer.HolonType)-[UsesLayout]->(Layout.HolonType)
+    ]
+  }
+}
+
+holon CanvasVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that compose a canvas experience."
+    display_name: "Canvas Visualizer"
+    display_plural: "Canvas Visualizers"
+    plural: "CanvasVisualizers"
+  }
+}
+
+holon NodeVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent individual holons."
+    display_name: "Node Visualizer"
+    display_plural: "Node Visualizers"
+    plural: "NodeVisualizers"
+  }
+}
+
+holon CollectionVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent holon collections."
+    display_name: "Collection Visualizer"
+    display_plural: "Collection Visualizers"
+    plural: "CollectionVisualizers"
+  }
+}
+
+holon PropertyVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent properties."
+    display_name: "Property Visualizer"
+    display_plural: "Property Visualizers"
+    plural: "PropertyVisualizers"
+  }
+}
+
+holon ValueVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent values."
+    display_name: "Value Visualizer"
+    display_plural: "Value Visualizers"
+    plural: "ValueVisualizers"
+  }
+}
+
+holon ActionVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent actions."
+    display_name: "Action Visualizer"
+    display_plural: "Action Visualizers"
+    plural: "ActionVisualizers"
+  }
+}
+
+holon GraphVisualizer.HolonType {
+  type MetaVisualizerType.MetaHolonType
+  extends Visualizer.HolonType
+  header {
+    description: "Concrete Visualizer Holon Type for visualizers that represent graph-oriented views."
+    display_name: "Graph Visualizer"
+    display_plural: "Graph Visualizers"
+    plural: "GraphVisualizers"
+  }
+}
+
+holon VisualizerImplementation.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "Concrete semantic identity for one executable realization of a Visualizer Holon. Its runtime and stable implementation key support static resolution without making a client registry semantic authority. Acquisition, compatibility, and implementation-private behavior are deferred."
+    display_name: "Visualizer Implementation"
+    display_plural: "Visualizer Implementations"
+    plural: "VisualizerImplementations"
+  }
+  relationships {
+    InstanceProperties -> [
+      VisualizerImplementationRuntime.PropertyType,
+      VisualizerImplementationKey.PropertyType
+    ]
+  }
+}
+
+holon Layout.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "First-class semantic layout identity used by a Visualizer for its internal composition. Layouts organize semantic VisualizerSlots only in this first cut; slot ordering, horizontal and vertical flow, nesting, grouping, grid, stack and overlay, gaps and padding, alignment, sizing, responsive variants, and compression variants are deferred."
+    display_name: "Layout"
+    display_plural: "Layouts"
+    plural: "Layouts"
+  }
+  relationships {
+    InstanceRelationships -> (Layout.HolonType)-[HasSlot]->(VisualizerSlot.HolonType)
+  }
+}
+
+holon VisualizerSlot.HolonType {
+  type MetaHolonType.MetaTypeDescriptor
+  extends HolonType.TypeDescriptor
+  header {
+    description: "Semantic role-bearing location within a Layout that declares one or more accepted Visualizer Holon Type roles. This is not runtime child occupancy; runtime occupancy, slot naming, layout policies, and selection constraints are deferred."
+    display_name: "Visualizer Slot"
+    display_plural: "Visualizer Slots"
+    plural: "VisualizerSlots"
+  }
+  relationships {
+    InstanceRelationships -> (VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType)
+  }
+}
+
+relationship (Visualizer.HolonType)-[ImplementedBy]->(VisualizerImplementation.HolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+    HasInverse -> ImplementsVisualizer
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source Visualizer.HolonType
+  target VisualizerImplementation.HolonType
+  deletion_semantic Allow
+  header {
+    description: "Relates a Visualizer Holon to one or more executable realization identities without making any realization the Visualizer's durable semantic identity."
+    display_name: "ImplementedBy Relationship"
+    display_plural: "ImplementedBy Relationships"
+    plural: "ImplementedByRelationships"
+  }
+}
+
+inverse relationship (VisualizerImplementation.HolonType)-[ImplementsVisualizer]->(Visualizer.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source VisualizerImplementation.HolonType
+  target Visualizer.HolonType
+  relationships {
+    Constraints -> ExactlyOne.CardinalityConstraint
+  }
+  deletion_semantic Block
+  header {
+    description: "Inverse of ImplementedBy. Each first-cut VisualizerImplementation realizes exactly one Visualizer Holon."
+    display_name: "ImplementsVisualizer Relationship"
+    display_plural: "ImplementsVisualizer Relationships"
+    plural: "ImplementsVisualizerRelationships"
+  }
+}
+
+relationship (Visualizer.HolonType)-[ApplicableToType]->(HolonType.TypeDescriptor) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+    HasInverse -> HasApplicableVisualizer
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source Visualizer.HolonType
+  target HolonType.TypeDescriptor
+  deletion_semantic Allow
+  header {
+    description: "Declares a subject Holon Type against which a selector evaluates a Visualizer Holon's applicability using the subject's direct descriptor and type lineage. A target of HolonType.TypeDescriptor means any ordinary subject described by a Holon Type, not descriptor holons as subjects. Additional applicability dimensions remain additive schema work."
+    display_name: "ApplicableToType Relationship"
+    display_plural: "ApplicableToType Relationships"
+    plural: "ApplicableToTypeRelationships"
+  }
+}
+
+inverse relationship (HolonType.TypeDescriptor)-[HasApplicableVisualizer]->(Visualizer.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source HolonType.TypeDescriptor
+  target Visualizer.HolonType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+  }
+  deletion_semantic Block
+  header {
+    description: "Inverse of ApplicableToType, exposing the Visualizer Holons applicable to a Holon Type."
+    display_name: "HasApplicableVisualizer Relationship"
+    display_plural: "HasApplicableVisualizer Relationships"
+    plural: "HasApplicableVisualizerRelationships"
+  }
+}
+
+relationship (Visualizer.HolonType)-[UsesLayout]->(Layout.HolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    Constraints -> ZeroOrOne.CardinalityConstraint
+    HasInverse -> LayoutUsedBy
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source Visualizer.HolonType
+  target Layout.HolonType
+  deletion_semantic Allow
+  header {
+    description: "Associates a Visualizer Holon with at most one semantic Layout for its internal composition, without encoding pixel geometry or global placement."
+    display_name: "UsesLayout Relationship"
+    display_plural: "UsesLayout Relationships"
+    plural: "UsesLayoutRelationships"
+  }
+}
+
+inverse relationship (Layout.HolonType)-[LayoutUsedBy]->(Visualizer.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source Layout.HolonType
+  target Visualizer.HolonType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+  }
+  deletion_semantic Block
+  header {
+    description: "Inverse of UsesLayout, exposing Visualizer Holons that use a semantic Layout."
+    display_name: "LayoutUsedBy Relationship"
+    display_plural: "LayoutUsedBy Relationships"
+    plural: "LayoutUsedByRelationships"
+  }
+}
+
+relationship (Layout.HolonType)-[HasSlot]->(VisualizerSlot.HolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+    HasInverse -> SlotForLayout
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source Layout.HolonType
+  target VisualizerSlot.HolonType
+  deletion_semantic Allow
+  header {
+    description: "Declares the semantic VisualizerSlots that a Layout organizes."
+    display_name: "HasSlot Relationship"
+    display_plural: "HasSlot Relationships"
+    plural: "HasSlotRelationships"
+  }
+}
+
+inverse relationship (VisualizerSlot.HolonType)-[SlotForLayout]->(Layout.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source VisualizerSlot.HolonType
+  target Layout.HolonType
+  relationships {
+    Constraints -> ExactlyOne.CardinalityConstraint
+  }
+  deletion_semantic Block
+  header {
+    description: "Inverse of HasSlot. Each first-cut VisualizerSlot belongs to exactly one Layout."
+    display_name: "SlotForLayout Relationship"
+    display_plural: "SlotForLayout Relationships"
+    plural: "SlotForLayoutRelationships"
+  }
+}
+
+relationship (VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType) {
+  type MetaDeclaredRelationshipType.MetaRelationshipType
+  relationships {
+    Constraints -> OneOrMore.CardinalityConstraint
+    HasInverse -> AcceptedByVisualizerSlot
+  }
+  extends DeclaredRelationshipType.RelationshipType
+  source VisualizerSlot.HolonType
+  target MetaVisualizerType.MetaHolonType
+  deletion_semantic Allow
+  header {
+    description: "Declares one or more Visualizer Holon Type roles accepted by a semantic slot. Its cardinality applies to accepted role declarations, not runtime child occupancy; runtime-selected Visualizer occupancy belongs to an experience occurrence and is not persisted in the Layout."
+    display_name: "AcceptsVisualizerType Relationship"
+    display_plural: "AcceptsVisualizerType Relationships"
+    plural: "AcceptsVisualizerTypeRelationships"
+  }
+}
+
+inverse relationship (MetaVisualizerType.MetaHolonType)-[AcceptedByVisualizerSlot]->(VisualizerSlot.HolonType) {
+  type MetaInverseRelationshipType.MetaRelationshipType
+  extends InverseRelationshipType.RelationshipType
+  source MetaVisualizerType.MetaHolonType
+  target VisualizerSlot.HolonType
+  relationships {
+    Constraints -> ZeroOrMore.CardinalityConstraint
+  }
+  deletion_semantic Block
+  header {
+    description: "Inverse of AcceptsVisualizerType, exposing the semantic slots that accept a Visualizer Holon Type role."
+    display_name: "AcceptedByVisualizerSlot Relationship"
+    display_plural: "AcceptedByVisualizerSlot Relationships"
+    plural: "AcceptedByVisualizerSlotRelationships"
+  }
+}
+
+property VisualizerImplementationRuntime.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value VisualizerImplementationRuntime.MapEnumValueType
+  IsValueRequired true
+  header {
+    description: "Runtime in which a VisualizerImplementation is executable; the initial runtime set is intentionally small and extensible."
+    display_name: "visualizer_implementation_runtime"
+    display_plural: "visualizer_implementation_runtimes"
+    plural: "VisualizerImplementationRuntimes"
+  }
+}
+
+property VisualizerImplementationKey.PropertyType {
+  type MetaPropertyType.MetaTypeDescriptor
+  extends PropertyType.TypeDescriptor
+  value MapStringValueType.StringValueType
+  IsValueRequired true
+  header {
+    description: "Stable symbolic key by which a statically bundled runtime may resolve a VisualizerImplementation to executable code."
+    display_name: "visualizer_implementation_key"
+    display_plural: "visualizer_implementation_keys"
+    plural: "VisualizerImplementationKeys"
+  }
+}
+
+enum VisualizerImplementationRuntime.MapEnumValueType {
+  type MetaEnumValueType.MetaValueType
+  extends MapEnumValueType.EnumValueType
+  header {
+    description: "Initial execution runtime variants supported by VisualizerImplementation identities; future runtime variants may be added without changing semantic Visualizer identity."
+    display_name: "Visualizer Implementation Runtime"
+    display_plural: "Visualizer Implementation Runtimes"
+    plural: "VisualizerImplementationRuntimes"
+  }
+  variants {
+    variant TypeScript {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "A TypeScript implementation bundled with a DAHN client."
+        display_name: "TypeScript"
+        display_plural: "TypeScript"
+        plural: "TypeScript"
+      }
+    }
+    variant Rust {
+      type MetaEnumVariantValueType.MetaValueType
+      extends MapEnumVariantValueType.EnumVariantValueType
+      header {
+        description: "A Rust implementation available to the MAP host runtime."
+        display_name: "Rust"
+        display_plural: "Rust"
+        plural: "Rust"
+      }
+    }
+  }
+}

--- a/schema-src/space-navigator/schema.tdl
+++ b/schema-src/space-navigator/schema.tdl
@@ -1,0 +1,47 @@
+schema "MAP Space Navigator Schema-v0.1.0" {
+  depends_on "MAP Core Schema-v0.0.7"
+  depends_on "MAP DAHN Schema-v0.1.0"
+  header {
+    description: "Non-Core MAP schema for the Space Navigator's statically bundled fallback Visualizer Holons and their locally resolvable implementation identities. These static mappings resolve semantic VisualizerImplementation Holons; they do not create TypeScript-only Visualizer identities. TableCollectionVisualizer intentionally omits ApplicableToType because shape-based collection applicability is deferred."
+  }
+}
+
+instance SpaceNavigator.CanvasVisualizer {
+  type CanvasVisualizer.HolonType
+  relationships {
+    ImplementedBy -> SpaceNavigatorTypeScript.VisualizerImplementation
+  }
+}
+
+instance GenericHolonNodeVisualizer.NodeVisualizer {
+  type NodeVisualizer.HolonType
+  relationships {
+    ImplementedBy -> GenericHolonNodeTypeScript.VisualizerImplementation
+    ApplicableToType -> HolonType.TypeDescriptor
+  }
+}
+
+instance TableCollectionVisualizer.CollectionVisualizer {
+  type CollectionVisualizer.HolonType
+  relationships {
+    ImplementedBy -> TableCollectionTypeScript.VisualizerImplementation
+  }
+}
+
+instance SpaceNavigatorTypeScript.VisualizerImplementation {
+  type VisualizerImplementation.HolonType
+  VisualizerImplementationRuntime TypeScript
+  VisualizerImplementationKey "dahn.space-navigator"
+}
+
+instance GenericHolonNodeTypeScript.VisualizerImplementation {
+  type VisualizerImplementation.HolonType
+  VisualizerImplementationRuntime TypeScript
+  VisualizerImplementationKey "dahn.generic-holon-node"
+}
+
+instance TableCollectionTypeScript.VisualizerImplementation {
+  type VisualizerImplementation.HolonType
+  VisualizerImplementationRuntime TypeScript
+  VisualizerImplementationKey "dahn.table-collection"
+}

--- a/tools/map-schema/src/tdl_compiler.rs
+++ b/tools/map-schema/src/tdl_compiler.rs
@@ -2142,7 +2142,7 @@ holon Example.HolonType {
     #[test]
     fn core_schema_check_accepts_tdl_v09_corpus() -> Result<()> {
         let fixture_root = fixture_dir();
-        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 16);
+        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 18);
 
         let diagnostics = check_inputs(&[fixture_root])?;
 
@@ -2164,8 +2164,8 @@ holon Example.HolonType {
         let parsed = parse_inputs(&[fixture_root.clone()])?;
         let compilation = build_r6_compilation(parsed)?;
 
-        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 16);
-        assert_eq!(compilation.files.len(), 16);
+        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 18);
+        assert_eq!(compilation.files.len(), 18);
         assert!(compilation
             .files
             .iter()
@@ -2180,8 +2180,8 @@ holon Example.HolonType {
         let out_dir = temp_out_dir();
         let compiled_files = compile_inputs(&[fixture_root.clone()], &out_dir)?;
 
-        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 16);
-        assert_eq!(compiled_files.len(), 16);
+        assert_eq!(discovered_tdl_file_count(&fixture_root)?, 18);
+        assert_eq!(compiled_files.len(), 18);
 
         let root_json = fs::read_to_string(out_dir.join("core/root.json"))?;
         assert!(root_json.contains(r#""TypeName""#));
@@ -2190,6 +2190,150 @@ holon Example.HolonType {
         assert!(!root_json.contains(r#""InstanceTypeKind""#));
         assert!(root_json.contains(r#""meta""#));
         assert!(root_json.contains(r#""load_with""#));
+
+        Ok(())
+    }
+
+    #[test]
+    fn dahn_and_space_navigator_schemas_separate_types_from_bootstrap_holons() -> Result<()> {
+        let out_dir = temp_out_dir();
+        compile_inputs(&[fixture_dir()], &out_dir)?;
+
+        let dahn: Value =
+            serde_json::from_str(&fs::read_to_string(out_dir.join("dahn/schema.json"))?)?;
+        let holons = dahn["holons"].as_array().expect("DAHN schema holons array");
+
+        for key in [
+            "CanvasVisualizer.HolonType",
+            "NodeVisualizer.HolonType",
+            "CollectionVisualizer.HolonType",
+            "PropertyVisualizer.HolonType",
+            "ValueVisualizer.HolonType",
+            "ActionVisualizer.HolonType",
+            "GraphVisualizer.HolonType",
+        ] {
+            let visualizer_type = holons
+                .iter()
+                .find(|holon| holon["key"].as_str() == Some(key))
+                .with_context(|| format!("{key} descriptor"))?;
+            let extends = visualizer_type["relationships"]
+                .as_array()
+                .and_then(|relationships| {
+                    relationships
+                        .iter()
+                        .find(|relationship| relationship["name"].as_str() == Some("Extends"))
+                })
+                .context("Extends relationship")?;
+            assert_eq!(extends["target"][0]["$ref"], "Visualizer.HolonType");
+        }
+
+        let space_navigator: Value = serde_json::from_str(&fs::read_to_string(
+            out_dir.join("space-navigator/schema.json"),
+        )?)?;
+        let space_navigator_holons =
+            space_navigator["holons"].as_array().expect("Space Navigator schema holons array");
+        let generic_node_visualizer = space_navigator_holons
+            .iter()
+            .find(|holon| {
+                holon["key"].as_str() == Some("GenericHolonNodeVisualizer.NodeVisualizer")
+            })
+            .context("Generic Holon Node Visualizer bootstrap holon")?;
+        assert_eq!(generic_node_visualizer["type"], "NodeVisualizer.HolonType");
+
+        let relationships = generic_node_visualizer["relationships"]
+            .as_array()
+            .context("Generic Holon Node Visualizer relationships")?;
+        let applicable_to_type = relationships
+            .iter()
+            .find(|relationship| relationship["name"].as_str() == Some("ApplicableToType"))
+            .context("ApplicableToType relationship")?;
+        assert_eq!(applicable_to_type["target"][0]["$ref"], "HolonType.TypeDescriptor");
+        let implemented_by = relationships
+            .iter()
+            .find(|relationship| relationship["name"].as_str() == Some("ImplementedBy"))
+            .context("ImplementedBy relationship")?;
+        assert_eq!(
+            implemented_by["target"][0]["$ref"],
+            "GenericHolonNodeTypeScript.VisualizerImplementation"
+        );
+
+        let generic_node_implementation = space_navigator_holons
+            .iter()
+            .find(|holon| {
+                holon["key"].as_str() == Some("GenericHolonNodeTypeScript.VisualizerImplementation")
+            })
+            .context("Generic Holon Node Visualizer implementation")?;
+        assert_eq!(
+            generic_node_implementation["properties"]["VisualizerImplementationRuntime"],
+            "TypeScript"
+        );
+        assert_eq!(
+            generic_node_implementation["properties"]["VisualizerImplementationKey"],
+            "dahn.generic-holon-node"
+        );
+
+        let layout_type = holons
+            .iter()
+            .find(|holon| holon["key"].as_str() == Some("Layout.HolonType"))
+            .context("Layout descriptor")?;
+        assert_eq!(layout_type["type"], "MetaHolonType.MetaTypeDescriptor");
+        let visualizer_slot_type = holons
+            .iter()
+            .find(|holon| holon["key"].as_str() == Some("VisualizerSlot.HolonType"))
+            .context("VisualizerSlot descriptor")?;
+        assert_eq!(visualizer_slot_type["type"], "MetaHolonType.MetaTypeDescriptor");
+        let slot_contract = visualizer_slot_type["relationships"]
+            .as_array()
+            .and_then(|relationships| {
+                relationships.iter().find(|relationship| {
+                    relationship["name"].as_str() == Some("InstanceRelationships")
+                        && relationship["target"].as_array().is_some_and(|targets| {
+                            targets.iter().any(|target| {
+                                target["$ref"]
+                                    == "(VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType)"
+                            })
+                        })
+                })
+            })
+            .context("AcceptsVisualizerType instance contract")?;
+        assert!(!slot_contract["target"].as_array().unwrap().is_empty());
+        let accepts_visualizer_type = holons
+            .iter()
+            .find(|holon| {
+                holon["key"].as_str()
+                    == Some(
+                        "(VisualizerSlot.HolonType)-[AcceptsVisualizerType]->(MetaVisualizerType.MetaHolonType)",
+                    )
+            })
+            .context("AcceptsVisualizerType descriptor")?;
+        let accepts_constraints = accepts_visualizer_type["relationships"]
+            .as_array()
+            .and_then(|relationships| {
+                relationships
+                    .iter()
+                    .find(|relationship| relationship["name"].as_str() == Some("Constraints"))
+            })
+            .context("AcceptsVisualizerType cardinality constraint")?;
+        assert_eq!(accepts_constraints["target"][0]["$ref"], "OneOrMore.CardinalityConstraint");
+        let visualizer_type = holons
+            .iter()
+            .find(|holon| holon["key"].as_str() == Some("Visualizer.HolonType"))
+            .context("Visualizer descriptor")?;
+        let uses_layout = visualizer_type["relationships"]
+            .as_array()
+            .and_then(|relationships| {
+                relationships.iter().find(|relationship| {
+                    relationship["name"].as_str() == Some("InstanceRelationships")
+                        && relationship["target"].as_array().is_some_and(|targets| {
+                            targets.iter().any(|target| {
+                                target["$ref"]
+                                    == "(Visualizer.HolonType)-[UsesLayout]->(Layout.HolonType)"
+                            })
+                        })
+                })
+            })
+            .context("UsesLayout instance contract")?;
+        assert!(!uses_layout["target"].as_array().unwrap().is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
# Summary

Defines the first-cut DAHN Visualizer schema and separates Space Navigator’s static bootstrap visualizers into their own non-Core schema.

Closes #671

## Changes

- Adds DAHN semantic types for Visualizers, executable implementations, Layouts, and Visualizer Slots.
- Adds `MetaVisualizerType` as the DAHN-specific descriptor family for Visualizer Holon Types.
- Separates stable semantic Visualizer identity from runtime-specific implementation identity through required runtime and implementation-key properties.
- Defines type-based visualizer applicability and semantic layout composition.
- Makes each Visualizer Slot declare one or more accepted Visualizer Type roles.
- Explicitly keeps runtime visualizer occupancy out of persisted Layout definitions.
- Adds the Space Navigator schema with static TypeScript implementation mappings for its initial Canvas, generic Holon Node, and table Collection visualizers.
- Regenerates the corresponding loader JSON imports.
- Adds compiler coverage for DAHN and Space Navigator schema separation, including Slot accepted-role cardinality.

## Design notes

- `AcceptsVisualizerType` expresses semantic role declarations, not runtime child occurrence occupancy.
- `GenericHolonNodeVisualizer` applies to ordinary instances of any Holon Type through descriptor lineage; it does not target descriptor holons as subjects.
- `TableCollectionVisualizer` intentionally has no `ApplicableToType` declaration because collection-shape applicability remains deferred.
- Layout grammar and geometry remain intentionally out of scope for this first cut, including ordering, flow, nesting, grouping, grid, stack/overlay, spacing, alignment, sizing, responsive behavior, and compression variants.

## Testing

- [x] `npm run map-schema:compile:coreschema`
- [x] `npm run map-schema:check:coreschema`
- [x] `cargo test --manifest-path tools/map-schema/Cargo.toml --lib`
- [x] `git diff --check`