### PR TITLE
688 instrument and profile core schema bootstrap performance

### DIFF
--- a/.agents/skills/map-issue-grounder/SKILL.md
+++ b/.agents/skills/map-issue-grounder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-issue-grounder
-description: "Use this skill when the user wants a GitHub Enhancement Issue generated for a specific MAP or map-holons workplan task, track item, PR unit, or wave-plan unit. Trigger on requests to ground a workplan task into an issue, turn a roadmap/spec/implementation-plan item into a GitHub enhancement, or generate, refine, or review a repository-grounded enhancement issue for MAP implementation work. This skill performs Phase 4 repository-grounded issue generation: prompt for copied DevDocs roadmap/spec inputs, inspect the map-holons repository, use the repository's .github/ISSUE_TEMPLATE/enhancement.md template, and produce an implementation-ready Enhancement Issue grounded in existing code."
+description: "Use this skill when the user wants a GitHub Enhancement Issue generated for a specific MAP or map-holons workplan task, track item, PR unit, or wave-plan unit. Trigger on requests to ground a workplan task into an issue, turn a roadmap/spec/implementation-plan item into a GitHub enhancement, or generate, refine, or review a repository-grounded enhancement issue for MAP implementation work. This skill performs Phase 4 repository-grounded issue generation: inspect authoritative DevDocs in situ, inspect the map-holons repository, use the repository's .github/ISSUE_TEMPLATE/enhancement.md template, and produce an implementation-ready Enhancement Issue grounded in existing code."
 ---
 
 # MAP Issue Grounder
@@ -22,7 +22,7 @@ Prefer this skill when the user is asking for a GitHub enhancement issue tied to
 
 ## Core posture
 
-Use DevDocs artifacts as architectural intent, but do not treat them as sufficient for implementation. Ground every issue in repository reality:
+Use `map-dev-docs` in situ as the authoritative source for architectural intent. Do not copy DevDocs specs, plans, or roadmaps into `map-holons`, and do not treat any copied local version as authoritative. Ground every issue in repository reality:
 
 - existing modules, types, APIs, tests, naming conventions, and architectural boundaries
 - current transaction, staging, versioning, validation, dance, command, query, and SDK patterns
@@ -33,31 +33,25 @@ Do not invent repository structures. If code context is missing, explicitly mark
 
 ## Required source artifacts
 
-Before generating the issue, ensure the working context includes these artifacts in the `map-holons` repository:
+Before generating the issue, inspect these artifacts in the authoritative `map-dev-docs` checkout and the code repository:
 
-1. The latest overall workplan copied from `map-dev-docs`:
-   - source: `roadmap/desc-driven-impl-plan.md`
-   - destination: `map-holons/docs/roadmap/desc-driven-impl-plan.md`
+1. The latest overall workplan in `map-dev-docs`:
+   - `docs/roadmap/desc-driven-impl-plan.md`
 2. The target PR selection from that workplan:
    - track name or identifier
    - PR/unit identifier or title
-3. The latest track-specific design spec copied from `map-dev-docs` into an appropriate `map-holons/docs/...` location.
-4. The latest track-specific implementation plan copied from `map-dev-docs` into an appropriate `map-holons/docs/...` location.
+3. The latest track-specific design spec in `map-dev-docs`.
+4. The latest track-specific implementation plan in `map-dev-docs`.
 5. The enhancement issue template from the code repository:
    - `.github/ISSUE_TEMPLATE/enhancement.md`
 
-If any required artifact is missing, prompt the user to copy or identify it before continuing. Do not substitute a generic issue format for the enhancement template.
+If the `map-dev-docs` checkout or a required artifact cannot be located, ask the user to identify its path or provide its content before continuing. Do not substitute a generic issue format for the enhancement template.
 
 ## Workflow
 
-### 1. Prompt for the latest overall workplan
+### 1. Inspect the latest overall workplan in situ
 
-Ask the user to copy the latest overall workplan from `map-dev-docs` into `map-holons`:
-
-- Copy `map-dev-docs/roadmap/desc-driven-impl-plan.md`
-- To `map-holons/docs/roadmap/desc-driven-impl-plan.md`
-
-Then inspect `map-holons/docs/roadmap/desc-driven-impl-plan.md`.
+Locate and inspect `map-dev-docs/docs/roadmap/desc-driven-impl-plan.md` in the authoritative DevDocs checkout.
 
 Use this file to understand:
 
@@ -86,22 +80,11 @@ Then extract from the workplan:
 
 Preserve the PR boundary. Do not silently expand scope beyond the selected workplan unit.
 
-### 3. Prompt for latest track-specific spec and implementation plan
+### 3. Inspect the latest track-specific spec and implementation plan in situ
 
-Based on the selected track, ask the user to copy the latest relevant DevDocs files into the `map-holons` repository.
+Based on the selected track, locate and inspect the latest relevant DevDocs design/specification and implementation-plan files in `map-dev-docs`.
 
-Ask for both:
-
-- the latest design/specification file for the selected track
-- the latest implementation-plan file for the selected track
-
-The exact destination may vary by repository convention, but prefer a location under `map-holons/docs/` that preserves enough path context to identify the source and track, such as:
-
-- `docs/specs/<track>/...`
-- `docs/roadmap/<track>/...`
-- `docs/devdocs-imports/<track>/...`
-
-After the user copies the files, inspect them and identify their paths in the issue's source/context sections according to the enhancement template.
+Record their authoritative paths in the issue's source/context sections according to the enhancement template. If either cannot be located, ask the user to identify it; do not request a copy into `map-holons`.
 
 ### 4. Load the enhancement issue template
 
@@ -219,9 +202,9 @@ When recommending a split, provide the smallest coherent sequence of issues and 
 
 The highest-value output is not a generic issue. The highest-value output records the discovered fit between:
 
-- what the copied DevDocs roadmap says this PR should do
-- what the copied track spec says should exist
-- what the copied implementation plan expects
+- what the authoritative DevDocs roadmap says this PR should do
+- what the authoritative track spec says should exist
+- what the authoritative implementation plan expects
 - what the `map-holons` codebase already supports
 - what must be added now
 - what should be deferred

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ name = "holons_loader"
 version = "0.1.0"
 dependencies = [
  "core_types",
+ "hdk",
  "holons_core",
  "holons_prelude",
  "tracing",

--- a/docs/testing/core-schema-bootstrap-performance.md
+++ b/docs/testing/core-schema-bootstrap-performance.md
@@ -1,0 +1,63 @@
+# Core Schema Bootstrap Performance Measurement
+
+Issue #688 measures the generated Core Schema bootstrap graph before selecting any optimization.
+
+Run one real-bundle measurement:
+
+```sh
+npm run sweet:bootstrap-perf
+```
+
+The command builds the normal hApp artifacts, creates one fresh Sweettest runtime, and loads the same generated Core Schema bootstrap bundle that ordinary Sweettests use. Capture the aggregate `[PERF-688]` records only; they avoid per-holon or per-link logging that would distort the result.
+
+Run at least five times for each condition and report median, minimum, and maximum:
+
+- **Warm:** repeat without clearing conductor/DNA caches.
+- **Cold:** use an explicitly fresh conductor/DNA cache according to the local Sweettest procedure.
+
+The logs separately report host parsing and dance round-trip time; loader phases; holon persistence; SmartLink expansion/action creation; semantic forward/inverse actions; keyed `Owns` index checks; lineage target materialization; inverse dedup expansion; and exact historical reads. Preserve the current Core Schema bundle and identical logging configuration across compared runs.
+
+Do not interpret a timing reduction as permission to change ownership, keyed discovery, immutable history, or native Delete semantics. Any optimization must be justified by these counts and timings and reviewed separately.
+
+## Inverse-dedup before baseline
+
+Captured 2026-09-07 from three fresh focused-test processes, with `RUST_LOG=info` and
+`WASM_LOG=info`. This is the comparison baseline for commit-local inverse membership indexing;
+retain the same fixture, binary configuration, and log filter for the after run.
+
+| Metric | Median | Range |
+| --- | ---: | ---: |
+| Focused test | 30.00s | 29.98–30.07s |
+| Loader-client total | 26.57s | 26.51–26.58s |
+| Sweettest conductor call | 26.29s | 26.24–26.30s |
+| Guest commit | 8.62s | 8.57–8.63s |
+| Inverse-dedup expansion and scan | 1.031s | 1.031–1.034s |
+| Inverse-dedup expansions | 495 | 495–495 |
+| Inverse-dedup candidates | 122,265 | 122,265–122,265 |
+| Inverse-dedup skips | 0 | 0–0 |
+
+The inverse-dedup elapsed value is nested within guest commit. It must not be subtracted or
+added to other nested spans when calculating end-to-end savings.
+
+## Inverse-dedup after sample
+
+Captured 2026-09-07 from one fresh focused-test process after the commit-local inverse-membership
+index was introduced. Repeat this measurement to the same five-run standard before treating the
+timing values as a median comparison.
+
+| Metric | Observed value |
+| --- | ---: |
+| Focused test | 28.85s |
+| Loader-client total | 25.46s |
+| Sweettest conductor call | 25.19s |
+| Guest commit | 7.55s |
+| Inverse-dedup bucket-load time | <1ms |
+| Inverse-dedup expansions | 1 |
+| Inverse-dedup candidates | 0 |
+| Inverse-dedup membership checks | 495 |
+| Inverse-dedup skips | 0 |
+
+This confirms the algorithmic result. The Core Schema fixture starts with no existing `Owns`
+memberships in its one inverse bucket, so the one required seed expansion returns no candidates.
+The context still seeds from persisted occurrence-free local links for populated buckets, and adds
+members only after a successful inverse write.

--- a/happ/Cargo.lock
+++ b/happ/Cargo.lock
@@ -782,6 +782,7 @@ name = "holons_loader"
 version = "0.1.0"
 dependencies = [
  "core_types",
+ "hdk",
  "holons_core",
  "holons_prelude",
  "tracing",

--- a/happ/crates/holons_guest/src/dances_guest/dance_adapter.rs
+++ b/happ/crates/holons_guest/src/dances_guest/dance_adapter.rs
@@ -24,6 +24,10 @@ pub fn dance_adapter(envelope: DanceRequestEnvelope) -> ExternResult<DanceRespon
     let is_load_holons = dance_name.0 == "load_holons";
     let total_started_at = performance_timestamp_micros();
 
+    if is_load_holons {
+        info!("[PERF-688] guest_dance_adapter: load_holons_entered");
+    }
+
     info!("\n\n\n***********************  Entered dance_adapter() with {}", request.summarize());
 
     // ---- ingress validation ----
@@ -97,6 +101,10 @@ pub fn dance_adapter(envelope: DanceRequestEnvelope) -> ExternResult<DanceRespon
     }
 
     info!("\n======== RETURNING FROM {:?} Dance with {:?}", dance_name.0, response_wire,);
+
+    if is_load_holons {
+        info!("[PERF-688] guest_dance_adapter: load_holons_returning");
+    }
 
     Ok(DanceResponseEnvelope { response: response_wire, session: response_session })
 }

--- a/happ/crates/holons_guest/src/dances_guest/dance_adapter.rs
+++ b/happ/crates/holons_guest/src/dances_guest/dance_adapter.rs
@@ -21,10 +21,13 @@ use holons_core::{
 pub fn dance_adapter(envelope: DanceRequestEnvelope) -> ExternResult<DanceResponseEnvelope> {
     let DanceRequestEnvelope { request, session } = envelope;
     let dance_name = request.dance_name.clone();
+    let is_load_holons = dance_name.0 == "load_holons";
+    let total_started_at = performance_timestamp_micros();
 
     info!("\n\n\n***********************  Entered dance_adapter() with {}", request.summarize());
 
     // ---- ingress validation ----
+    let validation_started_at = performance_timestamp_micros();
     if let Err(status_code) = validate_request(&request) {
         let response_wire = DanceResponseWire {
             status_code,
@@ -36,6 +39,7 @@ pub fn dance_adapter(envelope: DanceRequestEnvelope) -> ExternResult<DanceRespon
 
         return Ok(DanceResponseEnvelope { response: response_wire, session });
     }
+    let validation_micros = elapsed_micros(validation_started_at);
 
     // ---- context hydration ----
     let session_state = match session.as_ref() {
@@ -49,29 +53,63 @@ pub fn dance_adapter(envelope: DanceRequestEnvelope) -> ExternResult<DanceRespon
         }
     };
 
+    let hydration_started_at = performance_timestamp_micros();
     let context = match initialize_context_from_session_state(session_state) {
         Ok(ctx) => ctx,
         Err(error) => return Ok(create_error_response_envelope(error, session)),
     };
+    let hydration_micros = elapsed_micros(hydration_started_at);
 
     // ---- bind wire -> runtime ----
+    let request_binding_started_at = performance_timestamp_micros();
     let bound_request = match request.bind(&context) {
         Ok(bound) => bound,
         Err(error) => return Ok(create_error_response_envelope(error, session)),
     };
+    let request_binding_micros = elapsed_micros(request_binding_started_at);
 
     // ---- dispatch ----
+    let dispatch_started_at = performance_timestamp_micros();
     let response_runtime = dispatch_dance(&context, bound_request);
+    let dispatch_micros = elapsed_micros(dispatch_started_at);
 
     // ---- project runtime -> wire ----
+    let response_projection_started_at = performance_timestamp_micros();
     let response_wire = DanceResponseWire::from(&response_runtime);
+    let response_projection_micros = elapsed_micros(response_projection_started_at);
 
     // ---- export session state ----
+    let session_export_started_at = performance_timestamp_micros();
     let response_session = restore_session_state_from_context(&context);
+    let session_export_micros = elapsed_micros(session_export_started_at);
+
+    if is_load_holons {
+        info!(
+            "[PERF-688] guest_dance_adapter: validation_ms={} hydration_ms={} request_binding_ms={} dispatch_ms={} response_projection_ms={} session_export_ms={} total_ms={}",
+            validation_micros / 1_000,
+            hydration_micros / 1_000,
+            request_binding_micros / 1_000,
+            dispatch_micros / 1_000,
+            response_projection_micros / 1_000,
+            session_export_micros / 1_000,
+            elapsed_micros(total_started_at) / 1_000,
+        );
+    }
 
     info!("\n======== RETURNING FROM {:?} Dance with {:?}", dance_name.0, response_wire,);
 
     Ok(DanceResponseEnvelope { response: response_wire, session: response_session })
+}
+
+fn performance_timestamp_micros() -> Option<i64> {
+    sys_time().ok().map(|timestamp| timestamp.as_micros())
+}
+
+fn elapsed_micros(started_at: Option<i64>) -> i64 {
+    started_at
+        .zip(performance_timestamp_micros())
+        .map(|(started_at, completed_at)| completed_at.saturating_sub(started_at))
+        .unwrap_or_default()
 }
 
 /// Backward-compatible extern name until host config is fully switched.

--- a/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
+++ b/happ/crates/holons_guest/src/guest_shared_objects/commit_functions.rs
@@ -1,6 +1,6 @@
 use hdk::prelude::*;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
 
@@ -57,10 +57,43 @@ type RelationshipCollectionSnapshot = Vec<(RelationshipName, Arc<RwLock<HolonCol
 /// outlive the Wasm call, and the measurements must not alter commit behavior.
 #[derive(Default)]
 struct CommitPerformanceMetrics {
+    commit_pass_1_micros: i64,
+    commit_pass_2_micros: i64,
+    holon_persist_count: usize,
+    holon_persist_micros: i64,
     inverse_resolution_count: usize,
     inverse_resolution_micros: i64,
     smartlink_persist_count: usize,
     smartlink_persist_micros: i64,
+    smartlink_expansion_count: usize,
+    smartlink_expansion_micros: i64,
+    smartlink_expansion_links: usize,
+    smartlink_action_create_count: usize,
+    smartlink_action_create_micros: i64,
+    semantic_forward_attempt_count: usize,
+    semantic_inverse_attempt_count: usize,
+    keyed_owns_index_attempt_count: usize,
+    smartlink_inserted_count: usize,
+    smartlink_already_present_count: usize,
+    owns_key_lookup_count: usize,
+    owns_key_lookup_micros: i64,
+    owns_key_lookup_links: usize,
+    lineage_target_materialization_count: usize,
+    lineage_target_materialization_micros: i64,
+    exact_historical_read_count: usize,
+    exact_historical_read_micros: i64,
+    inverse_dedup_expansion_count: usize,
+    inverse_dedup_expansion_micros: i64,
+    inverse_dedup_candidate_count: usize,
+    inverse_dedup_membership_check_count: usize,
+    inverse_dedup_skip_count: usize,
+}
+
+#[derive(Clone, Copy)]
+enum SmartLinkWriteCategory {
+    SemanticForward,
+    SemanticInverse,
+    KeyedOwnsIndex,
 }
 
 /// Tracks `(lineage root, key)` entries already observed during this commit.
@@ -71,6 +104,66 @@ struct CommitPerformanceMetrics {
 #[derive(Default)]
 struct KeyIndexMaintenance {
     observed_entries: HashSet<(LocalId, MapString)>,
+}
+
+/// Tracks occurrence-free inverse members observed within one commit invocation.
+///
+/// A lineage-bound inverse can collapse several version-bound forward links into
+/// one membership. Each inverse `(source, relationship)` bucket is loaded once
+/// from storage so pre-existing memberships remain authoritative; successful
+/// writes are then recorded locally to avoid rescanning the growing bucket.
+#[derive(Default)]
+struct InverseDedupContext {
+    members_by_bucket: HashMap<(LocalId, RelationshipName), HashSet<LocalId>>,
+}
+
+impl InverseDedupContext {
+    fn contains_or_load(
+        &mut self,
+        inverse_source_id: &LocalId,
+        inverse_name: &RelationshipName,
+        inverse_target_id: &LocalId,
+        performance_metrics: &mut CommitPerformanceMetrics,
+    ) -> Result<bool, HolonError> {
+        let bucket_key = (inverse_source_id.clone(), inverse_name.clone());
+
+        if !self.members_by_bucket.contains_key(&bucket_key) {
+            let dedup_started_at = performance_timestamp_micros();
+            let existing_inverse_links = expand_from_source(inverse_source_id, inverse_name)?;
+            performance_metrics.inverse_dedup_expansion_count += 1;
+            performance_metrics.inverse_dedup_candidate_count += existing_inverse_links.len();
+            record_elapsed_micros(
+                dedup_started_at,
+                &mut performance_metrics.inverse_dedup_expansion_micros,
+            );
+
+            let members = existing_inverse_links
+                .into_iter()
+                .filter_map(|link| match (link.target_id, link.occurrence_id) {
+                    (HolonId::Local(target_id), None) => Some(target_id),
+                    _ => None,
+                })
+                .collect();
+            self.members_by_bucket.insert(bucket_key.clone(), members);
+        }
+
+        performance_metrics.inverse_dedup_membership_check_count += 1;
+        Ok(self
+            .members_by_bucket
+            .get(&bucket_key)
+            .is_some_and(|members| members.contains(inverse_target_id)))
+    }
+
+    fn record_successful_write(
+        &mut self,
+        inverse_source_id: &LocalId,
+        inverse_name: &RelationshipName,
+        inverse_target_id: LocalId,
+    ) {
+        let bucket_key = (inverse_source_id.clone(), inverse_name.clone());
+        let members = self.members_by_bucket.entry(bucket_key).or_default();
+        members.insert(inverse_target_id);
+    }
 }
 
 fn performance_timestamp_micros() -> Option<i64> {
@@ -221,8 +314,11 @@ pub fn commit(
     let mut abandoned_count = 0_usize;
     let mut failed_count = 0_usize;
 
+    let mut performance_metrics = CommitPerformanceMetrics::default();
+
     // === FIRST PASS: Commit Staged Holons ===
     {
+        let pass_started_at = performance_timestamp_micros();
         info!("\n\nStarting FIRST PASS... commit staged holons...");
 
         let mut saved_holons: Vec<HolonReference> = Vec::new();
@@ -234,7 +330,7 @@ pub fn commit(
 
             trace!("Committing {:?}", staged_reference.temporary_id());
 
-            match commit_holon(staged_reference, context) {
+            match commit_holon(staged_reference, context, &mut performance_metrics) {
                 Ok(CommitOutcome::Saved { establishes_key_index_entry }) => {
                     let holon_id = staged_reference.holon_id()?;
                     let key_string: MapString = staged_reference.key()?.ok_or_else(|| {
@@ -274,6 +370,7 @@ pub fn commit(
         // Attach results to the CommitResponse holon
         response_reference.add_related_holons(SavedHolons, saved_holons)?;
         response_reference.add_related_holons(AbandonedHolons, abandoned_holons)?;
+        record_elapsed_micros(pass_started_at, &mut performance_metrics.commit_pass_1_micros);
     }
 
     // Check if Pass 1 ended with an incomplete status
@@ -300,9 +397,10 @@ pub fn commit(
     // This context is deliberately narrower than TransactionContext: it represents only the
     // bounded relationship write set for this commit invocation.
     let mut smartlink_write_context = SmartLinkWriteContext::default();
-    let mut performance_metrics = CommitPerformanceMetrics::default();
+    let pass_started_at = performance_timestamp_micros();
     let owns_index_space_id = resolve_owns_index_space_id(context, staged_references)?;
     let mut key_index_maintenance = KeyIndexMaintenance::default();
+    let mut inverse_dedup_context = InverseDedupContext::default();
 
     for staged_reference in staged_references {
         let rc_holon = staged_reference.get_holon_to_commit(context)?;
@@ -392,6 +490,7 @@ pub fn commit(
                 inverse_name,
                 &holon_collection,
                 &mut smartlink_write_context,
+                &mut inverse_dedup_context,
                 &mut performance_metrics,
             ) {
                 first_error = Some(err);
@@ -437,6 +536,7 @@ pub fn commit(
     }
 
     // Pass 2 can downgrade the status, so read it back rather than assuming "Complete".
+    record_elapsed_micros(pass_started_at, &mut performance_metrics.commit_pass_2_micros);
     let final_status = match response_reference.property_value(CommitRequestStatus)? {
         Some(status_value) => (&status_value).into(),
         None => "Unknown".to_string(),
@@ -444,11 +544,37 @@ pub fn commit(
 
     info!("Commit completed: all staged holons processed and commit response constructed.");
     info!(
-        "[PERF-674] relationship commit: inverse_resolutions={} inverse_resolution_ms={} smartlink_persists={} smartlink_persist_ms={}",
+        "[PERF-688] guest_commit: pass_1_ms={} pass_2_ms={} holon_persists={} holon_persist_ms={} inverse_resolutions={} inverse_resolution_ms={} smartlink_attempts={} smartlink_total_ms={} smartlink_expansions={} smartlink_expansion_ms={} smartlink_expansion_links={} smartlink_action_creates={} smartlink_action_create_ms={} semantic_forward_attempts={} semantic_inverse_attempts={} keyed_owns_index_attempts={} smartlink_inserted={} smartlink_already_present={} owns_key_lookups={} owns_key_lookup_ms={} owns_key_lookup_links={} lineage_target_materializations={} lineage_target_materialization_ms={} exact_historical_get_details_calls={} exact_historical_batch_requests=0 exact_historical_read_ms={} inverse_dedup_expansions={} inverse_dedup_expansion_ms={} inverse_dedup_candidates={} inverse_dedup_membership_checks={} inverse_dedup_skips={}",
+        performance_metrics.commit_pass_1_micros / 1_000,
+        performance_metrics.commit_pass_2_micros / 1_000,
+        performance_metrics.holon_persist_count,
+        performance_metrics.holon_persist_micros / 1_000,
         performance_metrics.inverse_resolution_count,
         performance_metrics.inverse_resolution_micros / 1_000,
         performance_metrics.smartlink_persist_count,
         performance_metrics.smartlink_persist_micros / 1_000,
+        performance_metrics.smartlink_expansion_count,
+        performance_metrics.smartlink_expansion_micros / 1_000,
+        performance_metrics.smartlink_expansion_links,
+        performance_metrics.smartlink_action_create_count,
+        performance_metrics.smartlink_action_create_micros / 1_000,
+        performance_metrics.semantic_forward_attempt_count,
+        performance_metrics.semantic_inverse_attempt_count,
+        performance_metrics.keyed_owns_index_attempt_count,
+        performance_metrics.smartlink_inserted_count,
+        performance_metrics.smartlink_already_present_count,
+        performance_metrics.owns_key_lookup_count,
+        performance_metrics.owns_key_lookup_micros / 1_000,
+        performance_metrics.owns_key_lookup_links,
+        performance_metrics.lineage_target_materialization_count,
+        performance_metrics.lineage_target_materialization_micros / 1_000,
+        performance_metrics.exact_historical_read_count,
+        performance_metrics.exact_historical_read_micros / 1_000,
+        performance_metrics.inverse_dedup_expansion_count,
+        performance_metrics.inverse_dedup_expansion_micros / 1_000,
+        performance_metrics.inverse_dedup_candidate_count,
+        performance_metrics.inverse_dedup_membership_check_count,
+        performance_metrics.inverse_dedup_skip_count,
     );
     log_commit_response(&final_status, stage_count, &saved_ids, abandoned_count, failed_count);
 
@@ -500,6 +626,7 @@ fn log_commit_response(
 fn commit_holon(
     staged_reference: &StagedReference,
     context: &Arc<TransactionContext>,
+    performance_metrics: &mut CommitPerformanceMetrics,
 ) -> Result<CommitOutcome, HolonError> {
     // Resolve the staged holon from the pool
     let rc_holon = staged_reference.get_holon_to_commit(context)?;
@@ -518,9 +645,15 @@ fn commit_holon(
             StagedState::ForCreate => {
                 trace!("StagedState::ForCreate — publishing a new HolonNode lineage");
                 staged_holon.prepare_full_relationship_commit_scope()?;
+                let persist_started_at = performance_timestamp_micros();
                 let stored = persist_holon(HolonWriteRequest::PublishRoot {
                     holon_node: staged_holon.into_node_model(),
                 })?;
+                performance_metrics.holon_persist_count += 1;
+                record_elapsed_micros(
+                    persist_started_at,
+                    &mut performance_metrics.holon_persist_micros,
+                );
 
                 info!(
                     "Committed root (Create): version_id={} lineage=self",
@@ -553,10 +686,16 @@ fn commit_holon(
                 // Storage decides how a version is written: it resolves the lineage this
                 // predecessor belongs to and roots the new version there. Immediate-predecessor
                 // ordering is not carried by the node — it is staged below as a SmartLink.
+                let persist_started_at = performance_timestamp_micros();
                 let stored = persist_holon(HolonWriteRequest::PublishVersion {
                     holon_node: staged_holon.into_node_model(),
                     predecessor_ids: vec![predecessor_id.clone()],
                 })?;
+                performance_metrics.holon_persist_count += 1;
+                record_elapsed_micros(
+                    persist_started_at,
+                    &mut performance_metrics.holon_persist_micros,
+                );
 
                 // The lineage is logged alongside the predecessor precisely because they differ
                 // once a lineage is more than one version deep: the new version is rooted at the
@@ -629,6 +768,7 @@ fn commit_relationship(
     inverse_name: RelationshipName,
     collection: &HolonCollection,
     smartlink_write_context: &mut SmartLinkWriteContext,
+    inverse_dedup_context: &mut InverseDedupContext,
     performance_metrics: &mut CommitPerformanceMetrics,
 ) -> Result<(), HolonError> {
     collection.is_accessible(AccessType::Commit)?;
@@ -639,6 +779,7 @@ fn commit_relationship(
         inverse_name,
         collection,
         smartlink_write_context,
+        inverse_dedup_context,
         performance_metrics,
     )?;
 
@@ -736,16 +877,23 @@ fn maintain_owns_key_index(
         return Ok(());
     };
 
-    let lineage_root =
-        materialize_target_binding(source.source_local_id(), TargetBinding::Lineage)?;
+    let lineage_root = materialize_target_binding(
+        source.source_local_id(),
+        TargetBinding::Lineage,
+        performance_metrics,
+    )?;
     if !maintenance.observed_entries.insert((lineage_root.clone(), key.clone())) {
         return Ok(());
     }
 
     let canonical_key = CanonicalKey::new(key.0.clone())?;
     let owns = CoreRelationshipTypeName::Owns.as_relationship_name();
+    let lookup_started_at = performance_timestamp_micros();
     let existing =
         expand_from_source_by_key(space_id, &owns, KeyMatch::Exact(canonical_key.clone()))?;
+    performance_metrics.owns_key_lookup_count += 1;
+    performance_metrics.owns_key_lookup_links += existing.len();
+    record_elapsed_micros(lookup_started_at, &mut performance_metrics.owns_key_lookup_micros);
     if existing.into_iter().any(|link| link.target_id == HolonId::Local(lineage_root.clone())) {
         return Ok(());
     }
@@ -759,7 +907,12 @@ fn maintain_owns_key_index(
         relationship_property_values: PropertyMap::new(),
         target_property_cache_candidates: Vec::new(),
     };
-    persist_smartlink(smartlink_write_context, keyed_owns, performance_metrics)
+    persist_smartlink(
+        smartlink_write_context,
+        keyed_owns,
+        SmartLinkWriteCategory::KeyedOwnsIndex,
+        performance_metrics,
+    )
 }
 
 /// Resolves the physical SmartLink target selected by a completed descriptor binding.
@@ -770,12 +923,27 @@ fn maintain_owns_key_index(
 fn materialize_target_binding(
     target_id: &LocalId,
     binding: TargetBinding,
+    performance_metrics: &mut CommitPerformanceMetrics,
 ) -> Result<LocalId, HolonError> {
     match binding {
         TargetBinding::Version => Ok(target_id.clone()),
-        TargetBinding::Lineage => get_holon(target_id)?
-            .ok_or_else(|| HolonError::HolonNotFound(target_id.to_string()))
-            .map(|stored| stored.version_metadata.lineage_root().as_local_id().clone()),
+        TargetBinding::Lineage => {
+            let started_at = performance_timestamp_micros();
+            let stored = get_holon(target_id)?;
+            performance_metrics.lineage_target_materialization_count += 1;
+            performance_metrics.exact_historical_read_count += 1;
+            record_elapsed_micros(
+                started_at,
+                &mut performance_metrics.lineage_target_materialization_micros,
+            );
+            record_elapsed_micros(
+                started_at,
+                &mut performance_metrics.exact_historical_read_micros,
+            );
+            stored
+                .ok_or_else(|| HolonError::HolonNotFound(target_id.to_string()))
+                .map(|stored| stored.version_metadata.lineage_root().as_local_id().clone())
+        }
     }
 }
 
@@ -797,6 +965,7 @@ fn save_smartlinks_for_collection(
     inverse_name: RelationshipName,
     collection: &HolonCollection,
     smartlink_write_context: &mut SmartLinkWriteContext,
+    inverse_dedup_context: &mut InverseDedupContext,
     performance_metrics: &mut CommitPerformanceMetrics,
 ) -> Result<(), HolonError> {
     let relationship_descriptor = source
@@ -877,8 +1046,11 @@ fn save_smartlinks_for_collection(
         // emits set-style links today. That is a coordinator choice, not a storage
         // limitation: storage persists supplied occurrences as distinct identities
         // (Storage SL3). Assigning and pairing them is deferred coordinator work.
-        let forward_target_id =
-            materialize_target_binding(&resolved_target.target_local_id, forward_binding)?;
+        let forward_target_id = materialize_target_binding(
+            &resolved_target.target_local_id,
+            forward_binding,
+            performance_metrics,
+        )?;
         let forward_smartlink = PreparedSmartLink {
             source_id: source_id.clone(),
             target_id: HolonId::Local(forward_target_id),
@@ -893,26 +1065,33 @@ fn save_smartlinks_for_collection(
             "saving smartlink (idx={}): relationship={:?}, source={:?}, target={:?}",
             target_index, name.0 .0, source_id, forward_smartlink.target_id
         );
-        persist_smartlink(smartlink_write_context, forward_smartlink, performance_metrics)?;
+        persist_smartlink(
+            smartlink_write_context,
+            forward_smartlink,
+            SmartLinkWriteCategory::SemanticForward,
+            performance_metrics,
+        )?;
 
-        let inverse_target_id = materialize_target_binding(source_id, inverse_binding)?;
+        let inverse_target_id =
+            materialize_target_binding(source_id, inverse_binding, performance_metrics)?;
         // A version-bound forward relationship can map to one lineage-bound inverse
         // membership. The physical inverse must therefore be deduplicated by its normalized
-        // `(source, relationship, lineage-root)` identity, before a canonical key from a later
-        // version can collide with the already-established occurrence-free membership.
-        if inverse_binding == TargetBinding::Lineage
-            && expand_from_source(&resolved_target.target_local_id, &inverse_name)?.into_iter().any(
-                |link| {
-                    link.target_id == HolonId::Local(inverse_target_id.clone())
-                        && link.occurrence_id.is_none()
-                },
-            )
-        {
-            continue;
+        // `(source, relationship, lineage-root)` identity. Load each storage bucket once, then
+        // retain successful writes locally so later members do not rescan the growing bucket.
+        if inverse_binding == TargetBinding::Lineage {
+            if inverse_dedup_context.contains_or_load(
+                &resolved_target.target_local_id,
+                &inverse_name,
+                &inverse_target_id,
+                performance_metrics,
+            )? {
+                performance_metrics.inverse_dedup_skip_count += 1;
+                continue;
+            }
         }
         let inverse_smartlink = PreparedSmartLink {
             source_id: resolved_target.target_local_id.clone(),
-            target_id: HolonId::Local(inverse_target_id),
+            target_id: HolonId::Local(inverse_target_id.clone()),
             relationship_name: inverse_name.clone(),
             canonical_key: inverse_canonical_key.clone(),
             occurrence_id: None,
@@ -924,7 +1103,19 @@ fn save_smartlinks_for_collection(
             "saving inverse smartlink (idx={}): relationship={:?}, source={:?}, target={:?}",
             target_index, inverse_name.0 .0, resolved_target.target_local_id, source_id
         );
-        persist_smartlink(smartlink_write_context, inverse_smartlink, performance_metrics)?;
+        persist_smartlink(
+            smartlink_write_context,
+            inverse_smartlink,
+            SmartLinkWriteCategory::SemanticInverse,
+            performance_metrics,
+        )?;
+        if inverse_binding == TargetBinding::Lineage {
+            inverse_dedup_context.record_successful_write(
+                &resolved_target.target_local_id,
+                &inverse_name,
+                inverse_target_id,
+            );
+        }
     }
 
     Ok(())
@@ -953,6 +1144,7 @@ fn save_smartlinks_for_collection(
 fn persist_smartlink(
     smartlink_write_context: &mut SmartLinkWriteContext,
     prepared: PreparedSmartLink,
+    category: SmartLinkWriteCategory,
     performance_metrics: &mut CommitPerformanceMetrics,
 ) -> Result<(), HolonError> {
     let source_id = prepared.source_id.clone();
@@ -960,12 +1152,42 @@ fn persist_smartlink(
     let relationship_name = prepared.relationship_name.clone();
 
     let started_at = performance_timestamp_micros();
-    let outcome = put_smartlink_cached(smartlink_write_context, prepared);
+    let result = put_smartlink_cached(smartlink_write_context, prepared);
     performance_metrics.smartlink_persist_count += 1;
     record_elapsed_micros(started_at, &mut performance_metrics.smartlink_persist_micros);
+    match category {
+        SmartLinkWriteCategory::SemanticForward => {
+            performance_metrics.semantic_forward_attempt_count += 1
+        }
+        SmartLinkWriteCategory::SemanticInverse => {
+            performance_metrics.semantic_inverse_attempt_count += 1
+        }
+        SmartLinkWriteCategory::KeyedOwnsIndex => {
+            performance_metrics.keyed_owns_index_attempt_count += 1
+        }
+    }
 
-    match outcome? {
-        PutSmartLinkOutcome::Inserted(_) | PutSmartLinkOutcome::AlreadyPresent(_) => Ok(()),
+    let result = result?;
+    if let Some(expansion_micros) = result.expansion_micros {
+        performance_metrics.smartlink_expansion_count += 1;
+        performance_metrics.smartlink_expansion_micros += expansion_micros;
+        performance_metrics.smartlink_expansion_links +=
+            result.expanded_link_count.unwrap_or_default();
+    }
+    if let Some(action_create_micros) = result.action_create_micros {
+        performance_metrics.smartlink_action_create_count += 1;
+        performance_metrics.smartlink_action_create_micros += action_create_micros;
+    }
+
+    match result.outcome {
+        PutSmartLinkOutcome::Inserted(_) => {
+            performance_metrics.smartlink_inserted_count += 1;
+            Ok(())
+        }
+        PutSmartLinkOutcome::AlreadyPresent(_) => {
+            performance_metrics.smartlink_already_present_count += 1;
+            Ok(())
+        }
         PutSmartLinkOutcome::Conflict(existing) => Err(HolonError::CommitFailure(format!(
             "SmartLink conflict: a live link {existing:?} already shares the insertion identity \
              (source={source_id:?}, target={target_id:?}, relationship={relationship_name:?}) \

--- a/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
+++ b/happ/crates/holons_guest/src/persistence_layer/smartlink.rs
@@ -267,22 +267,62 @@ pub fn put_smartlink(prepared: PreparedSmartLink) -> Result<PutSmartLinkOutcome,
 pub(crate) fn put_smartlink_cached(
     context: &mut SmartLinkWriteContext,
     prepared: PreparedSmartLink,
-) -> Result<PutSmartLinkOutcome, HolonError> {
+) -> Result<CachedPutSmartLinkOutcome, HolonError> {
     // Preserve standalone preflight precedence even when a matching identity is already cached.
     let validated_tag = prepare_validated_smartlink_tag(&prepared)?;
     let bucket_key = SmartLinkBucketKey::from_prepared(&prepared);
     let identity = SmartLinkIdentity::from_prepared(&prepared);
+    let cache_miss = !context.buckets.contains_key(&bucket_key);
+    let expansion_started_at = sys_time().ok().map(|timestamp| timestamp.as_micros());
     let bucket = context.bucket_for(bucket_key, || {
         expand_from_source(&prepared.source_id, &prepared.relationship_name)
     })?;
+    let expansion_micros = cache_miss.then(|| {
+        sys_time()
+            .ok()
+            .map(|completed_at| {
+                completed_at
+                    .as_micros()
+                    .saturating_sub(expansion_started_at.unwrap_or(completed_at.as_micros()))
+            })
+            .unwrap_or_default()
+    });
+    let expanded_link_count = cache_miss.then_some(bucket.identities.len());
 
     if let Some(existing) = bucket.identities.get(&identity) {
-        return Ok(existing.outcome_for(&prepared));
+        return Ok(CachedPutSmartLinkOutcome {
+            outcome: existing.outcome_for(&prepared),
+            expansion_micros,
+            expanded_link_count,
+            action_create_micros: None,
+        });
     }
 
+    let action_create_started_at = sys_time().ok().map(|timestamp| timestamp.as_micros());
     let smartlink_id = create_prepared_smartlink(&prepared, validated_tag)?;
     bucket.insert(identity, CachedSmartLink::from_inserted(&prepared, smartlink_id.clone()));
-    Ok(PutSmartLinkOutcome::Inserted(smartlink_id))
+    let action_create_micros = sys_time()
+        .ok()
+        .zip(action_create_started_at)
+        .map(|(completed_at, started_at)| completed_at.as_micros().saturating_sub(started_at));
+    Ok(CachedPutSmartLinkOutcome {
+        outcome: PutSmartLinkOutcome::Inserted(smartlink_id),
+        expansion_micros,
+        expanded_link_count,
+        action_create_micros,
+    })
+}
+
+/// Per-call timing and cache information for commit's bounded SmartLink write context.
+///
+/// This remains crate-private because the public storage API deliberately exposes only its
+/// semantic insertion outcome. Commit uses it to attribute bootstrap work without changing
+/// storage behavior or publishing a second write surface.
+pub(crate) struct CachedPutSmartLinkOutcome {
+    pub(crate) outcome: PutSmartLinkOutcome,
+    pub(crate) expansion_micros: Option<i64>,
+    pub(crate) expanded_link_count: Option<usize>,
+    pub(crate) action_create_micros: Option<i64>,
 }
 
 // ---------------------------------------------------------------------------

--- a/happ/crates/holons_loader/Cargo.toml
+++ b/happ/crates/holons_loader/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 holons_prelude = { workspace = true }
 core_types = { workspace = true }
 tracing = { workspace = true }
+hdk = "0.6"
 
 [dev-dependencies]
 holons_core = { workspace = true }

--- a/happ/crates/holons_loader/src/controller.rs
+++ b/happ/crates/holons_loader/src/controller.rs
@@ -10,6 +10,7 @@
 // This controller keeps only per-call, in-memory state (no cross-call persistence).
 // It is intentionally thin: it wires together Mapper → Resolver → Commit → Response.
 
+use hdk::prelude::sys_time;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -77,6 +78,7 @@ impl HolonLoaderController {
         context: &Arc<TransactionContext>,
         set_reference: TransientReference, // -> HolonLoadSet
     ) -> Result<TransientReference, HolonError> {
+        let load_started_at = performance_timestamp_micros();
         // let run_id = Uuid::new_v4();
         // info!("HolonLoaderController::load_set - start run_id={run_id}");
         let run_id = 1; // Temporary fixed run_id until we wire in Uuid
@@ -118,6 +120,7 @@ impl HolonLoaderController {
         // ─────────────────────────────────────────────────────────────────────
         info!("HolonLoaderController::load_set - pass1_stage_all_bundles");
 
+        let pass_1_started_at = performance_timestamp_micros();
         let mut total_loader_holons = 0;
         let mut total_holons_staged = 0;
         let mut merged_queued_relationship_references: Vec<TransientReference> = Vec::new();
@@ -269,16 +272,21 @@ impl HolonLoaderController {
             return Ok(response_reference);
         }
 
+        let pass_1_micros = elapsed_micros(pass_1_started_at);
+
         // ─────────────────────────────────────────────────────────────────────
         // PASS 2: resolve queued references and write declared links (across the set)
         // ─────────────────────────────────────────────────────────────────────
         info!("HolonLoaderController::load_set - pass2_resolve_all");
 
+        let queued_relationship_count = merged_queued_relationship_references.len();
+        let pass_2_started_at = performance_timestamp_micros();
         let ResolverOutcome { links_created, errors: resolver_errors } =
             LoaderRefResolver::resolve_relationships(
                 context,
                 merged_queued_relationship_references,
             )?;
+        let pass_2_micros = elapsed_micros(pass_2_started_at);
 
         // SHORT-CIRCUIT CASE 3:
         // If Pass 2 produced any errors, build the response now and return (skip commit).
@@ -318,6 +326,7 @@ impl HolonLoaderController {
         // DEFAULT POPULATION: retry construction completion after Pass-2 resolution
         // over the exact nursery-staged set.
         // ─────────────────────────────────────────────────────────────────────
+        let default_population_started_at = performance_timestamp_micros();
         let mut population_errors = Vec::new();
         let mut deferred_count = 0;
         for mut staged_holon in context.staged_references()? {
@@ -363,13 +372,16 @@ impl HolonLoaderController {
             )?;
             return Ok(response_reference);
         }
+        let default_population_micros = elapsed_micros(default_population_started_at);
 
         // ─────────────────────────────────────────────────────────────────────
         // COMMIT: persist all staged holons (only if both phases succeeded)
         // ─────────────────────────────────────────────────────────────────────
         info!("HolonLoaderController::load_set - commit");
 
+        let guest_commit_started_at = performance_timestamp_micros();
         let commit_response = context.commit()?;
+        let guest_commit_micros = elapsed_micros(guest_commit_started_at);
         // Commit status is driven by the explicit CommitRequestStatus property emitted by
         // commit() (authoritative), while counts are retained for summary/diagnostics.
         let commit_status_value = commit_response
@@ -460,6 +472,19 @@ impl HolonLoaderController {
             commit_error_holons,
         )?;
 
+        info!(
+            "[PERF-688] loader: total_ms={} bundles={} loader_holons={} staged_holons={} queued_relationships={} pass_1_ms={} pass_2_ms={} links_created={} default_population_ms={} guest_commit_ms={}",
+            elapsed_micros(load_started_at) / 1_000,
+            total_bundles,
+            total_loader_holons,
+            total_holons_staged,
+            queued_relationship_count,
+            pass_1_micros / 1_000,
+            pass_2_micros / 1_000,
+            links_created,
+            default_population_micros / 1_000,
+            guest_commit_micros / 1_000,
+        );
         debug!("HolonLoaderController::load_set - done");
         Ok(response_reference)
     }
@@ -741,4 +766,15 @@ impl HolonLoaderController {
 
         Ok(response_reference)
     }
+}
+
+fn performance_timestamp_micros() -> Option<i64> {
+    sys_time().ok().map(|timestamp| timestamp.as_micros())
+}
+
+fn elapsed_micros(started_at: Option<i64>) -> i64 {
+    started_at
+        .zip(performance_timestamp_micros())
+        .map(|(started_at, completed_at)| completed_at.saturating_sub(started_at))
+        .unwrap_or_default()
 }

--- a/happ/zomes/coordinator/holons/src/lib.rs
+++ b/happ/zomes/coordinator/holons/src/lib.rs
@@ -56,42 +56,11 @@ fn signal_action(action: SignedActionHashed) -> ExternResult<()> {
     let action_id = local_id_from_action_hash(action_hash.clone());
     let timestamp = PersistenceTimestamp(action.hashed.content.timestamp().0);
     match action.hashed.content.clone() {
-        Action::CreateLink(create_link) => {
-            if let Ok(Some(link_type)) =
-                LinkTypes::from_type(create_link.zome_index, create_link.link_type)
-            {
-                emit_signal(Signal::LinkCreated {
-                    action_id,
-                    link_type: format!("{:?}", link_type),
-                    timestamp,
-                })?;
-            }
-            Ok(())
-        }
-        Action::DeleteLink(delete_link) => {
-            let record = get(delete_link.link_add_address.clone(), GetOptions::default())?.ok_or(
-                wasm_error!(WasmErrorInner::Guest("Failed to fetch CreateLink action".to_string())),
-            )?;
-            match record.action() {
-                Action::CreateLink(create_link) => {
-                    if let Ok(Some(link_type)) =
-                        LinkTypes::from_type(create_link.zome_index, create_link.link_type)
-                    {
-                        emit_signal(Signal::LinkDeleted {
-                            action_id,
-                            link_type: format!("{:?}", link_type),
-                            timestamp,
-                        })?;
-                    }
-                    Ok(())
-                }
-                _ => {
-                    return Err(wasm_error!(WasmErrorInner::Guest(
-                        "Create Link should exist".to_string()
-                    )));
-                }
-            }
-        }
+        // SmartLink mutations are intentionally not signalled individually. Bulk commits can
+        // contain thousands of links, and the initial notification foundation has no consumer
+        // that can use a link action hash for targeted invalidation. A future batched
+        // relationship-notification contract can reintroduce this at commit granularity.
+        Action::CreateLink(_) | Action::DeleteLink(_) => Ok(()),
         Action::Create(_create) => {
             if let Ok(Some(EntryTypes::HolonNode(_))) = get_entry_for_action(&action_hash) {
                 // A freshly created holon's permanent identity is its own create hash.

--- a/host/conductora/src/setup/app_builder.rs
+++ b/host/conductora/src/setup/app_builder.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use std::sync::RwLock;
+use std::time::Instant;
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::{
@@ -102,21 +103,52 @@ impl AppBuilder {
 
             tauri::async_runtime::spawn(async move {
                 let startup_result = async {
+                    let startup_started_at = Instant::now();
+                    let setup_started_at = Instant::now();
                     SetupManager::apply_setups(&handle, &storage_cfg, &runtime_selection)
                         .await
                         .context("apply_setups failed")?;
+                    tracing::info!(
+                        "[PERF-688] conductora_startup: provider_setup_ms={}",
+                        setup_started_at.elapsed().as_millis(),
+                    );
+
+                    let receptor_config_started_at = Instant::now();
                     AppBuilder::load_receptor_configs(&handle)
                         .await
                         .context("load_receptor_configs failed")?;
+                    tracing::info!(
+                        "[PERF-688] conductora_startup: receptor_config_ms={}",
+                        receptor_config_started_at.elapsed().as_millis(),
+                    );
+
+                    let runtime_started_at = Instant::now();
                     if !runtime::init_from_state(&handle) {
                         anyhow::bail!("MAP Commands runtime initialization failed");
                     }
+                    tracing::info!(
+                        "[PERF-688] conductora_startup: runtime_init_ms={}",
+                        runtime_started_at.elapsed().as_millis(),
+                    );
+
+                    let bootstrap_started_at = Instant::now();
                     ensure_core_schema_space(&handle)
                         .await
                         .context("ensure_core_schema_space failed")?;
+                    tracing::info!(
+                        "[PERF-688] conductora_startup: core_schema_bootstrap_ms={}",
+                        bootstrap_started_at.elapsed().as_millis(),
+                    );
+
+                    let window_started_at = Instant::now();
                     SetupManager::create_window(&handle, &storage_cfg, &runtime_selection)
                         .await
                         .context("create_window failed")?;
+                    tracing::info!(
+                        "[PERF-688] conductora_startup: window_creation_ms={} total_ms={}",
+                        window_started_at.elapsed().as_millis(),
+                        startup_started_at.elapsed().as_millis(),
+                    );
                     handle
                         .emit(STARTUP_READY_EVENT, ())
                         .context("failed to emit startup ready event")?;

--- a/host/conductora/src/setup/core_schema_bootstrap.rs
+++ b/host/conductora/src/setup/core_schema_bootstrap.rs
@@ -11,7 +11,9 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::path::{Component, Path};
 use std::sync::RwLock;
+use std::time::Instant;
 use tauri::{AppHandle, Manager};
+use tracing::info;
 
 use crate::runtime::RuntimeState;
 
@@ -133,6 +135,7 @@ pub fn packaged_bootstrap_content_set(handle: &AppHandle) -> anyhow::Result<Cont
 /// Conductora ingress is opened. This is intentionally called directly from
 /// startup, never through a Tauri command.
 pub async fn ensure_core_schema_space(handle: &AppHandle) -> anyhow::Result<()> {
+    let bootstrap_started_at = Instant::now();
     let gate = handle
         .try_state::<CoreSchemaBootstrapGate>()
         .ok_or_else(|| anyhow::anyhow!("CoreSchemaBootstrapGate is not managed"))?;
@@ -150,11 +153,14 @@ pub async fn ensure_core_schema_space(handle: &AppHandle) -> anyhow::Result<()> 
         return Ok(());
     }
 
+    let input_started_at = Instant::now();
     let content_set = packaged_bootstrap_content_set(handle)?;
+    let input_millis = input_started_at.elapsed().as_millis();
     let tx_id = runtime.session().begin_transaction().await?;
     let context = runtime.session().get_transaction(&tx_id)?;
     context.enable_bootstrap_provisioning();
 
+    let load_started_at = Instant::now();
     let result = runtime
         .execute_command(
             MapCommand::Transaction(TransactionCommand {
@@ -164,6 +170,7 @@ pub async fn ensure_core_schema_space(handle: &AppHandle) -> anyhow::Result<()> 
             ExecutionPolicy::default(),
         )
         .await;
+    let load_millis = load_started_at.elapsed().as_millis();
     runtime.session().archive_transaction(&tx_id)?;
     result?;
 
@@ -174,6 +181,12 @@ pub async fn ensure_core_schema_space(handle: &AppHandle) -> anyhow::Result<()> 
     }
 
     gate.mark_ready()?;
+    info!(
+        "[PERF-688] conductora_bootstrap: input_ms={} load_and_commit_ms={} total_ms={}",
+        input_millis,
+        load_millis,
+        bootstrap_started_at.elapsed().as_millis(),
+    );
     Ok(())
 }
 

--- a/host/conductora/src/setup/providers/holochain/setup.rs
+++ b/host/conductora/src/setup/providers/holochain/setup.rs
@@ -35,16 +35,16 @@ impl HolochainSetup {
             tracing::error!("[HOLOCHAIN SETUP] Failed to load happ bundle: {}", e);
             anyhow::anyhow!("Failed to load happ bundle: {}", e)
         })?;
-        tracing::debug!(
-            "[HOLOCHAIN SETUP] happ bundle loaded in {:.1}s",
-            t_setup.elapsed().as_secs_f64()
+        tracing::info!(
+            "[PERF-688] holochain_setup: happ_bundle_ms={}",
+            t_setup.elapsed().as_millis(),
         );
 
         let t_admin = std::time::Instant::now();
         let admin_ws = handle.holochain()?.admin_websocket().await?;
-        tracing::debug!(
-            "[HOLOCHAIN SETUP] Admin websocket obtained in {:.1}s",
-            t_admin.elapsed().as_secs_f64()
+        tracing::info!(
+            "[PERF-688] holochain_setup: admin_websocket_ms={}",
+            t_admin.elapsed().as_millis(),
         );
 
         let installed_apps = admin_ws
@@ -70,15 +70,15 @@ impl HolochainSetup {
                 .await?;
         }
         tracing::info!(
-            "[HOLOCHAIN SETUP] App install/update done in {:.1}s",
-            t_install.elapsed().as_secs_f64()
+            "[PERF-688] holochain_setup: app_install_or_update_ms={}",
+            t_install.elapsed().as_millis(),
         );
 
         let t_appws = std::time::Instant::now();
         let app_ws = handle.holochain()?.app_websocket(app_id.clone()).await?;
-        tracing::debug!(
-            "[HOLOCHAIN SETUP] App websocket obtained in {:.1}s",
-            t_appws.elapsed().as_secs_f64()
+        tracing::info!(
+            "[PERF-688] holochain_setup: app_websocket_ms={}",
+            t_appws.elapsed().as_millis(),
         );
 
         let cell_details = hc_cfg
@@ -128,10 +128,7 @@ impl HolochainSetup {
         let (receptor_cfg, _client) =
             Self::build_receptor(app_ws, admin_ws, name, hc_cfg, cell0).await?;
         register_receptor(&handle, receptor_cfg).await?;
-        tracing::info!(
-            "[HOLOCHAIN SETUP] Total setup time: {:.1}s",
-            t_setup.elapsed().as_secs_f64()
-        );
+        tracing::info!("[PERF-688] holochain_setup: total_ms={}", t_setup.elapsed().as_millis(),);
 
         Ok(())
     }

--- a/host/crates/holochain_receptor/src/holochain_conductor_client.rs
+++ b/host/crates/holochain_receptor/src/holochain_conductor_client.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 use holochain_types::prelude::{FunctionName, ZomeName};
 use serde_bytes::ByteBuf;
@@ -88,6 +91,8 @@ impl ConductorDanceCaller for HolochainConductorClient {
         &self,
         request: DanceRequestEnvelope,
     ) -> Result<DanceResponseEnvelope, HolonError> {
+        let is_load_holons = request.request.dance_name.0.as_str() == "load_holons";
+
         // --- Serialize request ---
         let payload: ExternIO = match ExternIO::encode(request) {
             Ok(p) => p,
@@ -110,6 +115,10 @@ impl ConductorDanceCaller for HolochainConductorClient {
         };
 
         // --- Make zome call ---
+        let zome_call_started_at = Instant::now();
+        if is_load_holons {
+            tracing::info!("[PERF-688] conductor_zome_call: load_holons_started");
+        }
         let result = app_ws
             .call_zome(
                 ZomeCallTarget::RoleName(self.rolename.clone()),
@@ -118,6 +127,13 @@ impl ConductorDanceCaller for HolochainConductorClient {
                 payload,
             )
             .await;
+        if is_load_holons {
+            tracing::info!(
+                "[PERF-688] conductor_zome_call: load_holons_returned_ms={} success={}",
+                zome_call_started_at.elapsed().as_millis(),
+                result.is_ok(),
+            );
+        }
 
         let extern_io = result
             .map_err(|error| HolonError::ConductorError(format!("Zome call failed: {error:?}")))?;

--- a/host/crates/holons_client/src/client_shared_objects/client_holon_service.rs
+++ b/host/crates/holons_client/src/client_shared_objects/client_holon_service.rs
@@ -53,8 +53,10 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
+use tracing::info;
 
 #[derive(Debug, Clone)]
 pub struct ClientHolonService;
@@ -315,11 +317,15 @@ impl HolonServiceApi for ClientHolonService {
         set: TransientReference, // HolonLoadSet type
     ) -> Result<TransientReference, HolonError> {
         // 1) Build the dance request for the loader.
+        let request_started_at = Instant::now();
         let request = holon_dance_builders::build_load_holons_dance_request(set)?;
+        let request_millis = request_started_at.elapsed().as_millis();
 
         // 2) Bridge async → sync (ClientHolonService is synchronous)
+        let dance_started_at = Instant::now();
         let response =
             run_future_synchronously(async move { context.initiate_dance(request).await })?;
+        let dance_millis = dance_started_at.elapsed().as_millis();
 
         // 3) Check the status
         if response.status_code != ResponseStatusCode::OK {
@@ -331,7 +337,14 @@ impl HolonServiceApi for ClientHolonService {
 
         // 4) Extract the returned holon
         match response.body {
-            ResponseBody::HolonReference(HolonReference::Transient(tref)) => Ok(tref),
+            ResponseBody::HolonReference(HolonReference::Transient(tref)) => {
+                info!(
+                    "[PERF-688] loader_dance_client: request_build_ms={} initiate_dance_round_trip_ms={}",
+                    request_millis,
+                    dance_millis,
+                );
+                Ok(tref)
+            }
             ResponseBody::HolonReference(other) => Err(HolonError::InvalidParameter(format!(
                 "LoadHolons: expected TransientReference, got {:?}",
                 other

--- a/host/crates/holons_loader_client/src/loader_client.rs
+++ b/host/crates/holons_loader_client/src/loader_client.rs
@@ -22,7 +22,8 @@ use holons_core::core_shared_objects::transactions::TransactionContext;
 use holons_core::reference_layer::TransientReference;
 use holons_core::HolonReference;
 use std::sync::Arc;
-use tracing::debug;
+use std::time::Instant;
+use tracing::{debug, info};
 
 /// Primary entry point for the host-side Holon Loader.
 ///
@@ -54,6 +55,7 @@ pub async fn load_holons_from_files(
     context: Arc<TransactionContext>,
     content_set: ContentSet,
 ) -> Result<TransientReference, HolonError> {
+    let load_started_at = Instant::now();
     debug!("[loader-client] start load_holons_from_files");
     // Guard against missing content; this is almost certainly a caller bug.
     if content_set.files_to_load.is_empty() {
@@ -68,6 +70,7 @@ pub async fn load_holons_from_files(
     // a UI-provided identifier).
     let load_set_key: Option<MapString> = Some(MapString("HolonLoadSet".to_string()));
 
+    let parse_started_at = Instant::now();
     let load_set_reference: HolonReference =
         match parse_files_into_load_set(&context, load_set_key, &content_set) {
             Ok(reference) => reference,
@@ -76,6 +79,7 @@ pub async fn load_holons_from_files(
                 return Err(error);
             }
         };
+    let parse_millis = parse_started_at.elapsed().as_millis();
 
     // Phase 2: Ensure we have a transient reference to the HolonLoadSet.
     //
@@ -97,8 +101,17 @@ pub async fn load_holons_from_files(
     // builds the dance request, calls into the guest, and
     // returns a `TransientReference` to the `HolonLoadResponse` holon.
     debug!("[loader-client] invoking load_holons dance");
+    let dance_started_at = Instant::now();
     let response_reference = context.load_holons_and_commit(load_set_transient)?;
+    let dance_millis = dance_started_at.elapsed().as_millis();
     debug!("[loader-client] load_holons dance returned");
+    info!(
+        "[PERF-688] loader_client: files={} parse_and_prepare_ms={} dance_round_trip_ms={} total_ms={}",
+        content_set.files_to_load.len(),
+        parse_millis,
+        dance_millis,
+        load_started_at.elapsed().as_millis(),
+    );
 
     Ok(response_reference)
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sweetest:nocapture": "RUST_LOG=${RUST_LOG:-warn} WASM_LOG=${WASM_LOG:-warn} npm run build:happ && npm run build:probes -w map-happ && npm run check:happ-artifacts && npm run sweet:test:nocapture",
     "sweet:test": "cargo test --manifest-path tests/sweetests/Cargo.toml -- --test-threads=1",
     "sweet:test:nocapture": "cargo test --manifest-path tests/sweetests/Cargo.toml -- --test-threads=1 --nocapture",
+    "sweet:bootstrap-perf": "env RUST_LOG=info WASM_LOG=info sh -c 'npm run build:happ && npm run build:probes -w map-happ && npm run check:happ-artifacts && cargo test --manifest-path tests/sweetests/Cargo.toml --test bootstrap_performance_tests -- --nocapture'",
     "check:happ-artifacts": "cargo run --manifest-path tools/happ-artifact-audit/Cargo.toml -- --manifest happ/coordinator-surface.toml --dna happ/workdir/map_holons.dna --happ happ/workdir/map-holons.happ --probe-wasm happ/target/wasm32-unknown-unknown/release/holons_test_probes.wasm --deny-production-test-only",
     "map-schema": "cargo run --manifest-path tools/map-schema/Cargo.toml --",
     "map-schema:decompile": "cargo run --manifest-path tools/map-schema/Cargo.toml -- decompile",

--- a/shared_crates/holons_trust_channel/src/trust_channel.rs
+++ b/shared_crates/holons_trust_channel/src/trust_channel.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 use holons_core::core_shared_objects::transactions::TransactionContext;
 use holons_core::dances::{DanceRequest, DanceResponse};
 use std::sync::Arc;
-use tracing::debug;
+use std::time::Instant;
+use tracing::{debug, info};
 
 use crate::dance_envelope_transport::DanceEnvelopeTransport;
 use crate::envelopes::dance_envelope_adapter::DanceEnvelopeAdapter;
@@ -31,27 +32,45 @@ impl DanceInitiator for TrustChannel {
         context: &Arc<TransactionContext>,
         request: DanceRequest,
     ) -> DanceResponse {
+        let is_load_holons = request.dance_name.0 == "load_holons";
+        let total_started_at = Instant::now();
         // --- Outbound runtime -> envelope -----------------------------------------
+        let request_envelope_started_at = Instant::now();
         let request_envelope = match DanceEnvelopeAdapter::build_request_envelope(&context, request)
         {
             Ok(envelope) => envelope,
             Err(error) => return DanceResponse::from_error(error),
         };
+        let request_envelope_millis = request_envelope_started_at.elapsed().as_millis();
 
         debug!("TrustChannel::initiate_dance() — prepared envelope request");
 
         // --- Transmit via backend --------------------------------------------
+        let backend_started_at = Instant::now();
         let response_envelope = match self.backend.initiate_dance_envelope(request_envelope).await {
             Ok(envelope) => envelope,
             Err(error) => return DanceResponse::from_error(error),
         };
+        let backend_millis = backend_started_at.elapsed().as_millis();
 
         // --- Inbound envelope -> runtime -------------------------------------
+        let response_binding_started_at = Instant::now();
         let response =
             match DanceEnvelopeAdapter::bind_response_envelope(&context, response_envelope) {
                 Ok(response) => response,
                 Err(error) => return DanceResponse::from_error(error),
             };
+        let response_binding_millis = response_binding_started_at.elapsed().as_millis();
+
+        if is_load_holons {
+            info!(
+                "[PERF-688] trust_channel: request_envelope_ms={} backend_ms={} response_binding_ms={} total_ms={}",
+                request_envelope_millis,
+                backend_millis,
+                response_binding_millis,
+                total_started_at.elapsed().as_millis(),
+            );
+        }
 
         debug!("TrustChannel::initiate_dance() — got response: {:?}", response.summarize());
         response

--- a/tests/sweetests/src/harness/helpers/mock_conductor.rs
+++ b/tests/sweetests/src/harness/helpers/mock_conductor.rs
@@ -62,8 +62,8 @@ impl DanceEnvelopeTransport for MockConductorConfig {
 
         if is_load_holons {
             info!(
-                elapsed_ms = started.elapsed().as_millis(),
-                "sweettest transport: load_holons conductor call complete"
+                "[PERF-688] sweettest_transport: conductor_call_ms={}",
+                started.elapsed().as_millis(),
             );
         }
 

--- a/tests/sweetests/src/harness/helpers/test_context.rs
+++ b/tests/sweetests/src/harness/helpers/test_context.rs
@@ -107,11 +107,11 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
     let bootstrap_content_started = Instant::now();
     let bootstrap_content_set = build_core_schema_bootstrap_content_set()
         .expect("failed to build Core Schema bootstrap ContentSet");
-    info!(
-        elapsed_ms = bootstrap_content_started.elapsed().as_millis(),
-        "sweettest runtime: CoreSchemaSpace bootstrap inputs ready"
-    );
     let descriptor_keys = expected_descriptor_keys(&bootstrap_content_set);
+    info!(
+        "[PERF-688] sweettest_bootstrap: input_and_expectation_ms={}",
+        bootstrap_content_started.elapsed().as_millis(),
+    );
     let bootstrap_load_started = Instant::now();
     runtime
         .execute_command(
@@ -123,10 +123,15 @@ pub async fn init_test_runtime(test_case: &mut DancesTestCase) -> (Runtime, TxId
         )
         .await
         .expect("failed to load Core Schema bootstrap bundle");
+    info!(
+        "[PERF-688] sweettest_bootstrap: guest_load_and_commit_ms={}",
+        bootstrap_load_started.elapsed().as_millis(),
+    );
+    let bootstrap_verification_started = Instant::now();
     assert_descriptor_completion(&bootstrap_context, descriptor_keys);
     info!(
-        elapsed_ms = bootstrap_load_started.elapsed().as_millis(),
-        "sweettest runtime: CoreSchemaSpace bootstrap load complete"
+        "[PERF-688] sweettest_bootstrap: post_commit_verification_ms={}",
+        bootstrap_verification_started.elapsed().as_millis(),
     );
     runtime
         .session()

--- a/tests/sweetests/src/harness/helpers/tracing_utils.rs
+++ b/tests/sweetests/src/harness/helpers/tracing_utils.rs
@@ -1,6 +1,6 @@
 use std::sync::Once;
 use tracing::warn;
-use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
+use tracing_subscriber::{filter::LevelFilter, fmt, fmt::format::FmtSpan, EnvFilter};
 
 static INIT: Once = Once::new();
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::WARN;
@@ -13,9 +13,19 @@ pub fn init_tracing() {
             EnvFilter::default().add_directive(DEFAULT_LOG_LEVEL.into())
         });
 
+        let subscriber = fmt().with_env_filter(filter.clone()).with_target(true).with_test_writer();
+        let emit_span_closes = std::env::var_os("MAP_HOLONS_TRACE_SPAN_CLOSES").is_some();
+
+        // Existing Holochain workflow spans report busy and idle time on close.
+        // Keep them opt-in because full Sweettest runs can create substantial output.
+        let init_result = if emit_span_closes {
+            subscriber.with_span_events(FmtSpan::CLOSE).try_init()
+        } else {
+            subscriber.try_init()
+        };
+
         // Initialize tracing subscriber.
-        match fmt().with_env_filter(filter.clone()).with_target(true).with_test_writer().try_init()
-        {
+        match init_result {
             Ok(_) => {
                 // Derive a readable level summary
                 let level = filter.max_level_hint().unwrap_or(DEFAULT_LOG_LEVEL);

--- a/tests/sweetests/tests/bootstrap_performance_tests.rs
+++ b/tests/sweetests/tests/bootstrap_performance_tests.rs
@@ -1,0 +1,37 @@
+//! Focused Core Schema bootstrap measurement seam for Issue #688.
+//!
+//! Run with `npm run sweet:bootstrap-perf` and collect the aggregate `[PERF-688]`
+//! lines. This test deliberately exercises the generated bootstrap bundle through
+//! the same runtime path used by ordinary Sweettests, rather than a storage microbenchmark.
+
+use holons_core::reference_layer::HolonSpaceBehavior;
+use holons_test::{init_test_runtime, DancesTestCase};
+use std::time::Instant;
+use tracing::info;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn measures_generated_core_schema_bootstrap() {
+    let mut test_case = DancesTestCase::default();
+    let started_at = Instant::now();
+    let (runtime, transaction_id) = init_test_runtime(&mut test_case).await;
+
+    assert!(
+        runtime
+            .session()
+            .space_manager()
+            .get_space_holon_id()
+            .expect("Core Schema bootstrap space lookup must succeed")
+            .is_some(),
+        "focused measurement must bootstrap the CoreSchemaSpace anchor"
+    );
+
+    runtime
+        .session()
+        .archive_transaction(&transaction_id)
+        .expect("focused measurement transaction must archive");
+
+    info!(
+        "[PERF-688] sweettest_bootstrap_measurement: total_ms={}",
+        started_at.elapsed().as_millis(),
+    );
+}


### PR DESCRIPTION
# Summary

Closes #688.

This PR adds a reproducible Core Schema bootstrap measurement surface, fixes the confirmed commit-local inverse-dedup performance pathology, adds startup/zome boundary attribution, and suppresses an unnecessary per-SmartLink notification flood.

It preserves the ownership, keyed discovery, historical-read, and native Delete semantics established by #642 and #679.

## Changes

- Adds focused Core Schema bootstrap measurement and documentation:
  - `npm run sweet:bootstrap-perf`
  - same generated bootstrap bundle used by Conductora and Sweettest setup
  - aggregate phase, count, and commit instrumentation

- Replaces repeated inverse-dedup candidate scans with commit-local inverse-membership indexing:
  - before: 495 expansions and 122,265 examined candidates
  - after observed sample: 1 seed expansion, 0 candidates, 495 in-memory checks

- Adds correlated startup and zome-call timing boundaries:
  - Conductora provider/setup/runtime/bootstrap phases
  - host zome-call start/return
  - guest `load_holons` entry/return

- Suppresses individual `CreateLink` and `DeleteLink` post-commit signals:
  - bootstrap previously emitted 5,460 link signals
  - Holochain reported dropped signals under that load
  - holon lifecycle signals remain intact
  - existing link-signal types remain available for a future batched notification contract

- Updates the issue-grounding skill to inspect authoritative `map-dev-docs` sources in situ rather than copying DevDocs artifacts into this repository.

## Findings

The measured Core Schema bootstrap graph contains:

| Measure | Count |
|---|---:|
| Input bundles/files | 17 |
| Holons committed | 495 |
| Semantic relationships resolved | 2,730 |
| Physical SmartLink actions | 5,460 |
| Total Holochain actions | 5,955 |

Normal startup attribution showed:

| `load_holons` zome segment | Observed time |
|---|---:|
| Host call to guest entry | 9–12s |
| Guest execution | approximately 20–21s |
| Guest return to host response | approximately 26–27s |

The remaining dominant cost is Holochain’s synchronous validation and local flush of the intentionally persisted action set. A broad Holochain trace confirmed the post-guest workflow includes system validation, app validation, DHT-operation preparation, and source-chain flush.

Follow-up work:

- #689: derive version-bound `OwnedBy` from transaction Space context while retaining persisted lineage-bound `Owns`; this is the principal remaining MAP-owned structural action reduction.
- #690: Dance Sweettest consolidation was delivered separately to amortize bootstrap across suites.

## Validation

- `npm test` — nominal
- `npm start` — nominal
- hApp build — nominal
- Host build — nominal
- Pre-push formatting checks — passed

## Notes

The focused inverse-dedup after result is an observed fresh-process sample rather than a full five-run median. The instrumentation remains intentionally available for repeatable measurement and future before/after comparisons.