### PR TITLE
test: consolidate Dance Sweettests and stabilize bootstrap fixtures

### DIFF
--- a/host/conductora/src/setup/core_schema_bootstrap.rs
+++ b/host/conductora/src/setup/core_schema_bootstrap.rs
@@ -238,7 +238,23 @@ fn sha256_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEMP_DIRECTORY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temporary_bundle_directory() -> anyhow::Result<std::path::PathBuf> {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let sequence = TEMP_DIRECTORY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "conductora-bootstrap-{}-{}-{}",
+            std::process::id(),
+            timestamp,
+            sequence
+        ));
+        fs::create_dir_all(&directory)?;
+        Ok(directory)
+    }
 
     #[test]
     fn gate_rejects_ingress_until_marked_ready() {
@@ -260,8 +276,7 @@ mod tests {
 
     #[test]
     fn bundle_reader_accepts_manifest_selected_imports() -> anyhow::Result<()> {
-        let suffix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-        let directory = std::env::temp_dir().join(format!("conductora-bootstrap-{suffix}"));
+        let directory = temporary_bundle_directory()?;
         let imports = directory.join("imports");
         fs::create_dir_all(&imports)?;
         let contents = "{\"holons\":[]}";
@@ -284,8 +299,7 @@ mod tests {
 
     #[test]
     fn bundle_reader_rejects_digest_mismatch() -> anyhow::Result<()> {
-        let suffix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-        let directory = std::env::temp_dir().join(format!("conductora-bootstrap-{suffix}"));
+        let directory = temporary_bundle_directory()?;
         let imports = directory.join("imports");
         fs::create_dir_all(&imports)?;
         fs::write(imports.join("core.json"), "{\"holons\":[]}")?;
@@ -296,6 +310,18 @@ mod tests {
 
         assert!(bootstrap_content_set_from_directory(&directory).is_err());
         fs::remove_dir_all(directory)?;
+        Ok(())
+    }
+
+    #[test]
+    fn bundle_reader_test_directories_are_unique() -> anyhow::Result<()> {
+        let first = temporary_bundle_directory()?;
+        let second = temporary_bundle_directory()?;
+
+        assert_ne!(first, second);
+
+        fs::remove_dir_all(first)?;
+        fs::remove_dir_all(second)?;
         Ok(())
     }
 

--- a/tests/sweetests/src/harness/helpers/constants.rs
+++ b/tests/sweetests/src/harness/helpers/constants.rs
@@ -12,6 +12,10 @@ pub const BOOK_KEY: &str =
 pub const PERSON_1_KEY: &str = "Roger Briggs";
 pub const PERSON_2_KEY: &str = "George Smith";
 pub const PUBLISHER_KEY: &str = "Publishing Company";
+/// Instance keys reserved for the inverse-schema loader scenario. They must not
+/// collide with legacy fixtures that intentionally use the generic Book/Person keys.
+pub const BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY: &str = "Book.InverseSchema.Instance";
+pub const BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY: &str = "Person.InverseSchema.Instance";
 pub const BOOK_TO_PERSON_RELATIONSHIP: &str = "AuthoredBy";
 pub const PUBLISHED_BY: &str = "PublishedBy";
 pub const EDITOR_FOR: &str = "EditorFor";

--- a/tests/sweetests/src/harness/helpers/constants.rs
+++ b/tests/sweetests/src/harness/helpers/constants.rs
@@ -16,6 +16,8 @@ pub const PUBLISHER_KEY: &str = "Publishing Company";
 /// collide with legacy fixtures that intentionally use the generic Book/Person keys.
 pub const BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY: &str = "Book.InverseSchema.Instance";
 pub const BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY: &str = "Person.InverseSchema.Instance";
+pub const STAGE_NEW_VERSION_BOOK_KEY: &str = "Book.StageNewVersion";
+pub const STAGE_NEW_VERSION_PERSON_1_KEY: &str = "Person.StageNewVersion.1";
 pub const BOOK_TO_PERSON_RELATIONSHIP: &str = "AuthoredBy";
 pub const PUBLISHED_BY: &str = "PublishedBy";
 pub const EDITOR_FOR: &str = "EditorFor";

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -123,8 +123,8 @@ fn runtime_behavior_matrix_suite() -> DanceTestSuite {
     DanceTestSuite {
         name: "runtime_behavior_matrix",
         test_cases: vec![
-            stage_new_version_fixture().unwrap(),
             load_book_person_inverse_schema_fixture().unwrap(),
+            stage_new_version_fixture().unwrap(),
             simple_create_holon_fixture().unwrap(),
             simple_abandon_staged_changes_fixture().unwrap(),
             simple_add_remove_properties_fixture().unwrap(),

--- a/tests/sweetests/tests/dance_tests.rs
+++ b/tests/sweetests/tests/dance_tests.rs
@@ -21,7 +21,6 @@ mod execution_steps;
 mod fixture_cases;
 
 use rstest::*;
-
 use tracing::{
     // error,
     info,
@@ -86,23 +85,11 @@ use holons_test::harness::prelude::{DanceTestStep, DancesTestCase};
 
 use holons_test::harness::helpers::init_test_runtime;
 
-use holons_prelude::prelude::*;
+use map_commands_contract::{MapCommand, MapResult, SpaceCommand};
+use map_commands_runtime::ExecutionPolicy;
 
-/// This function accepts a DanceTestCase created by the test fixture for that case.
-/// It iterates through the vector of DanceTestSteps defined within that DanceTestCase.
-/// For each step, this function invokes the test execution functions created for that kind of
-/// DanceTestStep.
-///
-/// Prior to initiating the test case, the following initialization is performed:
-/// 1. Set up a mock Conductor
-/// 2. Initialize a ClientHolonsContext, injecting the ConductorConfig for the created Conductor
-///
-/// This function maintains the following TestState that allows the test steps to be linked together.
-/// * the Context's Nursery will hold the Holons staged during the course of the test case
-/// * session_state : SessionState
-/// * created_holons -- a BTree of Holons indexed by their key that is incrementally extended as
-/// staged holons are committed.
-/// It can be used to drive update/delete of those holons.
+/// Dance Sweettests share a bootstrapped runtime within each suite. Every
+/// scenario still receives its own transaction and fixture execution registry.
 ///
 /// To selectively run JUST THE TESTS in this file, use:
 ///      cargo test -p dances --test dance_tests
@@ -110,45 +97,107 @@ use holons_prelude::prelude::*;
 ///      set WASM_LOG to enable guest-side (i.e., zome code) tracing
 ///
 #[rstest]
-#[case::simple_undescribed_create_holon_test(simple_create_holon_fixture())]
-#[case::delete_holon(delete_holon_fixture())]
-#[case::simple_abandon_staged_changes_test(simple_abandon_staged_changes_fixture())]
-#[case::simple_add_remove_properties_test(simple_add_remove_properties_fixture())]
-#[case::simple_add_related_holon_test(simple_add_remove_related_holons_fixture())]
-#[case::ergonomic_add_remove_properties_test(ergonomic_add_remove_properties_fixture())]
-#[case::ergonomic_add_remove_related_holons_test(ergonomic_add_remove_related_holons_fixture())]
-#[case::stage_new_from_clone_test(stage_new_from_clone_fixture())]
-#[case::stage_new_version_test(stage_new_version_fixture())]
-#[case::load_holons_internal_test(loader_incremental_fixture())]
-#[case::transaction_lifecycle_test(transaction_lifecycle_fixture())]
-#[case::bootstrap_operational_schema_test(bootstrap_operational_schema_fixture())]
-#[case::load_book_person_inverse_schema_test(load_book_person_inverse_schema_fixture())]
-#[case::smartlink_commit_cache_test(smartlink_commit_cache_fixture())]
-#[case::frozen_member_head_redirect_test(frozen_member_head_redirect_fixture())]
-#[case::frozen_member_head_redirect_cross_tx_test(frozen_member_head_redirect_cross_tx_fixture())]
-#[case::cross_transaction_staged_target_diagnostic_test(
-    cross_transaction_staged_target_diagnostic_fixture()
-)]
+#[case::pristine_bootstrap_and_loader(pristine_bootstrap_and_loader_suite())]
+#[case::runtime_behavior_matrix(runtime_behavior_matrix_suite())]
 #[tokio::test(flavor = "multi_thread")]
-async fn rstest_dance_tests(#[case] input: Result<DancesTestCase, HolonError>) {
-    run_dance_test_case(input.unwrap()).await;
+async fn rstest_dance_test_suites(#[case] suite: DanceTestSuite) {
+    run_dance_test_suite(suite).await;
 }
 
-/// Drives a finalized `DancesTestCase` through runtime setup and step execution.
-async fn run_dance_test_case(mut test_case: DancesTestCase) {
+struct DanceTestSuite {
+    name: &'static str,
+    test_cases: Vec<DancesTestCase>,
+}
+
+fn pristine_bootstrap_and_loader_suite() -> DanceTestSuite {
+    DanceTestSuite {
+        name: "pristine_bootstrap_and_loader",
+        test_cases: vec![
+            bootstrap_operational_schema_fixture().unwrap(),
+            loader_incremental_fixture().unwrap(),
+        ],
+    }
+}
+
+fn runtime_behavior_matrix_suite() -> DanceTestSuite {
+    DanceTestSuite {
+        name: "runtime_behavior_matrix",
+        test_cases: vec![
+            stage_new_version_fixture().unwrap(),
+            load_book_person_inverse_schema_fixture().unwrap(),
+            simple_create_holon_fixture().unwrap(),
+            simple_abandon_staged_changes_fixture().unwrap(),
+            simple_add_remove_properties_fixture().unwrap(),
+            simple_add_remove_related_holons_fixture().unwrap(),
+            ergonomic_add_remove_properties_fixture().unwrap(),
+            ergonomic_add_remove_related_holons_fixture().unwrap(),
+            stage_new_from_clone_fixture().unwrap(),
+            transaction_lifecycle_fixture().unwrap(),
+            smartlink_commit_cache_fixture().unwrap(),
+            delete_holon_fixture().unwrap(),
+            frozen_member_head_redirect_fixture().unwrap(),
+            frozen_member_head_redirect_cross_tx_fixture().unwrap(),
+            cross_transaction_staged_target_diagnostic_fixture().unwrap(),
+        ],
+    }
+}
+
+/// Boots one fresh runtime, then executes each finalized scenario through its own
+/// transaction and execution registry. Scenario fixtures remain declarative and
+/// self-contained; only the immutable Core Schema bootstrap is amortized.
+async fn run_dance_test_suite(test_suite: DanceTestSuite) {
+    assert!(!test_suite.test_cases.is_empty(), "a Dance test suite needs at least one scenario");
+    info!("Starting Dance test suite: {}", test_suite.name);
+
+    let mut bootstrap_case = DancesTestCase::default();
+    let (runtime, initial_tx_id) = init_test_runtime(&mut bootstrap_case).await;
+    let mut book_person_schema_loaded = false;
+
+    for (scenario_index, test_case) in test_suite.test_cases.into_iter().enumerate() {
+        let tx_id = if scenario_index == 0 {
+            initial_tx_id.clone()
+        } else {
+            let result = runtime
+                .execute_command(
+                    MapCommand::Space(SpaceCommand::BeginTransaction),
+                    ExecutionPolicy::default(),
+                )
+                .await
+                .expect("failed to begin a scenario transaction");
+            match result {
+                MapResult::TransactionCreated { tx_id } => tx_id,
+                other => panic!("expected TransactionCreated, got {other:?}"),
+            }
+        };
+
+        let fixture_transient_holons = test_case.test_session_state.get_transient_holons().clone();
+        let fixture_head_index = test_case.test_session_state.fixture_head_index().clone();
+        let mut test_execution_state = TestExecutionState::new(
+            runtime.clone(),
+            tx_id.clone(),
+            fixture_transient_holons,
+            fixture_head_index,
+        );
+        test_execution_state
+            .activate_transaction(tx_id)
+            .expect("failed to import scenario fixture holons");
+        run_dance_test_case(test_case, &mut test_execution_state, &mut book_person_schema_loaded)
+            .await;
+    }
+}
+
+/// Drives a finalized `DancesTestCase` through step execution in an initialized runtime.
+async fn run_dance_test_case(
+    test_case: DancesTestCase,
+    mut test_execution_state: &mut TestExecutionState,
+    book_person_schema_loaded: &mut bool,
+) {
     // The heavy lifting for this test is in the test data set creation.
 
     assert!(
         test_case.is_finalized(),
         "DancesTestCase must be finalized before execution. Call test_case.finalize(&fixture_context, &fixture_holons) in the fixture."
     );
-    // Initialize runtime and execution state
-    let fixture_transient_holons = test_case.test_session_state.get_transient_holons().clone();
-    let fixture_head_index = test_case.test_session_state.fixture_head_index().clone();
-    let (runtime, tx_id) = init_test_runtime(&mut test_case).await;
-    let mut test_execution_state =
-        TestExecutionState::new(runtime, tx_id, fixture_transient_holons, fixture_head_index);
-
     info!("\n\n{TEST_CLIENT_PREFIX} ******* STARTING {} TEST CASE WITH {} TEST STEPS ***************************", test_case.name, test_case.steps.len());
     info!("\n   Test Case Description: {}", test_case.description);
 
@@ -257,7 +306,12 @@ async fn run_dance_test_case(mut test_case: DancesTestCase) {
                 execute_load_generated_query_dance_schema(&mut test_execution_state).await
             }
             DanceTestStep::LoadBookPersonInverseTestSchema { .. } => {
-                execute_load_book_person_inverse_test_schema(&mut test_execution_state).await
+                if *book_person_schema_loaded {
+                    info!("Book/Person inverse test schema is already available in this suite");
+                } else {
+                    execute_load_book_person_inverse_test_schema(&mut test_execution_state).await;
+                    *book_person_schema_loaded = true;
+                }
             }
             DanceTestStep::LoadInverseOrientedBookPersonInstancesExpectFailure { .. } => {
                 execute_load_inverse_oriented_book_person_instances_expect_failure(

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -17,7 +17,7 @@ use holons_test::harness::helpers::{
     DELETION_SEMANTIC_KEY, HOLON_TYPE_KEY, OPERATOR_CATEGORY_EQUALITY_KEY, OPERATOR_CATEGORY_KEY,
     OPERATOR_CATEGORY_ORDERING_KEY, PERSON_1_KEY, PERSON_DESCRIPTOR_KEY,
     PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY, PERSON_TO_BOOK_REL_INVERSE, SCHEMA_TYPE_KEY,
-    VARIANTS_RELATIONSHIP,
+    STAGE_NEW_VERSION_BOOK_KEY, STAGE_NEW_VERSION_PERSON_1_KEY, VARIANTS_RELATIONSHIP,
 };
 use holons_test::TestExecutionState;
 use integrity_core_types::LocalId;
@@ -827,7 +827,7 @@ pub async fn execute_verify_validation_bindings_descriptor_contract(
 pub async fn execute_verify_relationship_anchoring(state: &mut TestExecutionState) {
     let holons = loaded_holons(state, "verify_relationship_anchoring").await;
 
-    let books = find_holons_by_key(&holons, BOOK_KEY);
+    let books = find_holons_by_key(&holons, STAGE_NEW_VERSION_BOOK_KEY);
     assert_eq!(
         books.len(),
         1,
@@ -838,7 +838,7 @@ pub async fn execute_verify_relationship_anchoring(state: &mut TestExecutionStat
     let original_book = books[0].clone();
     assert_eq!(
         string_property(&original_book, "Title").as_deref(),
-        Some(BOOK_KEY),
+        Some(STAGE_NEW_VERSION_BOOK_KEY),
         "expected the enumerated Book node to be the lineage root, with its original title"
     );
 
@@ -859,7 +859,7 @@ pub async fn execute_verify_relationship_anchoring(state: &mut TestExecutionStat
     let new_book_id = local_id(&new_book);
     assert_ne!(original_book_id, new_book_id, "new version must have a distinct LocalId");
 
-    let person = find_holon_by_key(&holons, PERSON_1_KEY);
+    let person = find_holon_by_key(&holons, STAGE_NEW_VERSION_PERSON_1_KEY);
     let person_id = local_id(&person);
     let title_property = find_holon_by_key(&holons, "Title.PropertyType");
     let title_property_id = local_id(&title_property);

--- a/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
+++ b/tests/sweetests/tests/execution_steps/descriptor_verification_executor.rs
@@ -8,14 +8,16 @@ use holons_core::descriptors::{
 use holons_core::reference_layer::{HolonReference, TransientReference, WritableHolon};
 use holons_prelude::prelude::*;
 use holons_test::harness::helpers::{
-    BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_TO_PERSON_RELATIONSHIP, BOOK_TO_PERSON_RELATIONSHIP_KEY,
-    CORE_HAS_INVERSE_RELATIONSHIP_KEY, CORE_INSTANCE_PROPERTIES_RELATIONSHIP_KEY,
-    CORE_INSTANCE_PROPERTY_FOR_RELATIONSHIP_KEY, CORE_INVERSE_OF_RELATIONSHIP_KEY,
-    CORE_PREDECESSOR_RELATIONSHIP_KEY, DELETION_SEMANTIC_ALLOW_KEY, DELETION_SEMANTIC_BLOCK_KEY,
-    DELETION_SEMANTIC_CASCADE_KEY, DELETION_SEMANTIC_KEY, HOLON_TYPE_KEY,
-    OPERATOR_CATEGORY_EQUALITY_KEY, OPERATOR_CATEGORY_KEY, OPERATOR_CATEGORY_ORDERING_KEY,
-    PERSON_1_KEY, PERSON_DESCRIPTOR_KEY, PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY,
-    PERSON_TO_BOOK_REL_INVERSE, SCHEMA_TYPE_KEY, VARIANTS_RELATIONSHIP,
+    BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
+    BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY, BOOK_TO_PERSON_RELATIONSHIP,
+    BOOK_TO_PERSON_RELATIONSHIP_KEY, CORE_HAS_INVERSE_RELATIONSHIP_KEY,
+    CORE_INSTANCE_PROPERTIES_RELATIONSHIP_KEY, CORE_INSTANCE_PROPERTY_FOR_RELATIONSHIP_KEY,
+    CORE_INVERSE_OF_RELATIONSHIP_KEY, CORE_PREDECESSOR_RELATIONSHIP_KEY,
+    DELETION_SEMANTIC_ALLOW_KEY, DELETION_SEMANTIC_BLOCK_KEY, DELETION_SEMANTIC_CASCADE_KEY,
+    DELETION_SEMANTIC_KEY, HOLON_TYPE_KEY, OPERATOR_CATEGORY_EQUALITY_KEY, OPERATOR_CATEGORY_KEY,
+    OPERATOR_CATEGORY_ORDERING_KEY, PERSON_1_KEY, PERSON_DESCRIPTOR_KEY,
+    PERSON_TO_BOOK_RELATIONSHIP_INVERSE_KEY, PERSON_TO_BOOK_REL_INVERSE, SCHEMA_TYPE_KEY,
+    VARIANTS_RELATIONSHIP,
 };
 use holons_test::TestExecutionState;
 use integrity_core_types::LocalId;
@@ -702,20 +704,32 @@ pub async fn execute_verify_book_person_descriptors(state: &mut TestExecutionSta
 pub async fn execute_verify_book_person_instance_links(state: &mut TestExecutionState) {
     let holons = loaded_holons(state, "verify_book_person_instance_links").await;
 
-    let book = find_holon_by_key(&holons, BOOK_KEY);
-    let person = find_holon_by_key(&holons, PERSON_1_KEY);
+    let book = find_holon_by_key(&holons, BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY);
+    let person = find_holon_by_key(&holons, BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY);
     let book_type = find_holon_by_key(&holons, BOOK_DESCRIPTOR_KEY);
     let person_type = find_holon_by_key(&holons, PERSON_DESCRIPTOR_KEY);
 
     // Forward declared edges persisted from the staged relationships.
-    assert_contains(&related_holon_keys(&book, BOOK_TO_PERSON_RELATIONSHIP), PERSON_1_KEY);
+    assert_contains(
+        &related_holon_keys(&book, BOOK_TO_PERSON_RELATIONSHIP),
+        BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY,
+    );
     assert_contains(&related_holon_keys(&book, "DescribedBy"), BOOK_DESCRIPTOR_KEY);
     assert_contains(&related_holon_keys(&person, "DescribedBy"), PERSON_DESCRIPTOR_KEY);
 
     // Inverse edges materialized on the targets by commit Pass 2.
-    assert_contains(&related_holon_keys(&person, PERSON_TO_BOOK_REL_INVERSE), BOOK_KEY);
-    assert_contains(&related_holon_keys(&book_type, "Instances"), BOOK_KEY);
-    assert_contains(&related_holon_keys(&person_type, "Instances"), PERSON_1_KEY);
+    assert_contains(
+        &related_holon_keys(&person, PERSON_TO_BOOK_REL_INVERSE),
+        BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
+    );
+    assert_contains(
+        &related_holon_keys(&book_type, "Instances"),
+        BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
+    );
+    assert_contains(
+        &related_holon_keys(&person_type, "Instances"),
+        BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY,
+    );
 
     info!("verified bidirectional Book/Person instance SmartLink traversal");
 }

--- a/tests/sweetests/tests/fixture_cases/abandon_staged_changes_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/abandon_staged_changes_fixture.rs
@@ -25,6 +25,10 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
         &mut test_case,
         &mut fixture_holons,
         &mut fixture_bindings,
+        "Book.AbandonStagedChanges",
+        "Person.AbandonStagedChanges.1",
+        "Person.AbandonStagedChanges.2",
+        "Publisher.AbandonStagedChanges",
     )?;
 
     let person_1_staged_token =
@@ -69,7 +73,7 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     )?;
 
     //  STAGE:  Abandoned Holon1 (H4)  //
-    let abandoned_holon_1_key = MapString("Abandon1".to_string());
+    let abandoned_holon_1_key = MapString("AbandonStagedChanges.Candidate1".to_string());
     let abandoned_holon_1_transient_reference =
         fixture_context.mutation().new_holon(Some(abandoned_holon_1_key.clone()))?;
 
@@ -94,7 +98,7 @@ pub fn simple_abandon_staged_changes_fixture() -> Result<DancesTestCase, HolonEr
     )?;
 
     //  STAGE:  Abandoned Holon2 (H5)  //
-    let abandoned_holon_2_key = MapString("Abandon2".to_string());
+    let abandoned_holon_2_key = MapString("AbandonStagedChanges.Candidate2".to_string());
     let abandoned_holon_2_transient_reference =
         fixture_context.mutation().new_holon(Some(abandoned_holon_2_key.clone()))?;
     // Mint

--- a/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/delete_holon_fixture.rs
@@ -3,7 +3,7 @@ use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 use rstest::*;
 use std::collections::BTreeMap;
 
-use holons_test::harness::helpers::{BOOK_DESCRIPTOR_KEY, BOOK_KEY};
+use holons_test::harness::helpers::BOOK_DESCRIPTOR_KEY;
 
 /// Fixture for creating a DeleteHolon Testcase
 #[fixture]
@@ -38,12 +38,12 @@ pub fn delete_holon_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     //  ADD STEP:  STAGE:  Book Holon  //
-    let book_key = MapString(BOOK_KEY.to_string());
+    let book_key = MapString("Book.DeleteHolon".to_string());
     let book_transient_reference = fixture_context.mutation().new_holon(Some(book_key.clone()))?;
 
     // Mint
     let mut book_properties = BTreeMap::new();
-    book_properties.insert("Title".to_property_name(), BOOK_KEY.to_base_value());
+    book_properties.insert("Title".to_property_name(), book_key.clone().to_base_value());
 
     let book_step_token = test_case.add_new_holon_step(
         &mut fixture_holons,

--- a/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_properties_fixture.rs
@@ -32,7 +32,7 @@ pub fn ergonomic_add_remove_properties_fixture() -> Result<DancesTestCase, Holon
     // === TRANSIENT === //
 
     // -- ADD -- //
-    let book_key = MapString("BOOK_KEY".to_string());
+    let book_key = MapString("Book.ErgonomicProperties".to_string());
     let mut book_transient_reference =
         fixture_context.mutation().new_holon(Some(book_key.clone()))?;
     book_transient_reference.with_property_value("Description", "This is a book description")?;

--- a/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/ergonomic_add_remove_related_holons_fixture.rs
@@ -1,8 +1,7 @@
 use holons_core::{core_shared_objects::holon::EssentialRelationshipMap, CollectionState};
 use holons_prelude::prelude::*;
 use holons_test::{
-    DancesTestCase, TestCaseInit, BOOK_KEY, BOOK_TO_PERSON_RELATIONSHIP, EDITOR_FOR, PERSON_1_KEY,
-    PERSON_2_KEY, PUBLISHED_BY, PUBLISHER_KEY,
+    DancesTestCase, TestCaseInit, BOOK_TO_PERSON_RELATIONSHIP, EDITOR_FOR, PUBLISHED_BY,
 };
 use pretty_assertions::assert_eq;
 use rstest::*;
@@ -25,11 +24,11 @@ pub fn ergonomic_add_remove_related_holons_fixture() -> Result<DancesTestCase, H
 
     // === TRANSIENT === //
     //
-    let book_key = MapString(BOOK_KEY.to_string());
-    let person_1_key = MapString(PERSON_1_KEY.to_string());
-    let person_2_key = MapString(PERSON_2_KEY.to_string());
-    let publisher_key = MapString(PUBLISHER_KEY.to_string());
-    let descriptor_key = MapString("DESCRIPTOR_KEY".to_string());
+    let book_key = MapString("Book.ErgonomicRelationships".to_string());
+    let person_1_key = MapString("Person.ErgonomicRelationships.1".to_string());
+    let person_2_key = MapString("Person.ErgonomicRelationships.2".to_string());
+    let publisher_key = MapString("Publisher.ErgonomicRelationships".to_string());
+    let descriptor_key = MapString("Descriptor.ErgonomicRelationships".to_string());
     let mut book_transient_reference =
         fixture_context.mutation().new_holon(Some(book_key.clone()))?;
     let person_1_transient_reference =

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -1,8 +1,7 @@
 use holons_prelude::prelude::*;
 use holons_test::harness::helpers::{
-    BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
-    BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY, BOOK_TO_PERSON_RELATIONSHIP, PERSON_1_KEY,
-    PERSON_DESCRIPTOR_KEY,
+    BOOK_DESCRIPTOR_KEY, BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
+    BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY, BOOK_TO_PERSON_RELATIONSHIP, PERSON_DESCRIPTOR_KEY,
 };
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 
@@ -181,32 +180,38 @@ pub fn frozen_member_head_redirect_fixture() -> Result<DancesTestCase, HolonErro
     )?;
 
     // Stage Person, then Book, in the same transaction.
-    let person_source =
-        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let person_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Person.FrozenHeadRedirect".to_string())))?;
     let mut person_properties = PropertyMap::new();
-    person_properties
-        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    person_properties.insert(
+        "Name".to_property_name(),
+        MapString("Person.FrozenHeadRedirect".to_string()).to_base_value(),
+    );
     let person_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         person_source,
         person_properties,
-        Some(MapString(PERSON_1_KEY.to_string())),
+        Some(MapString("Person.FrozenHeadRedirect".to_string())),
         None,
         None,
     )?;
     let person_token =
         test_case.add_stage_holon_step(&mut fixture_holons, person_token, None, None)?;
 
-    let book_source =
-        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let book_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Book.FrozenHeadRedirect".to_string())))?;
     let mut book_properties = PropertyMap::new();
-    book_properties
-        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    book_properties.insert(
+        "Title".to_property_name(),
+        MapString("Book.FrozenHeadRedirect".to_string()).to_base_value(),
+    );
     let book_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         book_source,
         book_properties,
-        Some(MapString(BOOK_KEY.to_string())),
+        Some(MapString("Book.FrozenHeadRedirect".to_string())),
         None,
         None,
     )?;
@@ -285,16 +290,19 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
         None,
     )?;
 
-    let person_source =
-        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let person_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Person.FrozenHeadRedirectCrossTx".to_string())))?;
     let mut person_properties = PropertyMap::new();
-    person_properties
-        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    person_properties.insert(
+        "Name".to_property_name(),
+        MapString("Person.FrozenHeadRedirectCrossTx".to_string()).to_base_value(),
+    );
     let person_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         person_source,
         person_properties,
-        Some(MapString(PERSON_1_KEY.to_string())),
+        Some(MapString("Person.FrozenHeadRedirectCrossTx".to_string())),
         None,
         None,
     )?;
@@ -333,16 +341,19 @@ pub fn frozen_member_head_redirect_cross_tx_fixture() -> Result<DancesTestCase, 
         None,
     )?;
 
-    let book_source =
-        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let book_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Book.FrozenHeadRedirectCrossTx".to_string())))?;
     let mut book_properties = PropertyMap::new();
-    book_properties
-        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    book_properties.insert(
+        "Title".to_property_name(),
+        MapString("Book.FrozenHeadRedirectCrossTx".to_string()).to_base_value(),
+    );
     let book_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         book_source,
         book_properties,
-        Some(MapString(BOOK_KEY.to_string())),
+        Some(MapString("Book.FrozenHeadRedirectCrossTx".to_string())),
         None,
         None,
     )?;
@@ -392,16 +403,19 @@ pub fn cross_transaction_staged_target_diagnostic_fixture() -> Result<DancesTest
         "Relating to a never-committed staged holon from an earlier transaction fails fast",
     );
 
-    let person_source =
-        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let person_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Person.CrossTransactionDiagnostic".to_string())))?;
     let mut person_properties = PropertyMap::new();
-    person_properties
-        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    person_properties.insert(
+        "Name".to_property_name(),
+        MapString("Person.CrossTransactionDiagnostic".to_string()).to_base_value(),
+    );
     let person_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         person_source,
         person_properties,
-        Some(MapString(PERSON_1_KEY.to_string())),
+        Some(MapString("Person.CrossTransactionDiagnostic".to_string())),
         None,
         None,
     )?;
@@ -414,16 +428,19 @@ pub fn cross_transaction_staged_target_diagnostic_fixture() -> Result<DancesTest
         Some("Begin transaction while Person remains staged in the previous one".to_string()),
     )?;
 
-    let book_source =
-        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let book_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Book.CrossTransactionDiagnostic".to_string())))?;
     let mut book_properties = PropertyMap::new();
-    book_properties
-        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    book_properties.insert(
+        "Title".to_property_name(),
+        MapString("Book.CrossTransactionDiagnostic".to_string()).to_base_value(),
+    );
     let book_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         book_source,
         book_properties,
-        Some(MapString(BOOK_KEY.to_string())),
+        Some(MapString("Book.CrossTransactionDiagnostic".to_string())),
         None,
         None,
     )?;

--- a/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/load_book_person_inverse_schema_fixture.rs
@@ -1,6 +1,8 @@
 use holons_prelude::prelude::*;
 use holons_test::harness::helpers::{
-    BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_TO_PERSON_RELATIONSHIP, PERSON_1_KEY, PERSON_DESCRIPTOR_KEY,
+    BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY,
+    BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY, BOOK_TO_PERSON_RELATIONSHIP, PERSON_1_KEY,
+    PERSON_DESCRIPTOR_KEY,
 };
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 
@@ -55,32 +57,38 @@ pub fn load_book_person_inverse_schema_fixture() -> Result<DancesTestCase, Holon
     )?;
 
     // Book instance with the schema-declared Title property.
-    let book_source =
-        fixture_context.mutation().new_holon(Some(MapString(BOOK_KEY.to_string())))?;
+    let book_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString(BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY.to_string())))?;
     let mut book_properties = PropertyMap::new();
-    book_properties
-        .insert("Title".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    book_properties.insert(
+        "Title".to_property_name(),
+        MapString(BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY.to_string()).to_base_value(),
+    );
     let book_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         book_source,
         book_properties,
-        Some(MapString(BOOK_KEY.to_string())),
+        Some(MapString(BOOK_PERSON_INVERSE_INSTANCE_BOOK_KEY.to_string())),
         None,
         None,
     )?;
     let book_token = test_case.add_stage_holon_step(&mut fixture_holons, book_token, None, None)?;
 
     // Person instance with the schema-declared Name property.
-    let person_source =
-        fixture_context.mutation().new_holon(Some(MapString(PERSON_1_KEY.to_string())))?;
+    let person_source = fixture_context
+        .mutation()
+        .new_holon(Some(MapString(BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY.to_string())))?;
     let mut person_properties = PropertyMap::new();
-    person_properties
-        .insert("Name".to_property_name(), MapString(PERSON_1_KEY.to_string()).to_base_value());
+    person_properties.insert(
+        "Name".to_property_name(),
+        MapString(BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY.to_string()).to_base_value(),
+    );
     let person_token = test_case.add_new_holon_step(
         &mut fixture_holons,
         person_source,
         person_properties,
-        Some(MapString(PERSON_1_KEY.to_string())),
+        Some(MapString(BOOK_PERSON_INVERSE_INSTANCE_PERSON_KEY.to_string())),
         None,
         None,
     )?;

--- a/tests/sweetests/tests/fixture_cases/setup_book_and_authors_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/setup_book_and_authors_fixture.rs
@@ -3,9 +3,7 @@ use holons_test::{DancesTestCase, FixtureBindings, FixtureHolons};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use holons_test::harness::helpers::{
-    BOOK_KEY, BOOK_TO_PERSON_RELATIONSHIP, PERSON_1_KEY, PERSON_2_KEY, PUBLISHER_KEY,
-};
+use holons_test::harness::helpers::BOOK_TO_PERSON_RELATIONSHIP;
 
 /// Adds undescribed, freeform Book/Person/Publisher holons to `test_case`.
 ///
@@ -15,10 +13,7 @@ use holons_test::harness::helpers::{
 /// exercise property or lifecycle behavior without graph state.
 ///
 /// Specifically, this function adds test steps that will stage:
-/// * Book holon with `BOOK_KEY` Title
-/// * Person holon with `PERSON_1_KEY`
-/// * Person holon with `PERSON_2_KEY`
-/// * Publisher holon with `PUBLISHER_KEY`
+/// * Book, two Person, and Publisher holons with caller-supplied unique keys
 ///
 /// The Nursery within the supplied context is used as the test data setup area.
 ///
@@ -29,17 +24,21 @@ pub fn setup_undescribed_book_people_publisher_steps_with_context<'a>(
     test_case: &mut DancesTestCase,
     fixture_holons: &mut FixtureHolons,
     bindings: &'a mut FixtureBindings,
+    book_key: &str,
+    person_1_key: &str,
+    person_2_key: &str,
+    publisher_key: &str,
 ) -> Result<&'a mut FixtureBindings, HolonError> {
     //  STAGE:  Book Holon  //
     //
     // Create fresh holon
     let book_label = MapString("Book".to_string());
-    let book_key = MapString(BOOK_KEY.to_string());
+    let book_key = MapString(book_key.to_string());
     let book_transient_reference = fixture_context.mutation().new_holon(Some(book_key.clone()))?;
 
     // Mint
     let mut book_properties = BTreeMap::new();
-    book_properties.insert("Title".to_property_name(), BOOK_KEY.to_base_value());
+    book_properties.insert("Title".to_property_name(), book_key.clone().to_base_value());
     book_properties.insert("Description".to_property_name(), "Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_base_value());
 
     let book_transient_token = test_case.add_new_holon_step(
@@ -63,7 +62,7 @@ pub fn setup_undescribed_book_people_publisher_steps_with_context<'a>(
     //
     // Create
     let person_1_label = MapString("Person1".to_string());
-    let person_1_key = MapString(PERSON_1_KEY.to_string());
+    let person_1_key = MapString(person_1_key.to_string());
     let person_1_transient_reference =
         fixture_context.mutation().new_holon(Some(person_1_key.clone()))?;
 
@@ -92,7 +91,7 @@ pub fn setup_undescribed_book_people_publisher_steps_with_context<'a>(
     //
     // Create
     let person_2_label = MapString("Person2".to_string());
-    let person_2_key = MapString(PERSON_2_KEY.to_string());
+    let person_2_key = MapString(person_2_key.to_string());
     let person_2_transient_reference =
         fixture_context.mutation().new_holon(Some(person_2_key.clone()))?;
 
@@ -121,12 +120,12 @@ pub fn setup_undescribed_book_people_publisher_steps_with_context<'a>(
     //
     // Create
     let publisher_label = MapString("Publisher".to_string());
-    let publisher_key = MapString(PUBLISHER_KEY.to_string());
+    let publisher_key = MapString(publisher_key.to_string());
     let publisher_transient_reference =
         fixture_context.mutation().new_holon(Some(publisher_key.clone()))?;
 
     let mut publisher_properties = BTreeMap::new();
-    publisher_properties.insert("name".to_property_name(), PUBLISHER_KEY.to_base_value());
+    publisher_properties.insert("name".to_property_name(), publisher_key.clone().to_base_value());
     publisher_properties.insert(
         "Description".to_property_name(),
         "We publish Holons for testing purposes".to_base_value(),
@@ -166,12 +165,20 @@ pub fn setup_undescribed_book_author_steps_with_context<'a>(
     test_case: &mut DancesTestCase,
     fixture_holons: &mut FixtureHolons,
     bindings: &'a mut FixtureBindings,
+    book_key: &str,
+    person_1_key: &str,
+    person_2_key: &str,
+    publisher_key: &str,
 ) -> Result<&'a mut FixtureBindings, HolonError> {
     setup_undescribed_book_people_publisher_steps_with_context(
         fixture_context,
         test_case,
         fixture_holons,
         bindings,
+        book_key,
+        person_1_key,
+        person_2_key,
+        publisher_key,
     )?;
 
     // Set relationship

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_properties_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_properties_fixture.rs
@@ -4,7 +4,6 @@ use holons_prelude::prelude::*;
 use rstest::*;
 use std::collections::BTreeMap;
 
-use holons_test::harness::helpers::BOOK_KEY;
 use type_names::ToPropertyName;
 
 use super::setup_undescribed_book_people_publisher_steps_with_context;
@@ -31,6 +30,10 @@ pub fn simple_add_remove_properties_fixture() -> Result<DancesTestCase, HolonErr
         &mut test_case,
         &mut fixture_holons,
         &mut fixture_bindings,
+        "Book.SimpleProperties",
+        "Person.SimpleProperties.1",
+        "Person.SimpleProperties.2",
+        "Publisher.SimpleProperties",
     )?;
 
     // == //
@@ -38,7 +41,7 @@ pub fn simple_add_remove_properties_fixture() -> Result<DancesTestCase, HolonErr
     // -- ADD STEP -- //
 
     // EXAMPLE (Transient) //
-    let example_key = MapString("EXAMPLE_KEY".to_string());
+    let example_key = MapString("Example.SimpleProperties".to_string());
     let example_transient_reference =
         fixture_context.mutation().new_holon(Some(example_key.clone()))?;
     // Mint
@@ -68,12 +71,11 @@ pub fn simple_add_remove_properties_fixture() -> Result<DancesTestCase, HolonErr
     )?;
 
     // BOOK (Staged) //
-    let _book_key = MapString(BOOK_KEY.to_string());
     let book_step_token = fixture_bindings.get_token(&MapString("Book".to_string())).expect("Expected setup fixture return_items to contain a staged-intent token associated with 'Book' label").clone();
     // Add
     let mut book_properties = PropertyMap::new();
     book_properties.insert("Description".to_property_name(), "Changed description".to_base_value());
-    book_properties.insert("Title".to_property_name(), BOOK_KEY.to_base_value());
+    book_properties.insert("Title".to_property_name(), "Book.SimpleProperties".to_base_value());
     book_properties
         .insert("NewProperty".to_property_name(), "This is another property".to_base_value());
     book_properties.insert("Int".to_property_name(), 42.to_base_value());

--- a/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_add_remove_related_holons_fixture.rs
@@ -36,6 +36,10 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
         &mut test_case,
         &mut fixture_holons,
         &mut fixture_bindings,
+        "Book.SimpleRelationships",
+        "Person.SimpleRelationships.1",
+        "Person.SimpleRelationships.2",
+        "Publisher.SimpleRelationships",
     )?;
     info!("fixture: book and author setup complete.");
 
@@ -56,8 +60,8 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
     // Company -> HOST -> Website  //
     //
     let host_relationship = "HOST".to_relationship_name();
-    let company_key = MapString("COMPANY_KEY".to_string());
-    let website_key = MapString("WEBSITE_KEY".to_string());
+    let company_key = MapString("Company.SimpleRelationships".to_string());
+    let website_key = MapString("Website.SimpleRelationships".to_string());
     // Create transient references
     let company_transient_reference =
         fixture_context.mutation().new_holon(Some(company_key.clone()))?;
@@ -108,7 +112,7 @@ pub fn simple_add_remove_related_holons_fixture() -> Result<DancesTestCase, Holo
 
     // -- Again ADD STEP -- //
     let again_relationship = "AGAIN".to_relationship_name();
-    let example_key = MapString("EXAMPLE_KEY".to_string());
+    let example_key = MapString("Example.SimpleRelationships".to_string());
     // Create example
     let example_transient_reference =
         fixture_context.mutation().new_holon(Some(example_key.clone()))?;

--- a/tests/sweetests/tests/fixture_cases/simple_create_holon_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/simple_create_holon_fixture.rs
@@ -1,5 +1,4 @@
 use holons_prelude::prelude::*;
-use holons_test::harness::helpers::BOOK_KEY;
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 use rstest::*;
 use std::collections::BTreeMap;
@@ -16,11 +15,11 @@ pub fn simple_create_holon_fixture() -> Result<DancesTestCase, HolonError> {
     );
 
     //  ADD STEP:  STAGE:  Book Holon  //
-    let book_key = MapString(BOOK_KEY.to_string());
+    let book_key = MapString("Book.SimpleCreate".to_string());
     let book_transient_reference = fixture_context.mutation().new_holon(Some(book_key.clone()))?;
 
     let mut properties = BTreeMap::new();
-    properties.insert("title".to_property_name(), BOOK_KEY.to_base_value());
+    properties.insert("title".to_property_name(), book_key.clone().to_base_value());
     properties.insert("description".to_property_name(), "Why is there so much chaos and suffering in the world today? Are we sliding towards dystopia and perhaps extinction, or is there hope for a better future?".to_base_value());
     // Mint
     let book_step_token = test_case.add_new_holon_step(

--- a/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_from_clone_fixture.rs
@@ -1,7 +1,6 @@
 use crate::fixture_cases::setup_book_and_authors_fixture::*;
 use base_types::{MapString, ToBaseValue};
 use core_types::{HolonError, PropertyMap};
-use holons_test::harness::helpers::BOOK_KEY;
 use holons_test::{DancesTestCase, ExpectedCommitStatus, TestCaseInit};
 use integrity_core_types::HolonErrorKind;
 use std::collections::BTreeMap;
@@ -25,7 +24,7 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
         );
 
     // ──  PHASE A — Attempt clone from a Transient -- Expect BadRequest   ────────────────────────────
-    let transient_source_key = MapString("book:transient-source".to_string());
+    let transient_source_key = MapString("Book.StageNewFromClone.TransientSource".to_string());
     let transient_source =
         fixture_context.mutation().new_holon(Some(transient_source_key.clone()))?;
     // Mint transient source token
@@ -53,10 +52,13 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
         &mut test_case,
         &mut fixture_holons,
         &mut fixture_bindings,
+        "Book.StageNewFromClone.Source",
+        "Person.StageNewFromClone.1",
+        "Person.StageNewFromClone.2",
+        "Publisher.StageNewFromClone",
     )?;
 
-    let _book_key = MapString(BOOK_KEY.to_string());
-    let from_staged_key = MapString("book:clone:from-staged".to_string());
+    let from_staged_key = MapString("Book.StageNewFromClone.FromStaged".to_string());
     let book_staged_token = fixture_bindings.get_token(&MapString("Book".to_string())).expect("Expected setup fixture return_items to contain a staged-intent token associated with 'Book' label").clone();
 
     //  Stage New From Clone  //
@@ -96,9 +98,9 @@ pub fn stage_new_from_clone_fixture() -> Result<DancesTestCase, HolonError> {
     )?;
 
     // ── PHASE C — Clone FROM SAVED  ───────────────
-    // At this point, BOOK_KEY’s token (and any staged tokens included in the commit)
+    // At this point, the source Book token (and any staged tokens included in the commit)
     // have state == Saved inside `fixture_holons`.
-    let from_saved_key = MapString("book:clone:from-saved".to_string());
+    let from_saved_key = MapString("Book.StageNewFromClone.FromSaved".to_string());
 
     //  Stage New From Clone  //
     let clone_from_saved_staged = test_case.add_stage_new_from_clone_step(

--- a/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/stage_new_version_fixture.rs
@@ -5,7 +5,10 @@ use rstest::*;
 // use tracing::debug;
 
 use super::setup_undescribed_book_people_publisher_steps_with_context;
-use holons_test::harness::helpers::{BOOK_DESCRIPTOR_KEY, BOOK_KEY, BOOK_TO_PERSON_RELATIONSHIP};
+use holons_test::harness::helpers::{
+    BOOK_DESCRIPTOR_KEY, BOOK_TO_PERSON_RELATIONSHIP, STAGE_NEW_VERSION_BOOK_KEY,
+    STAGE_NEW_VERSION_PERSON_1_KEY,
+};
 
 // TODO: add/remove relationships
 
@@ -42,6 +45,10 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
         &mut test_case,
         &mut fixture_holons,
         &mut fixture_bindings,
+        STAGE_NEW_VERSION_BOOK_KEY,
+        STAGE_NEW_VERSION_PERSON_1_KEY,
+        "Person.StageNewVersion.2",
+        "Publisher.StageNewVersion",
     )?;
 
     let book_staged_token = fixture_bindings.get_token(&MapString("Book".to_string())).expect("Expected setup fixture return_items to contain a staged-intent token associated with 'Book' label").clone();
@@ -193,8 +200,10 @@ pub fn stage_new_version_fixture() -> Result<DancesTestCase, HolonError> {
 
     // Add properties
     let mut expected_clone_properties = PropertyMap::new();
-    expected_clone_properties
-        .insert("Key".to_property_name(), MapString(BOOK_KEY.to_string()).to_base_value());
+    expected_clone_properties.insert(
+        "Key".to_property_name(),
+        MapString(STAGE_NEW_VERSION_BOOK_KEY.to_string()).to_base_value(),
+    );
     expected_clone_properties.insert(
         "Description".to_property_name(),
         "This is a different description".to_base_value(),

--- a/tests/sweetests/tests/fixture_cases/transaction_lifecycle_fixture.rs
+++ b/tests/sweetests/tests/fixture_cases/transaction_lifecycle_fixture.rs
@@ -25,7 +25,7 @@ pub fn transaction_lifecycle_fixture() -> Result<DancesTestCase, HolonError> {
 
     // ── Phase 1: First transaction — create and commit ──
 
-    let book_key = MapString("book-lifecycle-1".to_string());
+    let book_key = MapString("Book.TransactionLifecycle.1".to_string());
     let book_transient = fixture_context.mutation().new_holon(Some(book_key.clone()))?;
 
     let mut book_props = BTreeMap::new();
@@ -64,8 +64,9 @@ pub fn transaction_lifecycle_fixture() -> Result<DancesTestCase, HolonError> {
 
     // Attempt to create a new holon on the committed transaction — should be
     // rejected at the Runtime lifecycle gate with TransactionAlreadyCommitted.
-    let rejected_transient =
-        fixture_context.mutation().new_holon(Some(MapString("rejected".to_string())))?;
+    let rejected_transient = fixture_context
+        .mutation()
+        .new_holon(Some(MapString("Rejected.TransactionLifecycle".to_string())))?;
 
     let mut rejected_props = BTreeMap::new();
     rejected_props.insert("Title".to_property_name(), "Should Not Exist".to_base_value());
@@ -74,7 +75,7 @@ pub fn transaction_lifecycle_fixture() -> Result<DancesTestCase, HolonError> {
         &mut fixture_holons,
         rejected_transient,
         rejected_props,
-        Some(MapString("rejected".to_string())),
+        Some(MapString("Rejected.TransactionLifecycle".to_string())),
         Some(HolonErrorKind::TransactionAlreadyCommitted),
         Some("NewHolon rejected on committed tx".to_string()),
     )?;
@@ -91,7 +92,7 @@ pub fn transaction_lifecycle_fixture() -> Result<DancesTestCase, HolonError> {
 
     test_case.add_begin_transaction_step(None, Some("Begin second transaction".to_string()))?;
 
-    let article_key = MapString("article-lifecycle-1".to_string());
+    let article_key = MapString("Article.TransactionLifecycle.1".to_string());
     let article_transient = fixture_context.mutation().new_holon(Some(article_key.clone()))?;
 
     let mut article_props = BTreeMap::new();


### PR DESCRIPTION
test: consolidate Dance Sweettests and stabilize bootstrap fixtures

Group Dance scenarios into two macro-selectable suites that share one
bootstrapped runtime while preserving a separate transaction and execution
state per scenario. Namespace the inverse-schema fixture instances and load
the shared Book/Person schema once per suite.

Make Conductora bootstrap test directories unique to prevent parallel
unit-test cleanup races.