### PR TITLE
678 val pre dependency safe validation outcomes and shared objects default completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
  "base_types",
  "integrity_core_types",
  "serde",
+ "serde_json",
  "uuid 1.21.0",
 ]
 

--- a/happ/crates/holons_loader/src/controller.rs
+++ b/happ/crates/holons_loader/src/controller.rs
@@ -315,14 +315,27 @@ impl HolonLoaderController {
         }
 
         // ─────────────────────────────────────────────────────────────────────
-        // DEFAULT POPULATION: complete only the exact nursery-staged set.
+        // DEFAULT POPULATION: retry construction completion after Pass-2 resolution
+        // over the exact nursery-staged set.
         // ─────────────────────────────────────────────────────────────────────
         let mut population_errors = Vec::new();
+        let mut deferred_count = 0;
         for mut staged_holon in context.staged_references()? {
             let source_loader_key = staged_holon.key()?;
-            if let Err(error) = staged_holon.populate_defaults() {
-                population_errors.push(ErrorWithContext { error, source_loader_key });
+            match staged_holon.populate_defaults() {
+                Ok(CompletionOutcome::Completed) => {}
+                Ok(CompletionOutcome::DeferredNoDescriptor) => deferred_count += 1,
+                Err(error) => {
+                    population_errors.push(ErrorWithContext { error, source_loader_key });
+                }
             }
+        }
+
+        if deferred_count > 0 {
+            warn!(
+                "Default population deferred for {} staged holon(s) with unresolved descriptors",
+                deferred_count
+            );
         }
 
         if !population_errors.is_empty() {

--- a/host/map-sdk/src/internal/wire-types/references.ts
+++ b/host/map-sdk/src/internal/wire-types/references.ts
@@ -130,6 +130,33 @@ export type ValidationState =
   | 'Validated'
   | 'Invalid';
 
+/** Identity-only semantic findings, matching Rust's default serde enum encoding. */
+export type CommitValidationViolationKindWire =
+  | 'NoDescriptor'
+  | 'UnsupportedValidationRule'
+  | { UnsupportedConstraintType: { constraint_identity: string; constraint_type_identity: string } }
+  | { RuleViolation: { code: string } }
+  | 'UnresolvedLocalDependency'
+  | 'RelationshipCoordinationRequired';
+
+export type ValidationSubjectPathWire =
+  | { Holon: { holon_identity: string } }
+  | { Property: { holon_identity: string; name: string } }
+  | { Value: { holon_identity: string; property: string } }
+  | { Relationship: { source_identity: string; name: string; target_identity: string } }
+  | 'Transaction';
+
+export type ValidationSeverityWire = 'Info' | 'Warning' | 'Error';
+
+export interface CommitValidationViolationWire {
+  kind: CommitValidationViolationKindWire;
+  rule_key: string | null;
+  severity: ValidationSeverityWire;
+  subject: ValidationSubjectPathWire;
+  descriptor_identity: string | null;
+  message: string;
+}
+
 // `Committed` is the only tuple-like staged payload variant used here.
 export type StagedState =
   | 'Abandoned'
@@ -161,6 +188,7 @@ export interface StagedHolonWire {
   holon_state: HolonState;
   staged_state: StagedState;
   validation_state: ValidationState;
+  validation_findings?: CommitValidationViolationWire[];
   property_map: PropertyMap;
   staged_relationships: StagedRelationshipMapWire;
   original_id: LocalId | null;
@@ -1158,6 +1186,9 @@ export function isStagedHolonWire(value: unknown): value is StagedHolonWire {
     isHolonState(value['holon_state']) &&
     isStagedState(value['staged_state']) &&
     isValidationState(value['validation_state']) &&
+    (value['validation_findings'] === undefined ||
+      (Array.isArray(value['validation_findings']) &&
+        value['validation_findings'].every(isCommitValidationViolationWire))) &&
     isPropertyMap(value['property_map']) &&
     isStagedRelationshipMapWire(value['staged_relationships']) &&
     isNullable(value['original_id'], isLocalId) &&
@@ -1168,6 +1199,95 @@ export function isStagedHolonWire(value: unknown): value is StagedHolonWire {
         value['touched_relationship_names'].every(isString))) &&
     Array.isArray(value['errors']) &&
     value['errors'].every(isHolonErrorWire)
+  );
+}
+
+export function isCommitValidationViolationKindWire(
+  value: unknown,
+): value is CommitValidationViolationKindWire {
+  return (
+    value === 'NoDescriptor' ||
+    value === 'UnsupportedValidationRule' ||
+    value === 'UnresolvedLocalDependency' ||
+    value === 'RelationshipCoordinationRequired' ||
+    isTaggedValue(
+      value,
+      'UnsupportedConstraintType',
+      (candidate): candidate is {
+        constraint_identity: string;
+        constraint_type_identity: string;
+      } =>
+        isRecord(candidate) &&
+        isString(candidate['constraint_identity']) &&
+        isString(candidate['constraint_type_identity']),
+    ) ||
+    isTaggedValue(
+      value,
+      'RuleViolation',
+      (candidate): candidate is { code: string } =>
+        isRecord(candidate) && isString(candidate['code']),
+    )
+  );
+}
+
+export function isValidationSubjectPathWire(
+  value: unknown,
+): value is ValidationSubjectPathWire {
+  return (
+    value === 'Transaction' ||
+    isTaggedValue(
+      value,
+      'Holon',
+      (candidate): candidate is { holon_identity: string } =>
+        isRecord(candidate) && isString(candidate['holon_identity']),
+    ) ||
+    isTaggedValue(
+      value,
+      'Property',
+      (candidate): candidate is { holon_identity: string; name: string } =>
+        isRecord(candidate) &&
+        isString(candidate['holon_identity']) &&
+        isString(candidate['name']),
+    ) ||
+    isTaggedValue(
+      value,
+      'Value',
+      (candidate): candidate is { holon_identity: string; property: string } =>
+        isRecord(candidate) &&
+        isString(candidate['holon_identity']) &&
+        isString(candidate['property']),
+    ) ||
+    isTaggedValue(
+      value,
+      'Relationship',
+      (candidate): candidate is {
+        source_identity: string;
+        name: string;
+        target_identity: string;
+      } =>
+        isRecord(candidate) &&
+        isString(candidate['source_identity']) &&
+        isString(candidate['name']) &&
+        isString(candidate['target_identity']),
+    )
+  );
+}
+
+export function isValidationSeverityWire(value: unknown): value is ValidationSeverityWire {
+  return value === 'Info' || value === 'Warning' || value === 'Error';
+}
+
+export function isCommitValidationViolationWire(
+  value: unknown,
+): value is CommitValidationViolationWire {
+  return (
+    isRecord(value) &&
+    isCommitValidationViolationKindWire(value['kind']) &&
+    isNullable(value['rule_key'], isString) &&
+    isValidationSeverityWire(value['severity']) &&
+    isValidationSubjectPathWire(value['subject']) &&
+    isNullable(value['descriptor_identity'], isString) &&
+    isString(value['message'])
   );
 }
 

--- a/host/map-sdk/tests/references-source-alignment.test.ts
+++ b/host/map-sdk/tests/references-source-alignment.test.ts
@@ -13,6 +13,58 @@ import {
 // ===========================================
 
 describe('source-aligned holon wire guards', () => {
+  it('accepts semantic findings separately from operational errors and rejects malformed findings', () => {
+    const finding = {
+      kind: { RuleViolation: { code: 'DS-PROP-001' } },
+      rule_key: 'required-property',
+      severity: 'Error',
+      subject: { Property: { holon_identity: 'subject', name: 'Name' } },
+      descriptor_identity: 'Name.PropertyType',
+      message: 'Supply Name',
+    };
+    const staged = {
+      version: 1, holon_state: 'Mutable', staged_state: 'ForCreate',
+      validation_state: 'Invalid', property_map: {},
+      staged_relationships: { map: {} }, original_id: null,
+      errors: [{ NotImplemented: 'persistence' }],
+    };
+    expect(isStagedHolonWire(staged)).toBe(true);
+    expect(isStagedHolonWire({ ...staged, validation_findings: [] })).toBe(true);
+    expect(isStagedHolonWire({ ...staged, validation_findings: [finding] })).toBe(true);
+    // Rust unit variants serialize as strings; struct variants use external tags.
+    for (const kind of [
+      'NoDescriptor', 'UnsupportedValidationRule', 'UnresolvedLocalDependency',
+      'RelationshipCoordinationRequired', { RuleViolation: { code: 'DS-PROP-001' } },
+      { UnsupportedConstraintType: { constraint_identity: 'constraint', constraint_type_identity: 'type' } },
+    ]) {
+      for (const subject of [
+        'Transaction', { Holon: { holon_identity: 'subject' } },
+        { Property: { holon_identity: 'subject', name: 'Name' } },
+        { Value: { holon_identity: 'subject', property: 'Name' } },
+        { Relationship: { source_identity: 'source', name: 'RelatedTo', target_identity: 'target' } },
+      ]) {
+        for (const severity of ['Info', 'Warning', 'Error']) {
+          expect(isStagedHolonWire({
+            ...staged,
+            validation_findings: [{ ...finding, kind, subject, severity, rule_key: null, descriptor_identity: null }],
+          })).toBe(true);
+        }
+      }
+    }
+    for (const invalid of [
+      null, {}, { ...finding, severity: 'Fatal' },
+      { ...finding, kind: { RuleViolation: { code: 1 } } },
+      { ...finding, subject: { Property: { holon_identity: 'subject' } } },
+      { ...finding, descriptor_identity: {} }, { ...finding, rule_key: 1 },
+      { ...finding, message: null },
+    ]) {
+      expect(isStagedHolonWire({ ...staged, validation_findings: [invalid] })).toBe(false);
+    }
+    expect(isStagedHolonWire({ ...staged, validation_findings: null })).toBe(false);
+    expect(isStagedHolonWire({ ...staged, validation_findings: staged.errors })).toBe(false);
+    expect(isStagedHolonWire({ ...staged, errors: [finding] })).toBe(false);
+  });
+
   it('accepts SavedState variants declared in Rust SavedState', () => {
     // Mirrors shared_crates/holons_core/src/core_shared_objects/holon/state.rs.
     expect(isSavedState('Fetched')).toBe(true);

--- a/shared_crates/holons_boundary/src/context_binding/staged_wire.rs
+++ b/shared_crates/holons_boundary/src/context_binding/staged_wire.rs
@@ -1,6 +1,6 @@
 use crate::context_binding::staged_relationship_wire::StagedRelationshipMapWire;
 use base_types::MapInteger;
-use core_types::{HolonError, LocalId, PropertyMap, RelationshipName};
+use core_types::{CommitValidationViolation, HolonError, LocalId, PropertyMap, RelationshipName};
 use holons_core::core_shared_objects::holon::{HolonState, StagedState, ValidationState};
 use holons_core::core_shared_objects::transactions::TransactionContext;
 use holons_core::core_shared_objects::StagedHolon;
@@ -14,6 +14,8 @@ pub struct StagedHolonWire {
     holon_state: HolonState,
     staged_state: StagedState,
     validation_state: ValidationState,
+    #[serde(default)]
+    validation_findings: Vec<CommitValidationViolation>,
     property_map: PropertyMap,
     staged_relationships: StagedRelationshipMapWire,
     original_id: Option<LocalId>,
@@ -32,6 +34,7 @@ impl StagedHolonWire {
             self.holon_state,
             self.staged_state,
             self.validation_state,
+            self.validation_findings,
             self.property_map,
             self.staged_relationships.bind(context)?,
             self.original_id,
@@ -49,6 +52,7 @@ impl StagedHolonWire {
             self.holon_state,
             self.staged_state,
             self.validation_state,
+            self.validation_findings,
             self.property_map,
             self.staged_relationships.rebind(context)?,
             self.original_id,
@@ -66,6 +70,7 @@ impl From<&StagedHolon> for StagedHolonWire {
             holon_state: value.holon_state().clone(),
             staged_state: value.staged_state().clone(),
             validation_state: value.validation_state().clone(),
+            validation_findings: value.validation_findings().to_vec(),
             property_map: value.property_map().clone(),
             staged_relationships: StagedRelationshipMapWire::from(value.staged_relationships()),
             original_id: value.original_id_ref().cloned(),
@@ -82,6 +87,115 @@ mod tests {
     use base_types::MapString;
     use core_types::RelationshipName;
     use holons_core::core_shared_objects::WriteableHolonState;
+
+    #[derive(Debug)]
+    struct UnusedHolonService;
+
+    impl holons_core::HolonServiceApi for UnusedHolonService {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn commit_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: &[holons_core::StagedReference],
+        ) -> Result<holons_core::TransientReference, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn delete_holon_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: &LocalId,
+        ) -> Result<(), HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn fetch_all_related_holons_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: &core_types::HolonId,
+        ) -> Result<holons_core::RelationshipMap, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn fetch_holon_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: &core_types::HolonId,
+        ) -> Result<holons_core::core_shared_objects::Holon, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn fetch_related_holons_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: &core_types::HolonId,
+            _: &RelationshipName,
+        ) -> Result<holons_core::HolonCollection, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn get_all_holons_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+        ) -> Result<holons_core::HolonCollection, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+        fn load_holons_internal(
+            &self,
+            _: &Arc<TransactionContext>,
+            _: holons_core::TransientReference,
+        ) -> Result<holons_core::TransientReference, HolonError> {
+            panic!("wire binding must not access persistence")
+        }
+    }
+
+    #[test]
+    fn validation_findings_round_trip_and_default_when_absent() -> Result<(), HolonError> {
+        use core_types::{
+            CommitValidationViolationKind, ValidationSeverity, ValidationSubjectPath,
+        };
+        use holons_core::core_shared_objects::{
+            space_manager::HolonSpaceManager, ServiceRoutingPolicy,
+        };
+
+        let space = Arc::new(HolonSpaceManager::new_with_managers(
+            None,
+            Arc::new(UnusedHolonService),
+            None,
+            ServiceRoutingPolicy::BlockExternal,
+        ));
+        let context = space.get_transaction_manager().open_new_transaction(Arc::clone(&space))?;
+        let mut staged = StagedHolon::new_for_create();
+        staged.add_error(HolonError::NotImplemented("persistence".into()))?;
+        staged.replace_validation_outcome(
+            ValidationState::Invalid,
+            vec![CommitValidationViolation {
+                kind: CommitValidationViolationKind::RuleViolation { code: "DS-PROP-001".into() },
+                rule_key: Some("required-property".into()),
+                severity: ValidationSeverity::Error,
+                subject: ValidationSubjectPath::Property {
+                    holon_identity: "subject".into(),
+                    name: "Name".into(),
+                },
+                descriptor_identity: Some("Name.PropertyType".into()),
+                message: "Supply Name".into(),
+            }],
+        )?;
+        let mut json = serde_json::to_value(StagedHolonWire::from(&staged)).unwrap();
+        assert_eq!(
+            json["validation_findings"][0]["kind"],
+            serde_json::json!({"RuleViolation": {"code": "DS-PROP-001"}})
+        );
+        assert_eq!(json["errors"], serde_json::json!([{"NotImplemented": "persistence"}]));
+        let wire: StagedHolonWire = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(wire.clone().bind(&context)?, staged);
+        assert_eq!(wire.rebind(&context)?, staged);
+
+        json.as_object_mut().unwrap().remove("validation_findings");
+        let legacy: StagedHolonWire = serde_json::from_value(json).unwrap();
+        let rebound = legacy.bind(&context)?;
+        assert!(rebound.validation_findings().is_empty());
+        assert_eq!(rebound.validation_state(), staged.validation_state());
+        assert_eq!(rebound.errors(), staged.errors());
+        Ok(())
+    }
 
     /// Regression guard (issue #515): relationship-mutation intent
     /// (`touched_relationship_names`) is transaction-scoped staged state that must

--- a/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/holon/staged.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 use base_types::{BaseValue, MapInteger, MapString};
 use core_types::{
-    HolonError, HolonId, HolonNodeModel, LocalId, PropertyMap, PropertyName, PropertyValue,
-    RelationshipName,
+    CommitValidationViolation, HolonError, HolonId, HolonNodeModel, LocalId, PropertyMap,
+    PropertyName, PropertyValue, RelationshipName,
 };
 use type_names::CorePropertyTypeName;
 
@@ -31,6 +31,7 @@ pub struct StagedHolon {
     holon_state: HolonState,   // Mutable or Immutable
     staged_state: StagedState, // ForCreate, update states, Abandoned, or Committed
     validation_state: ValidationState,
+    validation_findings: Vec<CommitValidationViolation>,
     property_map: PropertyMap, // Self-describing property data
     staged_relationships: StagedRelationshipMap,
     /// The lineage inherited from the holon this was cloned from, if any. Carried through staging
@@ -61,6 +62,7 @@ impl StagedHolon {
             holon_state: HolonState::Mutable,
             staged_state: StagedState::ForCreate,
             validation_state: ValidationState::ValidationRequired,
+            validation_findings: Vec::new(),
             property_map: PropertyMap::new(),
             staged_relationships: StagedRelationshipMap::new_empty(),
             original_id: None,
@@ -79,6 +81,7 @@ impl StagedHolon {
             holon_state: HolonState::Mutable,
             staged_state: StagedState::ForCreate,
             validation_state: ValidationState::ValidationRequired,
+            validation_findings: Vec::new(),
             property_map: model.properties,
             staged_relationships,
             original_id: model.original_id,
@@ -103,6 +106,7 @@ impl StagedHolon {
             holon_state: HolonState::Mutable,
             staged_state: StagedState::ForUpdate,
             validation_state: ValidationState::ValidationRequired,
+            validation_findings: Vec::new(),
             property_map: model.properties,
             staged_relationships,
             original_id: model.original_id,
@@ -119,6 +123,7 @@ impl StagedHolon {
         holon_state: HolonState,
         staged_state: StagedState,
         validation_state: ValidationState,
+        validation_findings: Vec<CommitValidationViolation>,
         property_map: PropertyMap,
         staged_relationships: StagedRelationshipMap,
         original_id: Option<LocalId>,
@@ -131,6 +136,7 @@ impl StagedHolon {
             holon_state,
             staged_state,
             validation_state,
+            validation_findings,
             property_map,
             staged_relationships,
             original_id,
@@ -224,6 +230,34 @@ impl StagedHolon {
 
     pub fn validation_state(&self) -> &ValidationState {
         &self.validation_state
+    }
+
+    /// Semantic findings from the most recent validation pass.
+    pub fn validation_findings(&self) -> &[CommitValidationViolation] {
+        &self.validation_findings
+    }
+
+    /// Replaces a live staged holon's validation outcome without changing operational errors.
+    ///
+    /// State and findings are installed together under exclusive mutable access so new
+    /// findings cannot be observed under a stale validation state. Abandoned and committed
+    /// holons reject replacement without changing either part of the outcome.
+    pub fn replace_validation_outcome(
+        &mut self,
+        state: ValidationState,
+        findings: Vec<CommitValidationViolation>,
+    ) -> Result<(), HolonError> {
+        self.is_accessible(AccessType::Commit)?;
+        // Immutable accessibility permits Commit even after the staged lifecycle has ended.
+        if matches!(self.staged_state, StagedState::Abandoned | StagedState::Committed(_)) {
+            return Err(HolonError::NotAccessible(
+                AccessType::Commit.to_string(),
+                self.staged_state.to_string(),
+            ));
+        }
+        self.validation_state = state;
+        self.validation_findings = findings;
+        Ok(())
     }
 
     pub fn property_map(&self) -> &PropertyMap {
@@ -628,6 +662,64 @@ mod tests {
 
     use super::*;
 
+    fn finding() -> CommitValidationViolation {
+        CommitValidationViolation {
+            kind: core_types::CommitValidationViolationKind::NoDescriptor,
+            rule_key: None,
+            severity: core_types::ValidationSeverity::Error,
+            subject: core_types::ValidationSubjectPath::Holon { holon_identity: "subject".into() },
+            descriptor_identity: None,
+            message: "Attach a governing descriptor".into(),
+        }
+    }
+
+    #[test]
+    fn validation_outcome_replaces_findings_and_preserves_operational_errors(
+    ) -> Result<(), HolonError> {
+        for state in [
+            StagedState::ForCreate,
+            StagedState::ForUpdate,
+            StagedState::ForUpdateGraphOnly,
+            StagedState::ForUpdateNewVersion,
+        ] {
+            for holon_state in [HolonState::Mutable, HolonState::Immutable] {
+                let mut staged = StagedHolon::new_for_create();
+                staged.staged_state = state.clone();
+                staged.holon_state = holon_state;
+                let error = HolonError::NotImplemented("persistence".into());
+                staged.add_error(error.clone())?;
+                staged.replace_validation_outcome(ValidationState::Invalid, vec![finding()])?;
+                assert_eq!(staged.validation_state(), &ValidationState::Invalid);
+                assert_eq!(staged.validation_findings(), &[finding()]);
+                staged.replace_validation_outcome(ValidationState::Validated, Vec::new())?;
+                assert_eq!(staged.validation_state(), &ValidationState::Validated);
+                assert!(staged.validation_findings().is_empty());
+                assert_eq!(staged.errors(), &[error]);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn validation_outcome_rejects_terminal_states_without_mutation() -> Result<(), HolonError> {
+        for state in [StagedState::Abandoned, StagedState::Committed(LocalId(vec![1]))] {
+            for holon_state in [HolonState::Mutable, HolonState::Immutable] {
+                let mut staged = StagedHolon::new_for_create();
+                staged.replace_validation_outcome(ValidationState::Invalid, vec![finding()])?;
+                staged.add_error(HolonError::NotImplemented("persistence".into()))?;
+                staged.staged_state = state.clone();
+                staged.holon_state = holon_state;
+                let before = staged.clone();
+                assert!(matches!(
+                    staged.replace_validation_outcome(ValidationState::Validated, Vec::new()),
+                    Err(HolonError::NotAccessible(..))
+                ));
+                assert_eq!(staged, before);
+            }
+        }
+        Ok(())
+    }
+
     #[test]
     fn instantiate_and_modify() {
         // Initialize default Holon
@@ -637,6 +729,7 @@ mod tests {
             holon_state: HolonState::Mutable,
             staged_state: StagedState::ForCreate,
             validation_state: ValidationState::ValidationRequired,
+            validation_findings: Vec::new(),
             property_map: BTreeMap::new(),
             staged_relationships: StagedRelationshipMap::new_empty(),
             original_id: None,
@@ -718,6 +811,7 @@ mod tests {
             holon_state: HolonState::Mutable,
             staged_state: StagedState::ForCreate,
             validation_state: ValidationState::ValidationRequired,
+            validation_findings: Vec::new(),
             property_map: BTreeMap::new(),
             staged_relationships: StagedRelationshipMap { map: BTreeMap::new() },
             original_id: None,
@@ -808,6 +902,7 @@ mod tests {
             HolonState::Mutable,
             StagedState::ForUpdateGraphOnly,
             ValidationState::ValidationRequired,
+            Vec::new(),
             PropertyMap::new(),
             StagedRelationshipMap { map: relationships },
             None,

--- a/shared_crates/holons_core/src/core_shared_objects/nursery.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/nursery.rs
@@ -191,7 +191,9 @@ impl HolonStagingBehavior for Nursery {
         let staged_holon =
             StagedHolon::new_from_clone_model(transient_reference.holon_clone_model()?)?;
         let new_id = self.stage_holon(staged_holon)?;
-        self.to_validated_staged_reference(&new_id)
+        let mut staged_reference = self.to_validated_staged_reference(&new_id)?;
+        staged_reference.populate_defaults()?;
+        Ok(staged_reference)
     }
 
     /// Stage a new holon by cloning an existing holon, with a new key and
@@ -234,12 +236,21 @@ impl HolonStagingBehavior for Nursery {
             }
         };
 
+        // Snapshot the persisted properties before cloning. `clone_holon` runs construction
+        // completion on the clone (see `SmartReference::clone_holon_impl`), so this is the
+        // last point at which the pre-completion state is observable.
+        let source_properties = current_version.into_model()?.property_map;
         // Clone through the reference layer so cached persisted relationships are preserved.
         let cloned_transient = current_version.clone_holon()?;
-        let staged_holon = StagedHolon::new_for_update_from_clone_model(
-            cloned_transient.holon_clone_model()?,
-            source_local_id,
-        )?;
+        let clone_model = cloned_transient.holon_clone_model()?;
+        let completion_changed_properties = clone_model.properties != source_properties;
+        let mut staged_holon =
+            StagedHolon::new_for_update_from_clone_model(clone_model, source_local_id)?;
+        // Defaults added to the clone are explicit content changes. A graph-only
+        // commit would reuse the saved node and silently discard those additions.
+        if completion_changed_properties {
+            staged_holon.note_property_mutation()?;
+        }
 
         let new_id = self.stage_holon(staged_holon)?;
         let mut staged_reference = self.to_validated_staged_reference(&new_id)?;
@@ -343,6 +354,7 @@ mod tests {
         source_id: LocalId,
         source_holon: SavedHolon,
         source_predecessor_id: Option<LocalId>,
+        described: bool,
     }
 
     impl HolonServiceApi for StageVersionTestService {
@@ -385,6 +397,28 @@ mod tests {
                     relationships.insert(
                         CoreRelationshipTypeName::Predecessor.to_relationship_name(),
                         Arc::new(RwLock::new(predecessor_collection)),
+                    );
+                }
+
+                if self.described {
+                    use crate::descriptors::test_support::new_descriptor_holon;
+                    let mut property =
+                        new_descriptor_holon(context, "enabled", "Enabled", "Property")?;
+                    property.with_property_value(CorePropertyTypeName::IsValueRequired, true)?;
+                    property.with_property_value(CorePropertyTypeName::DefaultValue, false)?;
+                    let property = context.mutation().stage_new_holon(property)?;
+                    let mut descriptor =
+                        new_descriptor_holon(context, "contract", "Contract", "Holon")?;
+                    descriptor.add_related_holons(
+                        CoreRelationshipTypeName::InstanceProperties,
+                        vec![property.into()],
+                    )?;
+                    let descriptor = context.mutation().stage_new_holon(descriptor)?;
+                    let mut collection = HolonCollection::new_existing();
+                    collection.add_references(vec![descriptor.into()])?;
+                    relationships.insert(
+                        CoreRelationshipTypeName::DescribedBy.to_relationship_name(),
+                        Arc::new(RwLock::new(collection)),
                     );
                 }
 
@@ -435,9 +469,14 @@ mod tests {
         source_id: LocalId,
         source_holon: SavedHolon,
         source_predecessor_id: Option<LocalId>,
+        described: bool,
     ) -> Arc<TransactionContext> {
-        let holon_service: Arc<dyn HolonServiceApi> =
-            Arc::new(StageVersionTestService { source_id, source_holon, source_predecessor_id });
+        let holon_service: Arc<dyn HolonServiceApi> = Arc::new(StageVersionTestService {
+            source_id,
+            source_holon,
+            source_predecessor_id,
+            described,
+        });
         let space_manager = Arc::new(HolonSpaceManager::new_with_managers(
             None,
             holon_service,
@@ -449,6 +488,66 @@ mod tests {
             .get_transaction_manager()
             .open_new_transaction(Arc::clone(&space_manager))
             .expect("test transaction should open")
+    }
+
+    #[test]
+    fn saved_clone_completion_preserves_history_and_classifies_content_changes(
+    ) -> Result<(), HolonError> {
+        for authored in [None, Some(true)] {
+            let source_id = LocalId(vec![4, 5, 6]);
+            let mut properties = PropertyMap::new();
+            properties.insert(
+                CorePropertyTypeName::Key.as_property_name(),
+                BaseValue::StringValue(MapString("saved-source".into())),
+            );
+            if let Some(value) = authored {
+                properties.insert(
+                    PropertyName(MapString("Enabled".into())),
+                    BaseValue::BooleanValue(base_types::MapBoolean(value)),
+                );
+            }
+            let source =
+                SavedHolon::new(source_id.clone(), properties.clone(), None, MapInteger(1));
+            let context = stage_version_test_context(source_id.clone(), source, None, true);
+            let saved =
+                SmartReference::new_from_id(context.context_handle(), HolonId::Local(source_id));
+            let cloned = saved.clone_holon()?;
+            assert_eq!(
+                cloned.property_value("Enabled")?,
+                Some(BaseValue::BooleanValue(base_types::MapBoolean(authored.unwrap_or(false))))
+            );
+            assert_eq!(saved.into_model()?.property_map, properties);
+
+            let independent = context
+                .mutation()
+                .stage_new_from_clone(saved.clone().into(), MapString("independent".into()))?;
+            assert_eq!(independent.property_value("Enabled")?, cloned.property_value("Enabled")?);
+            assert_eq!(saved.into_model()?.property_map, properties);
+
+            let staged = context.mutation().stage_new_version(saved.clone())?;
+            let expected_state = if authored.is_some() {
+                StagedState::ForUpdate
+            } else {
+                StagedState::ForUpdateNewVersion
+            };
+            assert!(staged.is_in_state(&context, expected_state)?);
+            assert_eq!(staged.property_value("Enabled")?, cloned.property_value("Enabled")?);
+            // Check the lifecycle consequence of a subsequent non-definitional edit.
+            let rc_holon = staged.get_holon_to_commit(&context)?;
+            let mut holon = rc_holon.write().unwrap();
+            let Holon::Staged(holon) = &mut *holon else { panic!("expected staged update") };
+            holon.note_relationship_mutation(false)?;
+            assert_eq!(
+                holon.get_staged_state(),
+                if authored.is_some() {
+                    StagedState::ForUpdateGraphOnly
+                } else {
+                    StagedState::ForUpdateNewVersion
+                }
+            );
+            assert_eq!(saved.into_model()?.property_map, properties);
+        }
+        Ok(())
     }
 
     #[test]
@@ -468,6 +567,7 @@ mod tests {
             source_id.clone(),
             source_holon,
             Some(LocalId(vec![9, 8, 7])),
+            false,
         );
         let current_version = SmartReference::new_from_id(
             context.context_handle(),

--- a/shared_crates/holons_core/src/core_shared_objects/transient_holon_manager.rs
+++ b/shared_crates/holons_core/src/core_shared_objects/transient_holon_manager.rs
@@ -16,7 +16,7 @@ use crate::{
         transient_manager_access_internal::TransientManagerAccessInternal,
         ReadableRelationship, TransientManagerAccess, TransientRelationshipMap,
     },
-    reference_layer::{TransientHolonBehavior, TransientReference},
+    reference_layer::{TransientHolonBehavior, TransientReference, WritableHolon},
 };
 use base_types::{BaseValue, MapInteger, MapString};
 use core_types::{HolonError, PropertyMap, TemporaryId};
@@ -179,7 +179,8 @@ impl TransientHolonBehavior for TransientHolonManager {
             holon_clone_model.original_id,
         );
 
-        let transient_reference = self.add_new_holon(holon)?;
+        let mut transient_reference = self.add_new_holon(holon)?;
+        transient_reference.populate_defaults()?;
 
         Ok(transient_reference)
     }

--- a/shared_crates/holons_core/src/descriptors/property_descriptor.rs
+++ b/shared_crates/holons_core/src/descriptors/property_descriptor.rs
@@ -154,7 +154,7 @@ mod tests {
     use super::*;
     use crate::descriptors::test_support::new_test_holon;
     use crate::descriptors::test_support::{build_context, new_descriptor_holon};
-    use crate::reference_layer::{ReadableHolon, WritableHolon};
+    use crate::reference_layer::{CompletionOutcome, ReadableHolon, WritableHolon};
     use base_types::MapString;
     use core_types::HolonError;
     use type_names::CoreRelationshipTypeName;
@@ -178,12 +178,12 @@ mod tests {
     }
 
     #[test]
-    fn populate_defaults_errors_for_an_undescribed_holon() -> Result<(), HolonError> {
+    fn populate_defaults_defers_for_an_undescribed_holon() -> Result<(), HolonError> {
         let context = build_context();
         let mut holon = new_test_holon(&context, "undescribed-instance")?;
         holon.with_property_value("Authored", "preserved")?;
 
-        assert!(matches!(holon.populate_defaults(), Err(HolonError::MissingDescribedBy { .. })));
+        assert_eq!(holon.populate_defaults()?, CompletionOutcome::DeferredNoDescriptor);
 
         assert!(matches!(
             holon.property_value("Authored")?,
@@ -208,6 +208,103 @@ mod tests {
             Err(HolonError::MultipleDescribedBy { count: 2, .. })
         ));
 
+        Ok(())
+    }
+
+    #[test]
+    fn completion_preserves_progress_and_retries_nested_descriptor_deferral(
+    ) -> Result<(), HolonError> {
+        let context = build_context();
+        let mut deferred = new_descriptor_holon(&context, "deferred", "Deferred", "Property")?;
+        deferred.with_property_value(CorePropertyTypeName::DefaultValue, true)?;
+        let mut required = new_descriptor_holon(&context, "required", "Required", "Property")?;
+        required
+            .with_property_value(CorePropertyTypeName::IsValueRequired, true)?
+            .with_property_value(CorePropertyTypeName::DefaultValue, false)?;
+        let mut optional = new_descriptor_holon(&context, "optional", "Optional", "Property")?;
+        optional
+            .with_property_value(CorePropertyTypeName::IsValueRequired, false)?
+            .with_property_value(CorePropertyTypeName::DefaultValue, true)?;
+        let mut descriptor = new_descriptor_holon(&context, "contract", "Contract", "Holon")?;
+        descriptor.add_related_holons(
+            CoreRelationshipTypeName::InstanceProperties,
+            vec![deferred.clone().into(), required.into(), optional.into()],
+        )?;
+        let mut target = new_test_holon(&context, "target")?;
+        target.with_descriptor(descriptor.into())?;
+
+        assert_eq!(target.populate_defaults()?, CompletionOutcome::DeferredNoDescriptor);
+        assert_eq!(
+            target.property_value("Required")?,
+            Some(BaseValue::BooleanValue(base_types::MapBoolean(false)))
+        );
+        assert_eq!(target.property_value("Deferred")?, None);
+        assert_eq!(target.property_value("Optional")?, None);
+
+        let mut required_definition =
+            new_descriptor_holon(&context, "required-definition", "IsValueRequired", "Property")?;
+        required_definition.with_property_value(CorePropertyTypeName::DefaultValue, true)?;
+        let mut meta_property =
+            new_descriptor_holon(&context, "meta-property", "MetaProperty", "Holon")?;
+        meta_property.add_related_holons(
+            CoreRelationshipTypeName::InstanceProperties,
+            vec![required_definition.into()],
+        )?;
+        deferred.with_descriptor(meta_property.into())?;
+        target.with_property_value("Required", true)?;
+
+        assert_eq!(target.populate_defaults()?, CompletionOutcome::Completed);
+        assert_eq!(target.populate_defaults()?, CompletionOutcome::Completed);
+        assert_eq!(
+            target.property_value("Required")?,
+            Some(BaseValue::BooleanValue(base_types::MapBoolean(true)))
+        );
+        assert_eq!(
+            target.property_value("Deferred")?,
+            Some(BaseValue::BooleanValue(base_types::MapBoolean(true)))
+        );
+        assert_eq!(target.property_value("Optional")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn construction_completes_clones_and_staging_without_changing_source() -> Result<(), HolonError>
+    {
+        let context = build_context();
+        let mut property = new_descriptor_holon(&context, "enabled", "Enabled", "Property")?;
+        property
+            .with_property_value(CorePropertyTypeName::IsValueRequired, true)?
+            .with_property_value(CorePropertyTypeName::DefaultValue, false)?;
+        let property = context.mutation().stage_new_holon(property)?;
+        let mut descriptor = new_descriptor_holon(&context, "contract", "Contract", "Holon")?;
+        descriptor.add_related_holons(
+            CoreRelationshipTypeName::InstanceProperties,
+            vec![property.into()],
+        )?;
+        let descriptor = context.mutation().stage_new_holon(descriptor)?;
+        let mut source = new_test_holon(&context, "source")?;
+        source.with_descriptor(descriptor.into())?;
+        source.with_property_value("Authored", "preserved")?;
+
+        let transient_clone = source.clone_holon()?;
+        let mut clone_source = context.mutation().stage_new_holon(source.clone())?;
+        assert_eq!(
+            clone_source.property_value("Enabled")?,
+            Some(BaseValue::BooleanValue(base_types::MapBoolean(false)))
+        );
+        clone_source.remove_property_value("Enabled")?;
+        let staged_clone = context
+            .mutation()
+            .stage_new_from_clone(clone_source.clone().into(), MapString("independent".into()))?;
+        for completed in [HolonReference::from(transient_clone), staged_clone.into()] {
+            assert_eq!(
+                completed.property_value("Enabled")?,
+                Some(BaseValue::BooleanValue(base_types::MapBoolean(false)))
+            );
+            assert_eq!(completed.property_value("Authored")?, source.property_value("Authored")?);
+        }
+        assert_eq!(source.property_value("Enabled")?, None);
+        assert_eq!(clone_source.property_value("Enabled")?, None);
         Ok(())
     }
 

--- a/shared_crates/holons_core/src/lib.rs
+++ b/shared_crates/holons_core/src/lib.rs
@@ -28,9 +28,9 @@ pub use descriptors::{
     TypeHeader, ValueDescriptor,
 };
 pub use reference_layer::{
-    Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi, HolonReference,
-    HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver, NodeResolution,
-    ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior, TransientReference,
-    WritableHolon,
+    CompletionOutcome, Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi,
+    HolonReference, HolonServiceApi, HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver,
+    NodeResolution, ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior,
+    TransientReference, WritableHolon,
 };
 // pub use utils::*;

--- a/shared_crates/holons_core/src/reference_layer/mod.rs
+++ b/shared_crates/holons_core/src/reference_layer/mod.rs
@@ -27,4 +27,4 @@ pub use space_manager_behavior::HolonSpaceBehavior;
 pub use staged_reference::StagedReference;
 pub use transient_holon_behavior::TransientHolonBehavior;
 pub use transient_reference::TransientReference;
-pub use writable_holon::WritableHolon;
+pub use writable_holon::{CompletionOutcome, WritableHolon};

--- a/shared_crates/holons_core/src/reference_layer/smart_reference.rs
+++ b/shared_crates/holons_core/src/reference_layer/smart_reference.rs
@@ -164,20 +164,21 @@ impl fmt::Display for SmartReference {
 impl ReadableHolonImpl for SmartReference {
     fn clone_holon_impl(&self) -> Result<TransientReference, HolonError> {
         self.is_accessible(AccessType::Clone)?;
-        let rc_holon = self.get_rc_holon()?;
-        let borrowed_holon = rc_holon.read().map_err(|e| {
-            HolonError::FailedToAcquireLock(format!(
-                "Failed to acquire read lock on holon for clone_holon_impl: {}",
-                e
-            ))
-        })?;
+        let clone_model = {
+            let rc_holon = self.get_rc_holon()?;
+            let borrowed_holon = rc_holon.read().map_err(|e| {
+                HolonError::FailedToAcquireLock(format!(
+                    "Failed to acquire read lock on holon for clone_holon_impl: {}",
+                    e
+                ))
+            })?;
+            borrowed_holon.holon_clone_model()
+        };
 
-        // HolonCloneModel for SavedHolon will have 'None' for relationships, as populating its RelationshipMap
-        // is deferred to the reference layer, because context is needed that is only available in reference layer.
-        let mut cloned_holon_transient_reference = self
-            .context_handle
-            .context()
-            .new_transient_from_clone_model(borrowed_holon.holon_clone_model())?;
+        // Saved clone models omit relationships; the bound reference resolves
+        // them after releasing the source lock, including self-describing edges.
+        let mut cloned_holon_transient_reference =
+            self.context_handle.context().new_transient_from_clone_model(clone_model)?;
 
         let relationships = self.all_related_holons()?;
         let transient_relationships = relationships.clone_for_new_source()?;
@@ -196,6 +197,14 @@ impl ReadableHolonImpl for SmartReference {
 
             cloned_holon_transient_reference.add_related_holons(name, members)?;
         }
+
+        // Saved clone models omit relationships, so completion must wait until
+        // the full relationship map (including DescribedBy) has been attached.
+        // `Nursery::stage_new_version` depends on completion happening here: it
+        // classifies a staged update by diffing this clone against the persisted
+        // properties, so removing this call would silently leave saved clones
+        // incomplete and suppress that content-change classification.
+        cloned_holon_transient_reference.populate_defaults()?;
 
         Ok(cloned_holon_transient_reference)
     }

--- a/shared_crates/holons_core/src/reference_layer/writable_holon.rs
+++ b/shared_crates/holons_core/src/reference_layer/writable_holon.rs
@@ -5,6 +5,15 @@ use base_types::ToBaseValue;
 use core_types::HolonError;
 use type_names::{relationship_names::ToRelationshipName, ToPropertyName};
 
+/// Whether construction defaults could be fully resolved during this pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompletionOutcome {
+    /// All applicable defaults were considered; this does not establish validity.
+    Completed,
+    /// A governing descriptor is not attached yet; retry after reference resolution.
+    DeferredNoDescriptor,
+}
+
 /// Public façade for write operations (ergonomic + complete).
 ///
 /// Accepts any types implementing [`ToRelationshipName`] or [`ToPropertyName`].
@@ -17,18 +26,32 @@ pub trait WritableHolon: WritableHolonImpl {
     /// Populates applicable effective defaults without overwriting authored
     /// values.
     ///
-    /// The receiver must have exactly one `DescribedBy` target so completion
-    /// can resolve its effective instance-property contract. Callers that
-    /// construct a holon in stages must attach that target before completion.
-    fn populate_defaults(&mut self) -> Result<(), HolonError>
+    /// Missing descriptors, including those needed by property descriptors, defer
+    /// completion while preserving progress on other properties. All other errors
+    /// propagate. Retrying after reference resolution is safe and idempotent.
+    fn populate_defaults(&mut self) -> Result<CompletionOutcome, HolonError>
     where
         Self: ReadableHolon,
     {
-        let properties = self.available_properties()?;
+        let properties =
+            match self.holon_descriptor().and_then(|descriptor| descriptor.instance_properties()) {
+                Ok(properties) => properties,
+                Err(HolonError::MissingDescribedBy { .. }) => {
+                    return Ok(CompletionOutcome::DeferredNoDescriptor);
+                }
+                Err(error) => return Err(error),
+            };
+        let mut outcome = CompletionOutcome::Completed;
         for property in properties {
-            property.populate_default_if_required_and_absent(self)?;
+            match property.populate_default_if_required_and_absent(self) {
+                Ok(()) => {}
+                Err(HolonError::MissingDescribedBy { .. }) => {
+                    outcome = CompletionOutcome::DeferredNoDescriptor;
+                }
+                Err(error) => return Err(error),
+            }
         }
-        Ok(())
+        Ok(outcome)
     }
 
     /// Adds one or more related holons under the given relationship.

--- a/shared_crates/holons_prelude/src/prelude/v1.rs
+++ b/shared_crates/holons_prelude/src/prelude/v1.rs
@@ -51,9 +51,10 @@ pub use holons_core::dances::{
 };
 pub use holons_core::query_layer::{Node, NodeCollection, QueryExpression, QueryPathMap};
 pub use holons_core::reference_layer::{
-    Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi, HolonReference,
-    HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver, NodeResolution, ReadableHolon,
-    SmartReference, StagedReference, TransientHolonBehavior, TransientReference, WritableHolon,
+    CompletionOutcome, Divergence, EquivalenceOutcome, EquivalenceResolver, HolonCollectionApi,
+    HolonReference, HolonSpaceBehavior, HolonStagingBehavior, NoOpResolver, NodeResolution,
+    ReadableHolon, SmartReference, StagedReference, TransientHolonBehavior, TransientReference,
+    WritableHolon,
 };
 pub use holons_core::{
     Descriptor, ExtendsIter, HolonDescriptor, HolonSpaceDescriptor, PropertyDescriptor,

--- a/shared_crates/type_system/core_types/Cargo.toml
+++ b/shared_crates/type_system/core_types/Cargo.toml
@@ -20,3 +20,6 @@ path = "../base_types"
 [dependencies.uuid]
 version = "1"
 features = ["serde"]
+
+[dev-dependencies]
+serde_json = "1"

--- a/shared_crates/type_system/core_types/src/commit_validation.rs
+++ b/shared_crates/type_system/core_types/src/commit_validation.rs
@@ -1,0 +1,155 @@
+//! Identity-only semantic findings shared across runtime and transport boundaries.
+
+use serde::{Deserialize, Serialize};
+
+/// A semantic finding, separate from an operational persistence error.
+///
+/// Findings cross transport boundaries unchanged and must never contain bound runtime
+/// references. Subjects and descriptors are represented only by serialized identities.
+/// Stable machine interpretation uses `kind`, `rule_key`, and the rule-specific `code`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitValidationViolation {
+    pub kind: CommitValidationViolationKind,
+    pub rule_key: Option<String>,
+    pub severity: ValidationSeverity,
+    pub subject: ValidationSubjectPath,
+    pub descriptor_identity: Option<String>,
+    /// Actionable local diagnostic text, not a consensus-visible canonical message.
+    pub message: String,
+}
+
+/// Machine-readable classification of a semantic finding.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommitValidationViolationKind {
+    NoDescriptor,
+    UnsupportedValidationRule,
+    UnsupportedConstraintType { constraint_identity: String, constraint_type_identity: String },
+    RuleViolation { code: String },
+    UnresolvedLocalDependency,
+    RelationshipCoordinationRequired,
+}
+
+/// Serialized identity and path of the subject; never a bound runtime handle.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValidationSubjectPath {
+    Holon { holon_identity: String },
+    Property { holon_identity: String, name: String },
+    Value { holon_identity: String, property: String },
+    Relationship { source_identity: String, name: String, target_identity: String },
+    Transaction,
+}
+
+/// Dependency-safe mirror of the Core schema's ValidationSeverity enum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValidationSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn findings_preserve_sdk_json_contract_in_both_directions() {
+        // Explicit wire fixtures protect the hand-maintained SDK mirror from serde shape changes.
+        let kinds = [
+            (CommitValidationViolationKind::NoDescriptor, json!("NoDescriptor")),
+            (
+                CommitValidationViolationKind::UnsupportedValidationRule,
+                json!("UnsupportedValidationRule"),
+            ),
+            (
+                CommitValidationViolationKind::UnsupportedConstraintType {
+                    constraint_identity: "constraint".into(),
+                    constraint_type_identity: "constraint-type".into(),
+                },
+                json!({"UnsupportedConstraintType": {
+                    "constraint_identity": "constraint",
+                    "constraint_type_identity": "constraint-type"
+                }}),
+            ),
+            (
+                CommitValidationViolationKind::RuleViolation { code: "DS-PROP-001".into() },
+                json!({"RuleViolation": {"code": "DS-PROP-001"}}),
+            ),
+            (
+                CommitValidationViolationKind::UnresolvedLocalDependency,
+                json!("UnresolvedLocalDependency"),
+            ),
+            (
+                CommitValidationViolationKind::RelationshipCoordinationRequired,
+                json!("RelationshipCoordinationRequired"),
+            ),
+        ];
+        let subjects = [
+            (
+                ValidationSubjectPath::Holon { holon_identity: "subject".into() },
+                json!({"Holon": {"holon_identity": "subject"}}),
+            ),
+            (
+                ValidationSubjectPath::Property {
+                    holon_identity: "subject".into(),
+                    name: "Name".into(),
+                },
+                json!({"Property": {"holon_identity": "subject", "name": "Name"}}),
+            ),
+            (
+                ValidationSubjectPath::Value {
+                    holon_identity: "subject".into(),
+                    property: "Name".into(),
+                },
+                json!({"Value": {"holon_identity": "subject", "property": "Name"}}),
+            ),
+            (
+                ValidationSubjectPath::Relationship {
+                    source_identity: "source".into(),
+                    name: "RelatedTo".into(),
+                    target_identity: "target".into(),
+                },
+                json!({"Relationship": {"source_identity": "source", "name": "RelatedTo", "target_identity": "target"}}),
+            ),
+            (ValidationSubjectPath::Transaction, json!("Transaction")),
+        ];
+        for (kind, kind_json) in kinds {
+            for (subject, subject_json) in &subjects {
+                for (severity, severity_json) in [
+                    (ValidationSeverity::Info, json!("Info")),
+                    (ValidationSeverity::Warning, json!("Warning")),
+                    (ValidationSeverity::Error, json!("Error")),
+                ] {
+                    for (rule_key, descriptor_identity) in [
+                        (None, None),
+                        (Some("required-property"), None),
+                        (None, Some("descriptor")),
+                        (Some("required-property"), Some("descriptor")),
+                    ] {
+                        let finding = CommitValidationViolation {
+                            kind: kind.clone(),
+                            rule_key: rule_key.map(str::to_owned),
+                            severity,
+                            subject: subject.clone(),
+                            descriptor_identity: descriptor_identity.map(str::to_owned),
+                            message: "Supply the required property".into(),
+                        };
+                        let expected = json!({
+                            "kind": kind_json,
+                            "rule_key": rule_key,
+                            "severity": severity_json,
+                            "subject": subject_json,
+                            "descriptor_identity": descriptor_identity,
+                            "message": "Supply the required property"
+                        });
+                        assert_eq!(serde_json::to_value(&finding).unwrap(), expected);
+                        assert_eq!(
+                            serde_json::from_value::<CommitValidationViolation>(expected).unwrap(),
+                            finding
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared_crates/type_system/core_types/src/lib.rs
+++ b/shared_crates/type_system/core_types/src/lib.rs
@@ -14,11 +14,13 @@
 //! These types define the shape and meaning of data in MAP holons and descriptors,
 //! and are shared across guest and client implementations.
 
+pub mod commit_validation;
 pub mod holon_storage;
 pub mod ids;
 pub mod loader_content;
 pub mod smartlink;
 
+pub use commit_validation::*;
 pub use holon_storage::*;
 pub use ids::*;
 pub use loader_content::*;

--- a/tests/sweetests/src/harness/helpers/descriptor_completion.rs
+++ b/tests/sweetests/src/harness/helpers/descriptor_completion.rs
@@ -1,0 +1,55 @@
+use core_types::ContentSet;
+use holons_prelude::prelude::*;
+use std::collections::BTreeSet;
+
+/// Captures descriptor identities from the input, independently of runtime
+/// descriptor resolution, so deferred completion cannot make the assertion vacuous.
+pub fn expected_descriptor_keys(content_set: &ContentSet) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    for file in &content_set.files_to_load {
+        let document: serde_json::Value = serde_json::from_str(&file.raw_contents)
+            .unwrap_or_else(|error| panic!("invalid schema JSON in {}: {error}", file.filename));
+        let holons = document["holons"].as_array().expect("schema must contain holons");
+        for holon in holons {
+            // In the canonical corpus, descriptor declarations name a Meta* type.
+            // TypeName alone also selects ordinary FormatRule instances, which
+            // do not carry the descriptor flags checked below.
+            if holon["type"].as_str().is_some_and(|name| name.starts_with("Meta")) {
+                keys.insert(holon["key"].as_str().expect("descriptor must have a key").to_owned());
+            }
+        }
+    }
+    assert!(!keys.is_empty(), "schema completion check must include descriptors");
+    keys
+}
+
+/// Checks explicit descriptor defaults on the returned staged pool after load.
+/// Input-derived identities also ensure every expected descriptor was inspected.
+pub fn assert_descriptor_completion(
+    context: &TransactionContext,
+    mut expected_keys: BTreeSet<String>,
+) {
+    for staged in context.staged_references().expect("failed to read schema staged pool") {
+        let Some(key) = staged.key().expect("failed to read staged schema key") else {
+            continue;
+        };
+        if !expected_keys.remove(&key.0) {
+            continue;
+        }
+        for property in ["IsAbstractType", "DefinesInstanceTypeKind"] {
+            let value =
+                staged.property_value(property).expect("failed to read descriptor property");
+            assert!(
+                matches!(value, Some(BaseValue::BooleanValue(_))),
+                "descriptor {} must have explicit {:?} after schema completion; got {:?}",
+                key.0,
+                property,
+                value
+            );
+        }
+    }
+    assert!(
+        expected_keys.is_empty(),
+        "schema descriptors missing from staged pool: {expected_keys:?}"
+    );
+}

--- a/tests/sweetests/src/harness/helpers/mod.rs
+++ b/tests/sweetests/src/harness/helpers/mod.rs
@@ -1,6 +1,7 @@
 pub mod book_person_inverse_schema;
 pub mod constants;
 pub mod core_schema;
+pub mod descriptor_completion;
 pub mod expected_test_result;
 pub mod mock_conductor;
 pub mod pvl_validation;
@@ -10,6 +11,7 @@ pub mod tracing_utils;
 pub use book_person_inverse_schema::*;
 pub use constants::*;
 pub use core_schema::*;
+pub use descriptor_completion::*;
 pub use expected_test_result::*;
 pub use mock_conductor::*;
 pub use pvl_validation::*;

--- a/tests/sweetests/src/harness/helpers/test_context.rs
+++ b/tests/sweetests/src/harness/helpers/test_context.rs
@@ -1,4 +1,5 @@
 use super::create_test_dance_initiator;
+use super::descriptor_completion::{assert_descriptor_completion, expected_descriptor_keys};
 use crate::{build_core_schema_bootstrap_content_set, init_tracing, DancesTestCase};
 use holons_client::ClientHolonService;
 use holons_core::core_shared_objects::space_manager::HolonSpaceManager;
@@ -110,17 +111,19 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
         elapsed_ms = bootstrap_content_started.elapsed().as_millis(),
         "sweettest runtime: CoreSchemaSpace bootstrap inputs ready"
     );
+    let descriptor_keys = expected_descriptor_keys(&bootstrap_content_set);
     let bootstrap_load_started = Instant::now();
     runtime
         .execute_command(
             MapCommand::Transaction(TransactionCommand {
-                context: bootstrap_context,
+                context: bootstrap_context.clone(),
                 action: TransactionAction::LoadHolons { content_set: bootstrap_content_set },
             }),
             ExecutionPolicy::default(),
         )
         .await
         .expect("failed to load Core Schema bootstrap bundle");
+    assert_descriptor_completion(&bootstrap_context, descriptor_keys);
     info!(
         elapsed_ms = bootstrap_load_started.elapsed().as_millis(),
         "sweettest runtime: CoreSchemaSpace bootstrap load complete"

--- a/tests/sweetests/tests/execution_steps/load_core_schema_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_core_schema_executor.rs
@@ -1,8 +1,9 @@
 use holons_test::harness::helpers::{
-    build_core_schema_content_set, build_generated_commands_schema_content_set,
-    build_generated_core_schema_content_set, build_generated_dance_schema_content_set,
-    build_generated_query_dance_schema_content_set, build_generated_query_schema_content_set,
-    build_generated_validation_schema_content_set,
+    assert_descriptor_completion, build_core_schema_content_set,
+    build_generated_commands_schema_content_set, build_generated_core_schema_content_set,
+    build_generated_dance_schema_content_set, build_generated_query_dance_schema_content_set,
+    build_generated_query_schema_content_set, build_generated_validation_schema_content_set,
+    expected_descriptor_keys,
 };
 use holons_test::TestExecutionState;
 
@@ -12,7 +13,9 @@ pub async fn execute_load_core_schema(test_state: &mut TestExecutionState) {
     let content_set = build_core_schema_content_set()
         .unwrap_or_else(|error| panic!("failed to build MAP core schema ContentSet: {error:?}"));
 
+    let descriptor_keys = expected_descriptor_keys(&content_set);
     execute_load_holons_client_expect_success(test_state, content_set).await;
+    assert_descriptor_completion(&test_state.context(), descriptor_keys);
 }
 
 /// Loads the validation-owned generated package after Core has committed.
@@ -21,7 +24,9 @@ pub async fn execute_load_generated_validation_schema(test_state: &mut TestExecu
         panic!("failed to build generated validation schema ContentSet: {error:?}")
     });
 
+    let descriptor_keys = expected_descriptor_keys(&content_set);
     execute_load_holons_client_expect_success(test_state, content_set).await;
+    assert_descriptor_completion(&test_state.context(), descriptor_keys);
 }
 
 /// Loads the Dance package after Core has committed.
@@ -62,5 +67,7 @@ pub async fn execute_load_generated_core_schema(test_state: &mut TestExecutionSt
         panic!("failed to build generated Schema 2.0 core ContentSet: {error:?}")
     });
 
+    let descriptor_keys = expected_descriptor_keys(&content_set);
     execute_load_holons_client_expect_success(test_state, content_set).await;
+    assert_descriptor_completion(&test_state.context(), descriptor_keys);
 }

--- a/tests/sweetests/tests/execution_steps/load_holons_internal_executor.rs
+++ b/tests/sweetests/tests/execution_steps/load_holons_internal_executor.rs
@@ -238,9 +238,16 @@ pub async fn execute_load_holons_internal(
         expect_links_created.0, actual_links_created
     );
     assert_eq!(
-        actual_error_count, expect_errors.0,
-        "Expected ErrorCount={}, got {}",
-        expect_errors.0, actual_error_count
+        actual_error_count,
+        expect_errors.0,
+        "Expected ErrorCount={}, got {} (staged={}, committed={}, links={}, status={})\n{}",
+        expect_errors.0,
+        actual_error_count,
+        actual_staged,
+        actual_committed,
+        actual_links_created,
+        actual_status,
+        dump_error_holons_from_response(test_state, &response_reference)
     );
     assert_eq!(
         actual_total_bundles, expect_total_bundles.0,

--- a/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_holons_internal_fixture.rs
@@ -6,14 +6,14 @@
 //!
 //! Scope: loader-controller behavior only — empty bundles, undescribed loader holons,
 //! duplicate-key failure, response metrics, error holons, and `LoadCommitStatus`.
-//! Loader holons must be described before the loader can complete descriptor-aware
-//! default population or relationship resolution.
+//! Missing descriptors defer default population without blocking commit. Named
+//! relationship endpoints resolve independently of descriptor-aware validation.
 //!
 //! ## Fixture Progression (combined)
 //!
 //! 1. **Empty bundle** → `UnprocessableEntity`; no loader holons commit
-//! 2. **Nodes-only undescribed bundle** → staged, then skipped during default population
-//! 3. **Undescribed relationship bundle** → relationship staged, then skipped during default population
+//! 2. **Nodes-only undescribed bundle** → default population deferred; all nodes commit
+//! 3. **Undescribed relationship bundle** → nodes commit; inverse resolution fails; `Incomplete`
 //! 4. **Multi-bundle duplicate-key set** (same LoaderHolon key in two files) → `UnprocessableEntity`; no loader holons commit
 //!
 //! ### Why a single fixture?
@@ -73,7 +73,7 @@ fn build_empty_bundle(
 
 /// Build a HolonLoaderBundle with **N minimal undescribed LoaderHolons (nodes only)**.
 /// Each member is created with its **instance key string**; no relationship references.
-/// This exercises Pass-1 staging followed by default-population failure.
+/// This exercises Pass-1 staging followed by deferred completion and successful node commit.
 fn build_nodes_only_bundle(
     context: &Arc<TransactionContext>,
     bundle_key: &str,
@@ -197,9 +197,9 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
          2) Load a HolonLoadSet containing a single empty HolonLoaderBundle and assert the\n\
             loader short-circuits cleanly (no holons staged/committed, DB unchanged),\n\
          3) Load a nodes-only HolonLoadSet (Book/Person/Publisher LoaderHolons, no relationships)\n\
-            and assert undescribed holons are staged, rejected during default population, and not committed,\n\
+            and assert undescribed holons commit with default population deferred and no errors,\n\
          4) Load an undescribed relationship HolonLoadSet and assert relationship resolution stages the link\n\
-            before default population skips commit,\n\
+            before node commit succeeds but inverse resolution reports one error and Incomplete,\n\
          5) Load a multi-bundle HolonLoadSet where two different bundles each contain a\n\
             LoaderHolon with the same Key but different filenames and byte offsets, and assert\n\
             the loader reports a duplicate-key error, skips commit (HolonsCommitted = 0),\n\
@@ -223,7 +223,7 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
         MapInteger(0), // total_loader_holons
         ExpectedLoadStatus::Skipped,
     )?;
-    // C) Nodes-only undescribed bundle -> staged, then rejected before commit.
+    // C) Nodes-only undescribed bundle -> completion deferred; all nodes commit.
     let nodes_only_keys = &["Book.NodesOnly.1", "Person.NodesOnly.1", "Publisher.NodesOnly.1"];
     let (nodes_bundle, n_nodes) =
         build_nodes_only_bundle(&fixture_context, "Bundle.NodesOnly.1", nodes_only_keys)?;
@@ -235,20 +235,21 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_load_holons_internal_step(
         nodes_set,
         MapInteger(n_nodes as i64), // holons_staged
-        MapInteger(0),              // holons_committed
+        MapInteger(n_nodes as i64), // holons_committed
         MapInteger(0),              // links_created
-        MapInteger(n_nodes as i64), // errors_encountered (MissingDescribedBy per staged holon)
+        MapInteger(0),              // errors_encountered (completion deferred)
         MapInteger(1),              // total_bundles
         MapInteger(n_nodes as i64), // total_loader_holons
-        ExpectedLoadStatus::Skipped,
+        ExpectedLoadStatus::Complete,
     )?;
     test_case.add_begin_transaction_step(
         None,
         Some("Begin new transaction before declared-link load".to_string()),
     )?;
 
-    // D) Named relationships on undescribed holons can still be resolved and
-    // staged, but default population rejects the staged holons before commit.
+    // D) Named endpoints resolve and nodes commit, but persisting AuthoredBy
+    // requires a source descriptor to resolve its inverse. Commit records one
+    // MissingDescribedBy error for the source and reports Incomplete.
     let (declared_bundle, node_count, _links_created) = build_declared_links_bundle(
         &fixture_context,
         "Bundle.DeclaredLink.1",
@@ -264,12 +265,12 @@ pub fn loader_incremental_fixture() -> Result<DancesTestCase, HolonError> {
     test_case.add_load_holons_internal_step(
         declared_set,
         MapInteger(node_count as i64), // holons_staged
-        MapInteger(0),                 // holons_committed
+        MapInteger(node_count as i64), // holons_committed
         MapInteger(1),                 // relationship resolved and staged
-        MapInteger(node_count as i64), // MissingDescribedBy per staged holon
+        MapInteger(1),                 // source inverse resolution: MissingDescribedBy
         MapInteger(1),                 // total_bundles
         MapInteger(node_count as i64), // total_loader_holons
-        ExpectedLoadStatus::Skipped,
+        ExpectedLoadStatus::Incomplete,
     )?;
     test_case.add_begin_transaction_step(
         None,


### PR DESCRIPTION
Closes #678.

Adds the foundations for descriptor-aware Commit Validation: identity-only validation findings and default completion across shared-object construction and clone paths. No validator or new Commit acceptance gate is introduced.

- Defines serializable finding types in `core_types`, leaving `integrity_core_types` unchanged.
- Adds staged findings distinct from operational errors, with controlled replacement of validation state and findings together. Carries findings through wire binding, serialization, and the SDK contract.
- Makes missing descriptors a non-fatal completion deferral, preserves partial progress and authored values, and keeps multiple descriptors fatal.
- Uses the loader’s single post-resolution completion pass as the bootstrap retry. Undescribed nodes can now commit; relationship persistence still reports errors when required descriptor metadata is unavailable.

Corrects the issue’s assumption about saved clones: their clone models contain no relationships. `SmartReference` therefore completes defaults after attaching the relationship map, including `DescribedBy`. Version staging classifies any materialized defaults as content changes so a graph-only commit cannot discard them. Persisted historical state remains unchanged.

Coverage includes deferred retries, idempotency, clone isolation, lifecycle classification, findings round-trips, and explicit descriptor flags across the canonical Core and Validation bootstrap corpus.

Validation: `npm run check`, `npm run fmt:check`, 300 `holons_core` unit tests, and `npm run test` passed.