### PR TITLE
perf(smartlink): cache identity checks during relationship commit

### DIFF
--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -1,7 +1,7 @@
 use hdk::prelude::*;
 use std::sync::{Arc, RwLock};
 
-use crate::persistence_layer::{persist_holon, put_smartlink};
+use crate::persistence_layer::{persist_holon, put_smartlink_cached, SmartLinkWriteContext};
 use core_types::{HolonWriteRequest, PreparedSmartLink, PutSmartLinkOutcome};
 
 use holons_core::{
@@ -251,6 +251,10 @@ pub fn commit(
     // Snapshot the committed LocalId + relationship collections under a short-lived read lock,
     // then drop the lock before resolving targets / computing keys / saving smartlinks.
     // This avoids re-entrant locking when a relationship includes a self-edge.
+    // This context is deliberately narrower than TransactionContext: it represents only the
+    // bounded relationship write set for this commit invocation.
+    let mut smartlink_write_context = SmartLinkWriteContext::default();
+
     for staged_reference in staged_references {
         let rc_holon = staged_reference.get_holon_to_commit(context)?;
 
@@ -332,6 +336,7 @@ pub fn commit(
                 name.clone(),
                 inverse_name,
                 &holon_collection,
+                &mut smartlink_write_context,
             ) {
                 first_error = Some(err);
                 break;
@@ -546,10 +551,17 @@ fn commit_relationship(
     name: RelationshipName,
     inverse_name: RelationshipName,
     collection: &HolonCollection,
+    smartlink_write_context: &mut SmartLinkWriteContext,
 ) -> Result<(), HolonError> {
     collection.is_accessible(AccessType::Commit)?;
 
-    save_smartlinks_for_collection(source, name.clone(), inverse_name, collection)?;
+    save_smartlinks_for_collection(
+        source,
+        name.clone(),
+        inverse_name,
+        collection,
+        smartlink_write_context,
+    )?;
 
     Ok(())
 }
@@ -576,6 +588,7 @@ fn save_smartlinks_for_collection(
     name: RelationshipName,
     inverse_name: RelationshipName,
     collection: &HolonCollection,
+    smartlink_write_context: &mut SmartLinkWriteContext,
 ) -> Result<(), HolonError> {
     let source_id = source.source_local_id();
     debug!(
@@ -662,7 +675,7 @@ fn save_smartlinks_for_collection(
             "saving smartlink (idx={}): relationship={:?}, source={:?}, target={:?}",
             target_index, name.0 .0, source_id, forward_smartlink.target_id
         );
-        persist_smartlink(forward_smartlink)?;
+        persist_smartlink(smartlink_write_context, forward_smartlink)?;
 
         let inverse_smartlink = PreparedSmartLink {
             source_id: resolved_target.target_local_id.clone(),
@@ -678,7 +691,7 @@ fn save_smartlinks_for_collection(
             "saving inverse smartlink (idx={}): relationship={:?}, source={:?}, target={:?}",
             target_index, inverse_name.0 .0, resolved_target.target_local_id, source_id
         );
-        persist_smartlink(inverse_smartlink)?;
+        persist_smartlink(smartlink_write_context, inverse_smartlink)?;
     }
 
     Ok(())
@@ -704,12 +717,15 @@ fn save_smartlinks_for_collection(
 /// Note that no write happens either way: `put_smartlink` declines before authoring. The
 /// entire observable effect of this arm is the reported outcome, which is why
 /// `commit_conflict_tests.rs` asserts the response status rather than the DHT state.
-fn persist_smartlink(prepared: PreparedSmartLink) -> Result<(), HolonError> {
+fn persist_smartlink(
+    smartlink_write_context: &mut SmartLinkWriteContext,
+    prepared: PreparedSmartLink,
+) -> Result<(), HolonError> {
     let source_id = prepared.source_id.clone();
     let target_id = prepared.target_id.clone();
     let relationship_name = prepared.relationship_name.clone();
 
-    match put_smartlink(prepared)? {
+    match put_smartlink_cached(smartlink_write_context, prepared)? {
         PutSmartLinkOutcome::Inserted(_) | PutSmartLinkOutcome::AlreadyPresent(_) => Ok(()),
         PutSmartLinkOutcome::Conflict(existing) => Err(HolonError::CommitFailure(format!(
             "SmartLink conflict: a live link {existing:?} already shares the insertion identity \

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -23,6 +23,139 @@ use holons_guest_integrity::type_conversions::*;
 use holons_integrity::LinkTypes;
 use integrity_core_types::{LocalId, RelationshipName};
 use shared_validation::validate_smartlink_envelope;
+use std::collections::HashMap;
+
+/// Commit-local cache for SmartLink identity checks.
+///
+/// This is intentionally constructed by relationship commit orchestration rather than stored on a
+/// transaction. A bucket is populated from one complete, fail-closed storage expansion and is
+/// discarded when that commit returns.
+#[derive(Default)]
+pub(crate) struct SmartLinkWriteContext {
+    buckets: HashMap<SmartLinkBucketKey, SmartLinkBucket>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct SmartLinkBucketKey {
+    source_id: LocalId,
+    relationship_name: RelationshipName,
+}
+
+impl SmartLinkBucketKey {
+    fn from_prepared(prepared: &PreparedSmartLink) -> Self {
+        Self {
+            source_id: prepared.source_id.clone(),
+            relationship_name: prepared.relationship_name.clone(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct SmartLinkIdentity {
+    source_id: LocalId,
+    target_id: core_types::HolonId,
+    relationship_name: RelationshipName,
+    occurrence_id: Option<core_types::OccurrenceId>,
+}
+
+impl SmartLinkIdentity {
+    fn from_prepared(prepared: &PreparedSmartLink) -> Self {
+        Self {
+            source_id: prepared.source_id.clone(),
+            target_id: prepared.target_id.clone(),
+            relationship_name: prepared.relationship_name.clone(),
+            occurrence_id: prepared.occurrence_id,
+        }
+    }
+
+    fn from_smartlink(smartlink: &SmartLink) -> Self {
+        Self {
+            source_id: smartlink.source_id.clone(),
+            target_id: smartlink.target_id.clone(),
+            relationship_name: smartlink.relationship_name.clone(),
+            occurrence_id: smartlink.occurrence_id,
+        }
+    }
+}
+
+/// The fields relevant to identity conflict decisions. Optional target-property cache values are
+/// deliberately omitted because they do not participate in idempotency.
+struct CachedSmartLink {
+    smartlink_id: SmartLinkId,
+    canonical_key: core_types::CanonicalKey,
+    relationship_property_values: integrity_core_types::PropertyMap,
+}
+
+impl CachedSmartLink {
+    fn from_smartlink(smartlink: SmartLink) -> Self {
+        Self {
+            smartlink_id: smartlink.smartlink_id,
+            canonical_key: smartlink.canonical_key,
+            relationship_property_values: smartlink.relationship_property_values,
+        }
+    }
+
+    fn from_inserted(prepared: &PreparedSmartLink, smartlink_id: SmartLinkId) -> Self {
+        Self {
+            smartlink_id,
+            canonical_key: prepared.canonical_key.clone(),
+            relationship_property_values: prepared.relationship_property_values.clone(),
+        }
+    }
+
+    fn outcome_for(&self, prepared: &PreparedSmartLink) -> PutSmartLinkOutcome {
+        if self.canonical_key == prepared.canonical_key
+            && self.relationship_property_values == prepared.relationship_property_values
+        {
+            PutSmartLinkOutcome::AlreadyPresent(self.smartlink_id.clone())
+        } else {
+            PutSmartLinkOutcome::Conflict(self.smartlink_id.clone())
+        }
+    }
+}
+
+#[derive(Default)]
+struct SmartLinkBucket {
+    identities: HashMap<SmartLinkIdentity, CachedSmartLink>,
+}
+
+impl SmartLinkBucket {
+    fn from_expansion(smartlinks: Vec<SmartLink>) -> Self {
+        let mut bucket = Self::default();
+        for smartlink in smartlinks {
+            bucket.insert(
+                SmartLinkIdentity::from_smartlink(&smartlink),
+                CachedSmartLink::from_smartlink(smartlink),
+            );
+        }
+        bucket
+    }
+
+    fn insert(&mut self, identity: SmartLinkIdentity, candidate: CachedSmartLink) {
+        match self.identities.get(&identity) {
+            Some(existing) if existing.smartlink_id.0 .0 <= candidate.smartlink_id.0 .0 => {}
+            _ => {
+                self.identities.insert(identity, candidate);
+            }
+        }
+    }
+}
+
+impl SmartLinkWriteContext {
+    fn bucket_for<F>(
+        &mut self,
+        key: SmartLinkBucketKey,
+        expand: F,
+    ) -> Result<&mut SmartLinkBucket, HolonError>
+    where
+        F: FnOnce() -> Result<Vec<SmartLink>, HolonError>,
+    {
+        if !self.buckets.contains_key(&key) {
+            self.buckets.insert(key.clone(), SmartLinkBucket::from_expansion(expand()?));
+        }
+        Ok(self.buckets.get_mut(&key).expect("inserted or previously cached bucket"))
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Read: expansion
@@ -123,12 +256,33 @@ pub fn put_smartlink(prepared: PreparedSmartLink) -> Result<PutSmartLinkOutcome,
         return Ok(PutSmartLinkOutcome::Conflict(existing.smartlink_id.clone()));
     }
 
-    let source_hash = try_action_hash_from_local_id(&prepared.source_id)?;
-    let target_hash = try_action_hash_from_local_id(prepared.target_id.local_id())?;
-    let create_hash =
-        create_link(source_hash, target_hash, LinkTypes::SmartLink, LinkTag(validated_tag))
-            .map_err(holon_error_from_wasm_error)?;
-    Ok(PutSmartLinkOutcome::Inserted(SmartLinkId(local_id_from_action_hash(create_hash))))
+    Ok(PutSmartLinkOutcome::Inserted(create_prepared_smartlink(&prepared, validated_tag)?))
+}
+
+/// Commit-only variant of [`put_smartlink`] that reuses a successful relationship expansion.
+///
+/// The public storage API retains its complete standalone read/check/create behavior. Commit
+/// orchestration owns this bounded optimization context and supplies it only while persisting its
+/// relationship plan.
+pub(crate) fn put_smartlink_cached(
+    context: &mut SmartLinkWriteContext,
+    prepared: PreparedSmartLink,
+) -> Result<PutSmartLinkOutcome, HolonError> {
+    // Preserve standalone preflight precedence even when a matching identity is already cached.
+    let validated_tag = prepare_validated_smartlink_tag(&prepared)?;
+    let bucket_key = SmartLinkBucketKey::from_prepared(&prepared);
+    let identity = SmartLinkIdentity::from_prepared(&prepared);
+    let bucket = context.bucket_for(bucket_key, || {
+        expand_from_source(&prepared.source_id, &prepared.relationship_name)
+    })?;
+
+    if let Some(existing) = bucket.identities.get(&identity) {
+        return Ok(existing.outcome_for(&prepared));
+    }
+
+    let smartlink_id = create_prepared_smartlink(&prepared, validated_tag)?;
+    bucket.insert(identity, CachedSmartLink::from_inserted(&prepared, smartlink_id.clone()));
+    Ok(PutSmartLinkOutcome::Inserted(smartlink_id))
 }
 
 // ---------------------------------------------------------------------------
@@ -198,6 +352,18 @@ fn prepare_validated_smartlink_tag(prepared: &PreparedSmartLink) -> Result<Vec<u
     Ok(encoded)
 }
 
+fn create_prepared_smartlink(
+    prepared: &PreparedSmartLink,
+    validated_tag: Vec<u8>,
+) -> Result<SmartLinkId, HolonError> {
+    let source_hash = try_action_hash_from_local_id(&prepared.source_id)?;
+    let target_hash = try_action_hash_from_local_id(prepared.target_id.local_id())?;
+    let create_hash =
+        create_link(source_hash, target_hash, LinkTypes::SmartLink, LinkTag(validated_tag))
+            .map_err(holon_error_from_wasm_error)?;
+    Ok(SmartLinkId(local_id_from_action_hash(create_hash)))
+}
+
 /// Runs a prepared `LinkQuery` and decodes every live match into a `SmartLink`.
 fn decode_query(source_id: &LocalId, query: LinkQuery) -> Result<Vec<SmartLink>, HolonError> {
     let links = get_links(query, GetStrategy::default()).map_err(holon_error_from_wasm_error)?;
@@ -245,7 +411,7 @@ fn tag_error(error: impl std::fmt::Display) -> HolonError {
 mod tests {
     use super::*;
     use base_types::MapString;
-    use core_types::{CanonicalKey, HolonId, PropertyMap, HOLOCHAIN_ACTION_HASH_BYTES};
+    use core_types::{CanonicalKey, HolonId, PropertyMap, SmartLink, HOLOCHAIN_ACTION_HASH_BYTES};
     use integrity_core_types::PvlViolation;
 
     fn local_id(seed: u8) -> LocalId {
@@ -261,6 +427,19 @@ mod tests {
             occurrence_id: None,
             relationship_property_values: PropertyMap::new(),
             target_property_cache_candidates: Vec::new(),
+        }
+    }
+
+    fn decoded_smartlink(id_seed: u8, canonical_key: &str) -> SmartLink {
+        SmartLink {
+            smartlink_id: SmartLinkId(local_id(id_seed)),
+            source_id: local_id(1),
+            target_id: HolonId::Local(local_id(2)),
+            relationship_name: RelationshipName(MapString("Related".to_string())),
+            canonical_key: CanonicalKey::new(canonical_key).unwrap(),
+            occurrence_id: None,
+            relationship_property_values: PropertyMap::new(),
+            target_property_values: PropertyMap::new(),
         }
     }
 
@@ -289,5 +468,55 @@ mod tests {
             }
             other => panic!("packing failure must remain a storage error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn write_context_expands_a_bucket_once_and_keeps_the_lowest_identity_match() {
+        let prepared = prepared("Related");
+        let bucket_key = SmartLinkBucketKey::from_prepared(&prepared);
+        let identity = SmartLinkIdentity::from_prepared(&prepared);
+        let mut context = SmartLinkWriteContext::default();
+        let mut expansion_count = 0;
+
+        {
+            let bucket = context
+                .bucket_for(bucket_key.clone(), || {
+                    expansion_count += 1;
+                    // The DHT does not promise ordering. The cache must retain the same lowest-id
+                    // choice as standalone put_smartlink regardless of expansion order.
+                    Ok(vec![
+                        decoded_smartlink(9, "newer-conflicting-key"),
+                        decoded_smartlink(3, ""),
+                    ])
+                })
+                .unwrap();
+            assert_eq!(
+                bucket.identities.get(&identity).unwrap().outcome_for(&prepared),
+                PutSmartLinkOutcome::AlreadyPresent(SmartLinkId(local_id(3)))
+            );
+        }
+
+        let _ = context
+            .bucket_for(bucket_key, || -> Result<Vec<SmartLink>, HolonError> {
+                panic!("a populated commit bucket must not expand again")
+            })
+            .unwrap();
+        assert_eq!(expansion_count, 1);
+    }
+
+    #[test]
+    fn write_context_records_an_inserted_identity_for_later_writes() {
+        let prepared = prepared("Related");
+        let identity = SmartLinkIdentity::from_prepared(&prepared);
+        let mut bucket = SmartLinkBucket::default();
+        let inserted = SmartLinkId(local_id(7));
+
+        bucket
+            .insert(identity.clone(), CachedSmartLink::from_inserted(&prepared, inserted.clone()));
+
+        assert_eq!(
+            bucket.identities.get(&identity).unwrap().outcome_for(&prepared),
+            PutSmartLinkOutcome::AlreadyPresent(inserted)
+        );
     }
 }

--- a/tests/sweetests/src/harness/test_case/adders.rs
+++ b/tests/sweetests/src/harness/test_case/adders.rs
@@ -283,6 +283,21 @@ impl DancesTestCase {
         Ok(())
     }
 
+    /// Asserts the ordinary Book/Person relationship pattern that exercises
+    /// repeated declared and inverse SmartLink write buckets in one commit.
+    pub fn add_verify_book_person_smartlink_commit_cache_links_step(
+        &mut self,
+        description: Option<String>,
+    ) -> Result<(), HolonError> {
+        self.ensure_not_finalized()?;
+        let description = description.unwrap_or_else(|| {
+            "Verify repeated Book/Person forward and inverse SmartLink traversal".to_string()
+        });
+        self.steps.push(DanceTestStep::VerifyBookPersonSmartLinkCommitCacheLinks { description });
+
+        Ok(())
+    }
+
     pub fn add_verify_relationship_anchoring_step(
         &mut self,
         description: Option<String>,

--- a/tests/sweetests/src/harness/test_case/test_steps.rs
+++ b/tests/sweetests/src/harness/test_case/test_steps.rs
@@ -130,6 +130,9 @@ pub enum DanceTestStep {
     VerifyBookPersonInstanceLinks {
         description: String,
     },
+    VerifyBookPersonSmartLinkCommitCacheLinks {
+        description: String,
+    },
     VerifyRelationshipAnchoring {
         description: String,
     },
@@ -300,6 +303,9 @@ impl core::fmt::Display for DanceTestStep {
                 write!(f, "{description}")
             }
             DanceTestStep::VerifyBookPersonInstanceLinks { description } => {
+                write!(f, "{description}")
+            }
+            DanceTestStep::VerifyBookPersonSmartLinkCommitCacheLinks { description } => {
                 write!(f, "{description}")
             }
             DanceTestStep::VerifyRelationshipAnchoring { description } => {

--- a/tests/sweetests/tests/commit_conflict_tests.rs
+++ b/tests/sweetests/tests/commit_conflict_tests.rs
@@ -543,6 +543,8 @@ async fn commit_reuses_smartlink_buckets_for_declared_and_inverse_relationships(
     let context = begin_transaction(&runtime).await;
     let book_1 = stage_saved_holon(&runtime, &context, book_1_id, BOOK_CACHE_1_KEY).await;
     let book_2 = stage_saved_holon(&runtime, &context, book_2_id, BOOK_CACHE_2_KEY).await;
+    let committed_book_1 = book_1.clone();
+    let committed_book_2 = book_2.clone();
     let person_1 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_1_KEY).await;
     let person_2 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_2_KEY).await;
 
@@ -577,12 +579,11 @@ async fn commit_reuses_smartlink_buckets_for_declared_and_inverse_relationships(
         .expect("first relationship commit failed");
     assert_eq!(commit_status(first_commit), "Complete");
 
-    // AuthoredBy is definitional, so both Books now resolve to their new committed versions.
-    let context = begin_transaction(&runtime).await;
-    let committed_book_1_id =
-        local_id_of(&saved_reference_by_key(&runtime, &context, BOOK_CACHE_1_KEY).await);
-    let committed_book_2_id =
-        local_id_of(&saved_reference_by_key(&runtime, &context, BOOK_CACHE_2_KEY).await);
+    // AuthoredBy is definitional, so both Books now have new committed versions. Retain the
+    // staging references selected by pass 1: a broad GetAllHolons-by-key lookup may also expose
+    // an earlier version with the same key, which is not the SmartLink source under test.
+    let committed_book_1_id = local_id_of(&committed_book_1);
+    let committed_book_2_id = local_id_of(&committed_book_2);
 
     let book_1_authored = live_smartlinks(&backend, &committed_book_1_id, &rel(AUTHORED_BY)).await;
     let book_2_authored = live_smartlinks(&backend, &committed_book_2_id, &rel(AUTHORED_BY)).await;

--- a/tests/sweetests/tests/commit_conflict_tests.rs
+++ b/tests/sweetests/tests/commit_conflict_tests.rs
@@ -67,13 +67,6 @@ const PROBE_ZOME: &str = "holons_test_probes";
 const BOOK_KEY: &str = "Book.CommitConflict.1";
 const TITLE_PROPERTY_KEY: &str = "Title.PropertyType";
 const REFERENCES_PROPERTY: &str = "ReferencesProperty";
-const BOOK_CACHE_1_KEY: &str = "Book.SmartLinkCache.1";
-const BOOK_CACHE_2_KEY: &str = "Book.SmartLinkCache.2";
-const PERSON_CACHE_1_KEY: &str = "Person.SmartLinkCache.1";
-const PERSON_CACHE_2_KEY: &str = "Person.SmartLinkCache.2";
-const PERSON_DESCRIPTOR_KEY: &str = "Person.HolonType";
-const AUTHORED_BY: &str = "AuthoredBy";
-const AUTHOR_OF: &str = "AuthorOf";
 
 /// Canonical key on the planted link. Differs from the book's real key, which is what makes the
 /// commit-time write a `Conflict` rather than an idempotent `AlreadyPresent`.
@@ -92,22 +85,14 @@ fn rel(name: &str) -> RelationshipName {
 /// The descriptor is resolved inside this function's own transaction: `HolonReference`s are
 /// transaction-bound, so only ids may cross a transaction boundary.
 async fn create_described_book(runtime: &Runtime) -> LocalId {
-    create_described_holon(runtime, BOOK_KEY, BOOK_DESCRIPTOR_KEY).await
-}
-
-/// Creates and commits one instance with an explicit `DescribedBy` relationship.
-///
-/// The descriptor reference is resolved in the creation transaction because runtime references
-/// are transaction-bound; the returned local id can safely cross into later transactions.
-async fn create_described_holon(runtime: &Runtime, key: &str, descriptor_key: &str) -> LocalId {
     let context = begin_transaction(runtime).await;
-    let descriptor = saved_reference_by_key(runtime, &context, descriptor_key).await;
+    let book_type = saved_reference_by_key(runtime, &context, BOOK_DESCRIPTOR_KEY).await;
 
     let transient = match runtime
         .execute_command(
             MapCommand::Transaction(TransactionCommand {
                 context: Arc::clone(&context),
-                action: TransactionAction::NewHolon { key: Some(MapString(key.to_string())) },
+                action: TransactionAction::NewHolon { key: Some(MapString(BOOK_KEY.to_string())) },
             }),
             ExecutionPolicy::default(),
         )
@@ -140,13 +125,13 @@ async fn create_described_holon(runtime: &Runtime, key: &str, descriptor_key: &s
                 target: staged,
                 action: HolonAction::Write(WritableHolonAction::AddRelatedHolons {
                     name: CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
-                    holons: vec![descriptor],
+                    holons: vec![book_type.clone()],
                 }),
             }),
             ExecutionPolicy::default(),
         )
         .await
-        .unwrap_or_else(|error| panic!("describing '{key}' failed: {error:?}"));
+        .expect("describing the book failed");
 
     runtime
         .execute_command(
@@ -157,10 +142,10 @@ async fn create_described_holon(runtime: &Runtime, key: &str, descriptor_key: &s
             ExecutionPolicy::default(),
         )
         .await
-        .unwrap_or_else(|error| panic!("committing described '{key}' failed: {error:?}"));
+        .expect("committing the described book failed");
 
     let context = begin_transaction(runtime).await;
-    local_id_of(&saved_reference_by_key(runtime, &context, key).await)
+    local_id_of(&saved_reference_by_key(runtime, &context, BOOK_KEY).await)
 }
 
 /// Builds a runtime over `backend`, keeping the same conductor handle the test uses for raw probe
@@ -287,79 +272,6 @@ async fn live_smartlinks(
             (source_id.clone(), relationship_name.clone()),
         )
         .await
-}
-
-async fn stage_saved_holon(
-    runtime: &Runtime,
-    context: &Arc<TransactionContext>,
-    holon_id: LocalId,
-    label: &str,
-) -> HolonReference {
-    match runtime
-        .execute_command(
-            MapCommand::Transaction(TransactionCommand {
-                context: Arc::clone(context),
-                action: TransactionAction::StageNewVersionFromId {
-                    holon_id: HolonId::Local(holon_id),
-                },
-            }),
-            ExecutionPolicy::default(),
-        )
-        .await
-        .unwrap_or_else(|error| panic!("staging {label} failed: {error:?}"))
-    {
-        MapResult::Reference(reference) => reference,
-        other => panic!("staging {label}: expected a Reference, got {other:?}"),
-    }
-}
-
-async fn add_relationship(
-    runtime: &Runtime,
-    context: &Arc<TransactionContext>,
-    source: HolonReference,
-    relationship: &str,
-    targets: Vec<HolonReference>,
-    label: &str,
-) {
-    runtime
-        .execute_command(
-            MapCommand::Holon(HolonCommand {
-                context: Arc::clone(context),
-                target: source,
-                action: HolonAction::Write(WritableHolonAction::AddRelatedHolons {
-                    name: rel(relationship),
-                    holons: targets,
-                }),
-            }),
-            ExecutionPolicy::default(),
-        )
-        .await
-        .unwrap_or_else(|error| panic!("adding {label} failed: {error:?}"));
-}
-
-fn commit_status(result: MapResult) -> String {
-    let response = match result {
-        MapResult::Reference(HolonReference::Transient(response)) => response,
-        other => panic!("expected a transient CommitResponse reference, got {other:?}"),
-    };
-    match response.property_value(&CorePropertyTypeName::CommitRequestStatus) {
-        Ok(Some(PropertyValue::StringValue(MapString(status)))) => status,
-        other => panic!("expected a string CommitRequestStatus, got {other:?}"),
-    }
-}
-
-fn assert_exact_targets(links: &[SmartLink], expected: &[LocalId], label: &str) {
-    assert_eq!(links.len(), expected.len(), "{label}: unexpected link count: {links:?}");
-    for expected_id in expected {
-        assert_eq!(
-            links
-                .iter()
-                .filter(|link| link.target_id == HolonId::Local(expected_id.clone()))
-                .count(),
-            1,
-            "{label}: expected exactly one link to {expected_id:?}: {links:?}"
-        );
-    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -512,133 +424,5 @@ async fn smartlink_conflict_downgrades_commit_to_incomplete() {
     assert!(
         !from_target.iter().any(|link| link.target_id == HolonId::Local(book_id.clone())),
         "the inverse link back to the book must not be written after a forward conflict"
-    );
-}
-
-/// Relationship pass 2 must share its SmartLink write context across every staged holon in one
-/// commit. This ordinary domain scenario covers both repeated declared and repeated inverse
-/// buckets without relying on an instance-to-descriptor relationship:
-///
-/// - `Book.Cache.1 --AuthoredBy--> [Person.Cache.1, Person.Cache.2]` repeats the declared bucket;
-/// - `Book.Cache.2 --AuthoredBy--> Person.Cache.1` repeats Person.Cache.1's `AuthorOf` inverse
-///   bucket after the first Book's inverse has been materialized.
-#[tokio::test(flavor = "multi_thread")]
-async fn commit_reuses_smartlink_buckets_for_declared_and_inverse_relationships() {
-    let backend = setup_probe_enabled_conductor().await;
-    let runtime = runtime_over(Arc::clone(&backend)).await;
-
-    load(&runtime, build_core_schema_content_set().unwrap(), "core schema load").await;
-    load(&runtime, build_book_person_inverse_content_set().unwrap(), "book/person schema load")
-        .await;
-
-    let book_1_id = create_described_holon(&runtime, BOOK_CACHE_1_KEY, BOOK_DESCRIPTOR_KEY).await;
-    let book_2_id = create_described_holon(&runtime, BOOK_CACHE_2_KEY, BOOK_DESCRIPTOR_KEY).await;
-    let person_1_id =
-        create_described_holon(&runtime, PERSON_CACHE_1_KEY, PERSON_DESCRIPTOR_KEY).await;
-    let person_2_id =
-        create_described_holon(&runtime, PERSON_CACHE_2_KEY, PERSON_DESCRIPTOR_KEY).await;
-
-    // One transaction covers both repeated declared writes from Book.Cache.1 and repeated inverse
-    // writes from Person.Cache.1. The relationship is ordinary instance-to-instance domain data.
-    let context = begin_transaction(&runtime).await;
-    let book_1 = stage_saved_holon(&runtime, &context, book_1_id, BOOK_CACHE_1_KEY).await;
-    let book_2 = stage_saved_holon(&runtime, &context, book_2_id, BOOK_CACHE_2_KEY).await;
-    let committed_book_1 = book_1.clone();
-    let committed_book_2 = book_2.clone();
-    let person_1 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_1_KEY).await;
-    let person_2 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_2_KEY).await;
-
-    add_relationship(
-        &runtime,
-        &context,
-        book_1,
-        AUTHORED_BY,
-        vec![person_1.clone(), person_2.clone()],
-        "Book.Cache.1 --AuthoredBy--> Person.Cache.1 and Person.Cache.2",
-    )
-    .await;
-    add_relationship(
-        &runtime,
-        &context,
-        book_2,
-        AUTHORED_BY,
-        vec![person_1],
-        "Book.Cache.2 --AuthoredBy--> Person.Cache.1",
-    )
-    .await;
-
-    let first_commit = runtime
-        .execute_command(
-            MapCommand::Transaction(TransactionCommand {
-                context: Arc::clone(&context),
-                action: TransactionAction::Commit,
-            }),
-            ExecutionPolicy::default(),
-        )
-        .await
-        .expect("first relationship commit failed");
-    assert_eq!(commit_status(first_commit), "Complete");
-
-    // AuthoredBy is definitional, so both Books now have new committed versions. Retain the
-    // staging references selected by pass 1: a broad GetAllHolons-by-key lookup may also expose
-    // an earlier version with the same key, which is not the SmartLink source under test.
-    let committed_book_1_id = local_id_of(&committed_book_1);
-    let committed_book_2_id = local_id_of(&committed_book_2);
-
-    let book_1_authored = live_smartlinks(&backend, &committed_book_1_id, &rel(AUTHORED_BY)).await;
-    let book_2_authored = live_smartlinks(&backend, &committed_book_2_id, &rel(AUTHORED_BY)).await;
-    let person_1_authored = live_smartlinks(&backend, &person_1_id, &rel(AUTHOR_OF)).await;
-    let person_2_authored = live_smartlinks(&backend, &person_2_id, &rel(AUTHOR_OF)).await;
-
-    assert_exact_targets(
-        &book_1_authored,
-        &[person_1_id.clone(), person_2_id.clone()],
-        "Book.Cache.1 AuthoredBy",
-    );
-    assert_exact_targets(&book_2_authored, &[person_1_id.clone()], "Book.Cache.2 AuthoredBy");
-    assert_exact_targets(
-        &person_1_authored,
-        &[committed_book_1_id.clone(), committed_book_2_id.clone()],
-        "Person.Cache.1 AuthorOf",
-    );
-    assert_exact_targets(
-        &person_2_authored,
-        &[committed_book_1_id.clone()],
-        "Person.Cache.2 AuthorOf",
-    );
-
-    // A no-op transaction must leave the established directional links untouched.
-    let no_op_context = begin_transaction(&runtime).await;
-    let no_op_commit = runtime
-        .execute_command(
-            MapCommand::Transaction(TransactionCommand {
-                context: no_op_context,
-                action: TransactionAction::Commit,
-            }),
-            ExecutionPolicy::default(),
-        )
-        .await
-        .expect("no-op commit failed");
-    assert_eq!(commit_status(no_op_commit), "Complete");
-
-    assert_exact_targets(
-        &live_smartlinks(&backend, &committed_book_1_id, &rel(AUTHORED_BY)).await,
-        &[person_1_id.clone(), person_2_id.clone()],
-        "Book.Cache.1 AuthoredBy after no-op commit",
-    );
-    assert_exact_targets(
-        &live_smartlinks(&backend, &committed_book_2_id, &rel(AUTHORED_BY)).await,
-        &[person_1_id.clone()],
-        "Book.Cache.2 AuthoredBy after no-op commit",
-    );
-    assert_exact_targets(
-        &live_smartlinks(&backend, &person_1_id, &rel(AUTHOR_OF)).await,
-        &[committed_book_1_id.clone(), committed_book_2_id],
-        "Person.Cache.1 AuthorOf after no-op commit",
-    );
-    assert_exact_targets(
-        &live_smartlinks(&backend, &person_2_id, &rel(AUTHOR_OF)).await,
-        &[committed_book_1_id],
-        "Person.Cache.2 AuthorOf after no-op commit",
     );
 }

--- a/tests/sweetests/tests/commit_conflict_tests.rs
+++ b/tests/sweetests/tests/commit_conflict_tests.rs
@@ -67,6 +67,13 @@ const PROBE_ZOME: &str = "holons_test_probes";
 const BOOK_KEY: &str = "Book.CommitConflict.1";
 const TITLE_PROPERTY_KEY: &str = "Title.PropertyType";
 const REFERENCES_PROPERTY: &str = "ReferencesProperty";
+const BOOK_CACHE_1_KEY: &str = "Book.SmartLinkCache.1";
+const BOOK_CACHE_2_KEY: &str = "Book.SmartLinkCache.2";
+const PERSON_CACHE_1_KEY: &str = "Person.SmartLinkCache.1";
+const PERSON_CACHE_2_KEY: &str = "Person.SmartLinkCache.2";
+const PERSON_DESCRIPTOR_KEY: &str = "Person.HolonType";
+const AUTHORED_BY: &str = "AuthoredBy";
+const AUTHOR_OF: &str = "AuthorOf";
 
 /// Canonical key on the planted link. Differs from the book's real key, which is what makes the
 /// commit-time write a `Conflict` rather than an idempotent `AlreadyPresent`.
@@ -85,14 +92,22 @@ fn rel(name: &str) -> RelationshipName {
 /// The descriptor is resolved inside this function's own transaction: `HolonReference`s are
 /// transaction-bound, so only ids may cross a transaction boundary.
 async fn create_described_book(runtime: &Runtime) -> LocalId {
+    create_described_holon(runtime, BOOK_KEY, BOOK_DESCRIPTOR_KEY).await
+}
+
+/// Creates and commits one instance with an explicit `DescribedBy` relationship.
+///
+/// The descriptor reference is resolved in the creation transaction because runtime references
+/// are transaction-bound; the returned local id can safely cross into later transactions.
+async fn create_described_holon(runtime: &Runtime, key: &str, descriptor_key: &str) -> LocalId {
     let context = begin_transaction(runtime).await;
-    let book_type = saved_reference_by_key(runtime, &context, BOOK_DESCRIPTOR_KEY).await;
+    let descriptor = saved_reference_by_key(runtime, &context, descriptor_key).await;
 
     let transient = match runtime
         .execute_command(
             MapCommand::Transaction(TransactionCommand {
                 context: Arc::clone(&context),
-                action: TransactionAction::NewHolon { key: Some(MapString(BOOK_KEY.to_string())) },
+                action: TransactionAction::NewHolon { key: Some(MapString(key.to_string())) },
             }),
             ExecutionPolicy::default(),
         )
@@ -125,13 +140,13 @@ async fn create_described_book(runtime: &Runtime) -> LocalId {
                 target: staged,
                 action: HolonAction::Write(WritableHolonAction::AddRelatedHolons {
                     name: CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
-                    holons: vec![book_type.clone()],
+                    holons: vec![descriptor],
                 }),
             }),
             ExecutionPolicy::default(),
         )
         .await
-        .expect("describing the book failed");
+        .unwrap_or_else(|error| panic!("describing '{key}' failed: {error:?}"));
 
     runtime
         .execute_command(
@@ -142,10 +157,10 @@ async fn create_described_book(runtime: &Runtime) -> LocalId {
             ExecutionPolicy::default(),
         )
         .await
-        .expect("committing the described book failed");
+        .unwrap_or_else(|error| panic!("committing described '{key}' failed: {error:?}"));
 
     let context = begin_transaction(runtime).await;
-    local_id_of(&saved_reference_by_key(runtime, &context, BOOK_KEY).await)
+    local_id_of(&saved_reference_by_key(runtime, &context, key).await)
 }
 
 /// Builds a runtime over `backend`, keeping the same conductor handle the test uses for raw probe
@@ -272,6 +287,79 @@ async fn live_smartlinks(
             (source_id.clone(), relationship_name.clone()),
         )
         .await
+}
+
+async fn stage_saved_holon(
+    runtime: &Runtime,
+    context: &Arc<TransactionContext>,
+    holon_id: LocalId,
+    label: &str,
+) -> HolonReference {
+    match runtime
+        .execute_command(
+            MapCommand::Transaction(TransactionCommand {
+                context: Arc::clone(context),
+                action: TransactionAction::StageNewVersionFromId {
+                    holon_id: HolonId::Local(holon_id),
+                },
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("staging {label} failed: {error:?}"))
+    {
+        MapResult::Reference(reference) => reference,
+        other => panic!("staging {label}: expected a Reference, got {other:?}"),
+    }
+}
+
+async fn add_relationship(
+    runtime: &Runtime,
+    context: &Arc<TransactionContext>,
+    source: HolonReference,
+    relationship: &str,
+    targets: Vec<HolonReference>,
+    label: &str,
+) {
+    runtime
+        .execute_command(
+            MapCommand::Holon(HolonCommand {
+                context: Arc::clone(context),
+                target: source,
+                action: HolonAction::Write(WritableHolonAction::AddRelatedHolons {
+                    name: rel(relationship),
+                    holons: targets,
+                }),
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("adding {label} failed: {error:?}"));
+}
+
+fn commit_status(result: MapResult) -> String {
+    let response = match result {
+        MapResult::Reference(HolonReference::Transient(response)) => response,
+        other => panic!("expected a transient CommitResponse reference, got {other:?}"),
+    };
+    match response.property_value(&CorePropertyTypeName::CommitRequestStatus) {
+        Ok(Some(PropertyValue::StringValue(MapString(status)))) => status,
+        other => panic!("expected a string CommitRequestStatus, got {other:?}"),
+    }
+}
+
+fn assert_exact_targets(links: &[SmartLink], expected: &[LocalId], label: &str) {
+    assert_eq!(links.len(), expected.len(), "{label}: unexpected link count: {links:?}");
+    for expected_id in expected {
+        assert_eq!(
+            links
+                .iter()
+                .filter(|link| link.target_id == HolonId::Local(expected_id.clone()))
+                .count(),
+            1,
+            "{label}: expected exactly one link to {expected_id:?}: {links:?}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -424,5 +512,132 @@ async fn smartlink_conflict_downgrades_commit_to_incomplete() {
     assert!(
         !from_target.iter().any(|link| link.target_id == HolonId::Local(book_id.clone())),
         "the inverse link back to the book must not be written after a forward conflict"
+    );
+}
+
+/// Relationship pass 2 must share its SmartLink write context across every staged holon in one
+/// commit. This ordinary domain scenario covers both repeated declared and repeated inverse
+/// buckets without relying on an instance-to-descriptor relationship:
+///
+/// - `Book.Cache.1 --AuthoredBy--> [Person.Cache.1, Person.Cache.2]` repeats the declared bucket;
+/// - `Book.Cache.2 --AuthoredBy--> Person.Cache.1` repeats Person.Cache.1's `AuthorOf` inverse
+///   bucket after the first Book's inverse has been materialized.
+#[tokio::test(flavor = "multi_thread")]
+async fn commit_reuses_smartlink_buckets_for_declared_and_inverse_relationships() {
+    let backend = setup_probe_enabled_conductor().await;
+    let runtime = runtime_over(Arc::clone(&backend)).await;
+
+    load(&runtime, build_core_schema_content_set().unwrap(), "core schema load").await;
+    load(&runtime, build_book_person_inverse_content_set().unwrap(), "book/person schema load")
+        .await;
+
+    let book_1_id = create_described_holon(&runtime, BOOK_CACHE_1_KEY, BOOK_DESCRIPTOR_KEY).await;
+    let book_2_id = create_described_holon(&runtime, BOOK_CACHE_2_KEY, BOOK_DESCRIPTOR_KEY).await;
+    let person_1_id =
+        create_described_holon(&runtime, PERSON_CACHE_1_KEY, PERSON_DESCRIPTOR_KEY).await;
+    let person_2_id =
+        create_described_holon(&runtime, PERSON_CACHE_2_KEY, PERSON_DESCRIPTOR_KEY).await;
+
+    // One transaction covers both repeated declared writes from Book.Cache.1 and repeated inverse
+    // writes from Person.Cache.1. The relationship is ordinary instance-to-instance domain data.
+    let context = begin_transaction(&runtime).await;
+    let book_1 = stage_saved_holon(&runtime, &context, book_1_id, BOOK_CACHE_1_KEY).await;
+    let book_2 = stage_saved_holon(&runtime, &context, book_2_id, BOOK_CACHE_2_KEY).await;
+    let person_1 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_1_KEY).await;
+    let person_2 = saved_reference_by_key(&runtime, &context, PERSON_CACHE_2_KEY).await;
+
+    add_relationship(
+        &runtime,
+        &context,
+        book_1,
+        AUTHORED_BY,
+        vec![person_1.clone(), person_2.clone()],
+        "Book.Cache.1 --AuthoredBy--> Person.Cache.1 and Person.Cache.2",
+    )
+    .await;
+    add_relationship(
+        &runtime,
+        &context,
+        book_2,
+        AUTHORED_BY,
+        vec![person_1],
+        "Book.Cache.2 --AuthoredBy--> Person.Cache.1",
+    )
+    .await;
+
+    let first_commit = runtime
+        .execute_command(
+            MapCommand::Transaction(TransactionCommand {
+                context: Arc::clone(&context),
+                action: TransactionAction::Commit,
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("first relationship commit failed");
+    assert_eq!(commit_status(first_commit), "Complete");
+
+    // AuthoredBy is definitional, so both Books now resolve to their new committed versions.
+    let context = begin_transaction(&runtime).await;
+    let committed_book_1_id =
+        local_id_of(&saved_reference_by_key(&runtime, &context, BOOK_CACHE_1_KEY).await);
+    let committed_book_2_id =
+        local_id_of(&saved_reference_by_key(&runtime, &context, BOOK_CACHE_2_KEY).await);
+
+    let book_1_authored = live_smartlinks(&backend, &committed_book_1_id, &rel(AUTHORED_BY)).await;
+    let book_2_authored = live_smartlinks(&backend, &committed_book_2_id, &rel(AUTHORED_BY)).await;
+    let person_1_authored = live_smartlinks(&backend, &person_1_id, &rel(AUTHOR_OF)).await;
+    let person_2_authored = live_smartlinks(&backend, &person_2_id, &rel(AUTHOR_OF)).await;
+
+    assert_exact_targets(
+        &book_1_authored,
+        &[person_1_id.clone(), person_2_id.clone()],
+        "Book.Cache.1 AuthoredBy",
+    );
+    assert_exact_targets(&book_2_authored, &[person_1_id.clone()], "Book.Cache.2 AuthoredBy");
+    assert_exact_targets(
+        &person_1_authored,
+        &[committed_book_1_id.clone(), committed_book_2_id.clone()],
+        "Person.Cache.1 AuthorOf",
+    );
+    assert_exact_targets(
+        &person_2_authored,
+        &[committed_book_1_id.clone()],
+        "Person.Cache.2 AuthorOf",
+    );
+
+    // A no-op transaction must leave the established directional links untouched.
+    let no_op_context = begin_transaction(&runtime).await;
+    let no_op_commit = runtime
+        .execute_command(
+            MapCommand::Transaction(TransactionCommand {
+                context: no_op_context,
+                action: TransactionAction::Commit,
+            }),
+            ExecutionPolicy::default(),
+        )
+        .await
+        .expect("no-op commit failed");
+    assert_eq!(commit_status(no_op_commit), "Complete");
+
+    assert_exact_targets(
+        &live_smartlinks(&backend, &committed_book_1_id, &rel(AUTHORED_BY)).await,
+        &[person_1_id.clone(), person_2_id.clone()],
+        "Book.Cache.1 AuthoredBy after no-op commit",
+    );
+    assert_exact_targets(
+        &live_smartlinks(&backend, &committed_book_2_id, &rel(AUTHORED_BY)).await,
+        &[person_1_id.clone()],
+        "Book.Cache.2 AuthoredBy after no-op commit",
+    );
+    assert_exact_targets(
+        &live_smartlinks(&backend, &person_1_id, &rel(AUTHOR_OF)).await,
+        &[committed_book_1_id.clone(), committed_book_2_id],
+        "Person.Cache.1 AuthorOf after no-op commit",
+    );
+    assert_exact_targets(
+        &live_smartlinks(&backend, &person_2_id, &rel(AUTHOR_OF)).await,
+        &[committed_book_1_id],
+        "Person.Cache.2 AuthorOf after no-op commit",
     );
 }

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -38,6 +38,7 @@ use execution_steps::commit_executor::execute_commit;
 use execution_steps::delete_holon_executor::execute_delete_holon;
 use execution_steps::descriptor_verification_executor::{
     execute_verify_book_person_descriptors, execute_verify_book_person_instance_links,
+    execute_verify_book_person_smartlink_commit_cache_links,
     execute_verify_core_schema_descriptor_subtypes, execute_verify_core_schema_descriptors,
     execute_verify_core_schema_value_semantics, execute_verify_relationship_anchoring,
     execute_verify_validation_bindings_descriptor_contract,
@@ -76,6 +77,7 @@ use fixture_cases::load_holons_internal_fixture::*;
 use fixture_cases::simple_add_remove_properties_fixture::*;
 use fixture_cases::simple_add_remove_related_holons_fixture::*;
 use fixture_cases::simple_create_holon_fixture::*;
+use fixture_cases::smartlink_commit_cache_fixture::*;
 use fixture_cases::stage_new_from_clone_fixture::*;
 use fixture_cases::stage_new_version_fixture::*;
 use fixture_cases::transaction_lifecycle_fixture::*;
@@ -127,6 +129,7 @@ use holons_prelude::prelude::*;
 #[case::load_generated_validation_schema_test(load_generated_validation_schema_fixture())]
 #[case::load_generated_query_schema_test(load_generated_query_schema_fixture())]
 #[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
+#[case::smartlink_commit_cache_test(smartlink_commit_cache_fixture())]
 #[case::frozen_member_head_redirect_test(frozen_member_head_redirect_fixture())]
 #[case::frozen_member_head_redirect_cross_tx_test(frozen_member_head_redirect_cross_tx_fixture())]
 #[case::cross_transaction_staged_target_diagnostic_test(
@@ -273,6 +276,10 @@ async fn run_dance_test_case(mut test_case: DancesTestCase) {
             }
             DanceTestStep::VerifyBookPersonInstanceLinks { .. } => {
                 execute_verify_book_person_instance_links(&mut test_execution_state).await
+            }
+            DanceTestStep::VerifyBookPersonSmartLinkCommitCacheLinks { .. } => {
+                execute_verify_book_person_smartlink_commit_cache_links(&mut test_execution_state)
+                    .await
             }
             DanceTestStep::VerifyRelationshipAnchoring { .. } => {
                 execute_verify_relationship_anchoring(&mut test_execution_state).await

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -671,6 +671,32 @@ pub async fn execute_verify_book_person_instance_links(state: &mut TestExecution
     info!("verified bidirectional Book/Person instance SmartLink traversal");
 }
 
+/// Verifies the ordinary domain relationships used to exercise the commit-local
+/// SmartLink cache. The first Book produces two `AuthoredBy` writes from one
+/// source bucket; both Books produce inverse `AuthorOf` writes from the same
+/// first Person bucket.
+pub async fn execute_verify_book_person_smartlink_commit_cache_links(
+    state: &mut TestExecutionState,
+) {
+    const BOOK_1: &str = "Book.SmartLinkCache.1";
+    const BOOK_2: &str = "Book.SmartLinkCache.2";
+    const PERSON_1: &str = "Person.SmartLinkCache.1";
+    const PERSON_2: &str = "Person.SmartLinkCache.2";
+
+    let holons = loaded_holons(state, "verify_book_person_smartlink_commit_cache_links").await;
+    let book_1 = find_holon_by_key(&holons, BOOK_1);
+    let book_2 = find_holon_by_key(&holons, BOOK_2);
+    let person_1 = find_holon_by_key(&holons, PERSON_1);
+    let person_2 = find_holon_by_key(&holons, PERSON_2);
+
+    assert_exact_related_keys(&book_1, BOOK_TO_PERSON_RELATIONSHIP, &[PERSON_1, PERSON_2]);
+    assert_exact_related_keys(&book_2, BOOK_TO_PERSON_RELATIONSHIP, &[PERSON_1]);
+    assert_exact_related_keys(&person_1, PERSON_TO_BOOK_REL_INVERSE, &[BOOK_1, BOOK_2]);
+    assert_exact_related_keys(&person_2, PERSON_TO_BOOK_REL_INVERSE, &[BOOK_1]);
+
+    info!("verified repeated Book/Person SmartLink traversal");
+}
+
 /// Verifies the persisted anchoring rules after the stage-new-version
 /// fixture has exercised both update modes:
 /// - graph-only mutation: Book --Properties--> Title.PropertyType is anchored to
@@ -1056,6 +1082,14 @@ fn assert_contains(values: &[String], expected: &str) {
         values.iter().any(|actual| actual == expected),
         "expected {values:?} to contain {expected}"
     );
+}
+
+fn assert_exact_related_keys(holon: &HolonReference, relationship_name: &str, expected: &[&str]) {
+    let mut actual = related_holon_keys(holon, relationship_name);
+    actual.sort();
+    let mut expected = expected.iter().map(ToString::to_string).collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(actual, expected, "unexpected {relationship_name} relationship members");
 }
 
 fn assert_relationship_shape(

--- a/tests/sweetests/tests/fixture_cases/mod.rs
+++ b/tests/sweetests/tests/fixture_cases/mod.rs
@@ -13,6 +13,7 @@ pub mod setup_book_and_authors_fixture;
 pub mod simple_add_remove_properties_fixture;
 pub mod simple_add_remove_related_holons_fixture;
 pub mod simple_create_holon_fixture;
+pub mod smartlink_commit_cache_fixture;
 pub mod stage_new_from_clone_fixture;
 pub mod stage_new_version_fixture;
 pub mod transaction_lifecycle_fixture;

--- a/tests/sweetests/tests/fixture_cases/smartlink_commit_cache_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/smartlink_commit_cache_fixture.rs
@@ -1,0 +1,166 @@
+use holons_prelude::prelude::*;
+use holons_test::harness::helpers::{
+    BOOK_DESCRIPTOR_KEY, BOOK_PERSON_INVERSE_METRICS, BOOK_TO_PERSON_RELATIONSHIP,
+    CORE_SCHEMA_METRICS, PERSON_DESCRIPTOR_KEY,
+};
+use holons_test::{
+    DancesTestCase, ExpectedCommitStatus, FixtureHolons, TestCaseInit, TestReference,
+};
+use std::sync::Arc;
+
+const BOOK_1_KEY: &str = "Book.SmartLinkCache.1";
+const BOOK_2_KEY: &str = "Book.SmartLinkCache.2";
+const PERSON_1_KEY: &str = "Person.SmartLinkCache.1";
+const PERSON_2_KEY: &str = "Person.SmartLinkCache.2";
+
+/// Covers one relationship commit with two repeated SmartLink write buckets:
+///
+/// - `Book.SmartLinkCache.1 --AuthoredBy--> [Person.SmartLinkCache.1,
+///   Person.SmartLinkCache.2]` shares its declared source bucket; and
+/// - `Book.SmartLinkCache.1` and `Book.SmartLinkCache.2` both materialize an
+///   `AuthorOf` inverse on `Person.SmartLinkCache.1`, sharing that inverse
+///   source bucket.
+///
+/// The fixture uses only Dance Test Language adders. It proves the resulting
+/// bidirectional traversal, while instrumentation unit coverage pins the one
+/// initial storage expansion per populated bucket.
+pub fn smartlink_commit_cache_fixture() -> Result<DancesTestCase, HolonError> {
+    let TestCaseInit { mut test_case, fixture_context, mut fixture_holons, .. } = TestCaseInit::new(
+        "smartlink_commit_cache",
+        "Commit repeated declared and inverse Book/Person SmartLink relationships",
+    );
+
+    test_case.add_load_core_schema_step(None)?;
+    test_case.add_begin_transaction_step(None, None)?;
+    test_case.add_load_book_person_inverse_test_schema_step(None)?;
+    test_case.add_begin_transaction_step(
+        None,
+        Some("Begin transaction for repeated Book/Person relationships".to_string()),
+    )?;
+
+    let book_type = lookup_descriptor(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        BOOK_DESCRIPTOR_KEY,
+    )?;
+    let person_type = lookup_descriptor(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        PERSON_DESCRIPTOR_KEY,
+    )?;
+
+    let book_1 = add_described_instance(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        BOOK_1_KEY,
+        "Title",
+        book_type.clone(),
+    )?;
+    let book_2 = add_described_instance(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        BOOK_2_KEY,
+        "Title",
+        book_type,
+    )?;
+    let person_1 = add_described_instance(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        PERSON_1_KEY,
+        "Name",
+        person_type.clone(),
+    )?;
+    let person_2 = add_described_instance(
+        &fixture_context,
+        &mut test_case,
+        &mut fixture_holons,
+        PERSON_2_KEY,
+        "Name",
+        person_type,
+    )?;
+
+    let book_1 = test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_1,
+        RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
+        vec![person_1.clone(), person_2.clone()],
+        None,
+        Some("Relate Book.SmartLinkCache.1 --AuthoredBy--> both People".to_string()),
+    )?;
+    test_case.add_add_related_holons_step(
+        &mut fixture_holons,
+        book_2,
+        RelationshipName(MapString(BOOK_TO_PERSON_RELATIONSHIP.to_string())),
+        vec![person_1],
+        None,
+        Some("Relate Book.SmartLinkCache.2 --AuthoredBy--> Person.SmartLinkCache.1".to_string()),
+    )?;
+
+    // Keep the final Book.1 head in the fixture ledger before committing all four instances.
+    let _ = book_1;
+    test_case.add_commit_step(
+        &mut fixture_holons,
+        ExpectedCommitStatus::Complete,
+        None,
+        Some("Commit repeated declared and inverse SmartLink relationships".to_string()),
+    )?;
+
+    let expected_db_count = MapInteger(
+        fixture_holons.count_saved().0
+            + CORE_SCHEMA_METRICS.committed
+            + BOOK_PERSON_INVERSE_METRICS.committed,
+    );
+    test_case.add_ensure_database_count_step(expected_db_count, None)?;
+    test_case.add_match_saved_content_step()?;
+    test_case.add_verify_book_person_smartlink_commit_cache_links_step(None)?;
+    test_case.finalize(&fixture_context, &fixture_holons)?;
+
+    Ok(test_case)
+}
+
+fn lookup_descriptor(
+    fixture_context: &Arc<TransactionContext>,
+    test_case: &mut DancesTestCase,
+    fixture_holons: &mut FixtureHolons,
+    key: &str,
+) -> Result<TestReference, HolonError> {
+    let key = MapString(key.to_string());
+    let stub = fixture_context.mutation().new_holon(Some(key.clone()))?;
+    test_case.add_lookup_saved_holon_by_key_step(fixture_holons, stub, key, None, None)
+}
+
+fn add_described_instance(
+    fixture_context: &Arc<TransactionContext>,
+    test_case: &mut DancesTestCase,
+    fixture_holons: &mut FixtureHolons,
+    key: &str,
+    property_name: &str,
+    descriptor: TestReference,
+) -> Result<TestReference, HolonError> {
+    let key = MapString(key.to_string());
+    let source = fixture_context.mutation().new_holon(Some(key.clone()))?;
+    let mut properties = PropertyMap::new();
+    properties.insert(property_name.to_property_name(), key.clone().to_base_value());
+    let instance = test_case.add_new_holon_step(
+        fixture_holons,
+        source,
+        properties,
+        Some(key.clone()),
+        None,
+        Some(format!("Create {key}")),
+    )?;
+    let instance = test_case.add_stage_holon_step(fixture_holons, instance, None, None)?;
+    test_case.add_add_related_holons_step(
+        fixture_holons,
+        instance,
+        CoreRelationshipTypeName::DescribedBy.as_relationship_name(),
+        vec![descriptor],
+        None,
+        Some(format!("Describe {key}")),
+    )
+}


### PR DESCRIPTION
Closes #675

## Summary
- add a commit-scoped SmartLink write context keyed by source and relationship
- reuse each decoded relationship bucket across forward and inverse pass-2 writes
- preserve public put_smartlink behavior, validation precedence, malformed-link failure, conflict semantics, target-cache exclusion, and lowest-SmartLinkId selection
- update the cache immediately after inserts and cover bucket expansion/reuse behavior

## Verification
- cargo test --manifest-path happ/Cargo.toml -p holons_guest persistence_layer::smartlink::tests
- nix develop -c cargo check --manifest-path happ/Cargo.toml
- npm test
- npm start (clean dev conductor state)