### PR TITLE
feat(dahn): resolve Rust-selected visualizer implementations issue 673

### DIFF
--- a/host/ui/src/dahn/boundaries/exports.test.ts
+++ b/host/ui/src/dahn/boundaries/exports.test.ts
@@ -10,6 +10,8 @@ describe('DAHN export surface', () => {
     expect(dahn.DefaultThemeRegistry).toBeDefined();
     expect(dahn.registerBuiltInVisualizers).toBeDefined();
     expect(dahn.DahnHolonView).toBeDefined();
+    expect(dahn.DefaultVisualizerImplementationRuntime).toBeDefined();
+    expect(dahn.DahnImplementationResolutionError).toBeDefined();
   });
 
   it('does not leak obvious transport-facing concepts through the DAHN root export surface', () => {

--- a/host/ui/src/dahn/contracts/visualizers.ts
+++ b/host/ui/src/dahn/contracts/visualizers.ts
@@ -3,6 +3,7 @@ import type { CanvasApi } from './canvas';
 import type { HolonViewAccess } from './holon-view';
 import type { DahnTarget } from './targets';
 import type { DahnTheme } from './themes';
+import type { HolonReference } from '../deps';
 
 /**
  * Minimal target classification metadata for Phase 0. Definitions stay local
@@ -11,6 +12,8 @@ import type { DahnTheme } from './themes';
  */
 export interface VisualizerTargetRule {
   kind:
+    | 'canvas'
+    | 'collection'
     | 'holon-node'
     | 'action'
     | 'property'
@@ -22,12 +25,34 @@ export interface VisualizerTargetRule {
  * Runtime/local representation of a visualizer descriptor.
  */
 export interface VisualizerDefinition {
+  /**
+   * Local executable-registry identity. This is not a MAP semantic identity.
+   */
   id: string;
+  /**
+   * Stable MAP implementation key, when this definition realizes a bundled
+   * VisualizerImplementation Holon.
+   */
+  implementationKey?: string;
   displayName: string;
   version: string;
   componentTag: string;
   supportedTargets: VisualizerTargetRule[];
   load: () => Promise<void>;
+}
+
+/** Execution runtimes currently described by the DAHN schema. */
+export type VisualizerImplementationRuntimeKind = 'TypeScript' | 'Rust';
+
+/**
+ * A Rust-selected realization request. The resolver trusts this pairing and
+ * only maps the supplied implementation key to locally executable code.
+ */
+export interface VisualizerImplementationResolution {
+  selectedVisualizer: HolonReference;
+  implementation: HolonReference;
+  runtime: VisualizerImplementationRuntimeKind;
+  implementationKey?: string;
 }
 
 /**

--- a/host/ui/src/dahn/index.ts
+++ b/host/ui/src/dahn/index.ts
@@ -20,6 +20,8 @@ export type {
   VisualizerContext,
   VisualizerDefinition,
   VisualizerElement,
+  VisualizerImplementationResolution,
+  VisualizerImplementationRuntimeKind,
   VisualizerTargetRule,
 } from './contracts/visualizers';
 export { DomCanvas } from './canvas/dom-canvas';
@@ -35,6 +37,13 @@ export { Phase0Selector } from './selector/phase0-selector';
 export { DefaultDahnRuntime } from './runtime/default-dahn-runtime';
 export type { DahnRuntime } from './runtime/dahn-runtime';
 export {
+  DefaultVisualizerImplementationRuntime,
+} from './runtime/visualizer-implementation-runtime';
+export type {
+  VisualizerImplementationRuntime,
+} from './runtime/visualizer-implementation-runtime';
+export {
+  DahnImplementationResolutionError,
   DahnNotImplementedError,
   DahnRuntimeError,
 } from './runtime/runtime-errors';

--- a/host/ui/src/dahn/registry/default-visualizer-registry.test.ts
+++ b/host/ui/src/dahn/registry/default-visualizer-registry.test.ts
@@ -42,6 +42,66 @@ describe('DefaultVisualizerRegistry', () => {
     ).toThrow(/already registered/);
   });
 
+  it('indexes executable definitions by implementation key without replacing their local ids', async () => {
+    const registry = new DefaultVisualizerRegistry();
+    const definition = {
+      id: 'local-node-definition',
+      implementationKey: 'dahn.generic-holon-node',
+      displayName: 'Holon Node',
+      version: '0.0.0',
+      componentTag: 'test-implementation-key-visualizer',
+      supportedTargets: [{ kind: 'holon-node' as const }],
+      load: async () => {
+        class TestVisualizer extends HTMLElement {}
+        if (
+          customElements.get('test-implementation-key-visualizer') ===
+          undefined
+        ) {
+          customElements.define(
+            'test-implementation-key-visualizer',
+            TestVisualizer,
+          );
+        }
+      },
+    };
+
+    registry.register(definition);
+
+    expect(registry.get('local-node-definition')).toBe(definition);
+    expect(registry.getByImplementationKey('dahn.generic-holon-node')).toBe(
+      definition,
+    );
+    await expect(
+      registry.ensureImplementationLoaded('dahn.generic-holon-node'),
+    ).resolves.toBe(definition);
+  });
+
+  it('rejects duplicate implementation keys for different definitions', () => {
+    const registry = new DefaultVisualizerRegistry();
+    registry.register({
+      id: 'first-definition',
+      implementationKey: 'dahn.space-navigator',
+      displayName: 'First',
+      version: '0.0.0',
+      componentTag: 'test-first-implementation-key-visualizer',
+      supportedTargets: [{ kind: 'canvas' }],
+      load: async () => {},
+    });
+
+    expect(() =>
+      registry.register({
+        id: 'second-definition',
+        implementationKey: 'dahn.space-navigator',
+        displayName: 'Second',
+        version: '0.0.0',
+        componentTag: 'test-second-implementation-key-visualizer',
+        supportedTargets: [{ kind: 'canvas' }],
+        load: async () => {},
+      }),
+    ).toThrow(/implementation key.*already registered/);
+    expect(registry.get('second-definition')).toBeUndefined();
+  });
+
   it('loads definitions idempotently', async () => {
     const registry = new DefaultVisualizerRegistry();
     const load = vi.fn(async () => {

--- a/host/ui/src/dahn/registry/default-visualizer-registry.ts
+++ b/host/ui/src/dahn/registry/default-visualizer-registry.ts
@@ -3,6 +3,10 @@ import type { VisualizerRegistry } from './visualizer-registry';
 
 export class DefaultVisualizerRegistry implements VisualizerRegistry {
   private readonly definitions = new Map<string, VisualizerDefinition>();
+  private readonly definitionsByImplementationKey = new Map<
+    string,
+    VisualizerDefinition
+  >();
   private readonly loadedIds = new Set<string>();
   private readonly pendingLoads = new Map<string, Promise<VisualizerDefinition>>();
 
@@ -14,11 +18,33 @@ export class DefaultVisualizerRegistry implements VisualizerRegistry {
       );
     }
 
+    if (definition.implementationKey !== undefined) {
+      const existingByKey = this.definitionsByImplementationKey.get(
+        definition.implementationKey,
+      );
+      if (existingByKey !== undefined && existingByKey !== definition) {
+        throw new Error(
+          `Visualizer implementation key '${definition.implementationKey}' is already registered`,
+        );
+      }
+    }
+
     this.definitions.set(definition.id, definition);
+
+    if (definition.implementationKey !== undefined) {
+      this.definitionsByImplementationKey.set(
+        definition.implementationKey,
+        definition,
+      );
+    }
   }
 
   get(id: string): VisualizerDefinition | undefined {
     return this.definitions.get(id);
+  }
+
+  getByImplementationKey(key: string): VisualizerDefinition | undefined {
+    return this.definitionsByImplementationKey.get(key);
   }
 
   list(): VisualizerDefinition[] {
@@ -56,5 +82,14 @@ export class DefaultVisualizerRegistry implements VisualizerRegistry {
     } finally {
       this.pendingLoads.delete(id);
     }
+  }
+
+  async ensureImplementationLoaded(key: string): Promise<VisualizerDefinition> {
+    const definition = this.getByImplementationKey(key);
+    if (definition === undefined) {
+      throw new Error(`Unknown visualizer implementation key '${key}'`);
+    }
+
+    return this.ensureLoaded(definition.id);
   }
 }

--- a/host/ui/src/dahn/registry/visualizer-registry.ts
+++ b/host/ui/src/dahn/registry/visualizer-registry.ts
@@ -3,6 +3,8 @@ import type { VisualizerDefinition } from '../contracts/visualizers';
 export interface VisualizerRegistry {
   register(definition: VisualizerDefinition): void;
   get(id: string): VisualizerDefinition | undefined;
+  getByImplementationKey(key: string): VisualizerDefinition | undefined;
   list(): VisualizerDefinition[];
   ensureLoaded(id: string): Promise<VisualizerDefinition>;
+  ensureImplementationLoaded(key: string): Promise<VisualizerDefinition>;
 }

--- a/host/ui/src/dahn/runtime/runtime-errors.ts
+++ b/host/ui/src/dahn/runtime/runtime-errors.ts
@@ -1,3 +1,8 @@
+import type {
+  VisualizerImplementationResolution,
+  VisualizerImplementationRuntimeKind,
+} from '../contracts/visualizers';
+
 /**
  * Base class for DAHN runtime errors.
  */
@@ -16,5 +21,38 @@ export class DahnNotImplementedError extends DahnRuntimeError {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = 'DahnNotImplementedError';
+  }
+}
+
+/**
+ * Raised when a Rust-selected VisualizerImplementation cannot be realized by
+ * the local TypeScript runtime. This error never implies a fallback choice.
+ */
+export class DahnImplementationResolutionError extends DahnRuntimeError {
+  readonly selectedVisualizer: VisualizerImplementationResolution['selectedVisualizer'];
+  readonly implementation: VisualizerImplementationResolution['implementation'];
+  readonly runtime: VisualizerImplementationRuntimeKind;
+  readonly implementationKey?: string;
+  readonly reason:
+    | 'unsupported-runtime'
+    | 'missing-implementation-key'
+    | 'unknown-implementation-key'
+    | 'load-failed';
+
+  constructor(
+    reason: DahnImplementationResolutionError['reason'],
+    resolution: VisualizerImplementationResolution,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Unable to realize VisualizerImplementation '${resolution.implementationKey ?? '<missing>'}' (${reason})`,
+      options,
+    );
+    this.name = 'DahnImplementationResolutionError';
+    this.reason = reason;
+    this.selectedVisualizer = resolution.selectedVisualizer;
+    this.implementation = resolution.implementation;
+    this.runtime = resolution.runtime;
+    this.implementationKey = resolution.implementationKey;
   }
 }

--- a/host/ui/src/dahn/runtime/visualizer-implementation-runtime.test.ts
+++ b/host/ui/src/dahn/runtime/visualizer-implementation-runtime.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  HolonReference,
+  VisualizerImplementationResolution,
+} from '../index';
+import { registerBuiltInVisualizers } from '../registry/register-builtins';
+import { DefaultVisualizerRegistry } from '../registry/default-visualizer-registry';
+import {
+  DefaultVisualizerImplementationRuntime,
+} from './visualizer-implementation-runtime';
+import { DahnImplementationResolutionError } from './runtime-errors';
+
+const selectedVisualizer = {} as HolonReference;
+const implementation = {} as HolonReference;
+
+function resolution(
+  overrides: Partial<VisualizerImplementationResolution> = {},
+): VisualizerImplementationResolution {
+  return {
+    selectedVisualizer,
+    implementation,
+    runtime: 'TypeScript',
+    implementationKey: 'dahn.generic-holon-node',
+    ...overrides,
+  };
+}
+
+function runtime(): DefaultVisualizerImplementationRuntime {
+  const registry = new DefaultVisualizerRegistry();
+  registerBuiltInVisualizers(registry);
+  return new DefaultVisualizerImplementationRuntime(registry);
+}
+
+describe('DefaultVisualizerImplementationRuntime', () => {
+  it.each([
+    ['dahn.space-navigator', 'space-navigator'],
+    ['dahn.generic-holon-node', 'holon-node'],
+    ['dahn.table-collection', 'table-collection'],
+  ])('resolves %s to the local %s executable definition', async (key, id) => {
+    await expect(runtime().resolve(resolution({ implementationKey: key }))).resolves
+      .toMatchObject({ id, implementationKey: key });
+  });
+
+  it('does not select a fallback when the supplied implementation key is unavailable', async () => {
+    const input = resolution({ implementationKey: 'dahn.unavailable' });
+
+    await expect(runtime().resolve(input)).rejects.toMatchObject({
+      name: 'DahnImplementationResolutionError',
+      reason: 'unknown-implementation-key',
+      selectedVisualizer,
+      implementation,
+      implementationKey: 'dahn.unavailable',
+    } satisfies Partial<DahnImplementationResolutionError>);
+  });
+
+  it('rejects an implementation for a different runtime', async () => {
+    await expect(runtime().resolve(resolution({ runtime: 'Rust' }))).rejects
+      .toMatchObject({ reason: 'unsupported-runtime', runtime: 'Rust' });
+  });
+
+  it('rejects a missing implementation key with diagnostic identity context', async () => {
+    const input = resolution({ implementationKey: undefined });
+
+    await expect(runtime().resolve(input)).rejects.toMatchObject({
+      reason: 'missing-implementation-key',
+      selectedVisualizer,
+      implementation,
+    });
+  });
+
+  it('preserves the selected identity when local definition loading fails', async () => {
+    const registry = new DefaultVisualizerRegistry();
+    registry.register({
+      id: 'broken-local-definition',
+      implementationKey: 'dahn.broken',
+      displayName: 'Broken local definition',
+      version: '0.0.0',
+      componentTag: 'test-broken-local-definition',
+      supportedTargets: [{ kind: 'canvas' }],
+      load: async () => {
+        throw new Error('load failed');
+      },
+    });
+    const input = resolution({ implementationKey: 'dahn.broken' });
+
+    await expect(
+      new DefaultVisualizerImplementationRuntime(registry).resolve(input),
+    ).rejects.toMatchObject({
+      reason: 'load-failed',
+      selectedVisualizer,
+      implementation,
+      implementationKey: 'dahn.broken',
+    });
+  });
+});

--- a/host/ui/src/dahn/runtime/visualizer-implementation-runtime.ts
+++ b/host/ui/src/dahn/runtime/visualizer-implementation-runtime.ts
@@ -1,0 +1,55 @@
+import type {
+  VisualizerDefinition,
+  VisualizerImplementationResolution,
+} from '../contracts/visualizers';
+import type { VisualizerRegistry } from '../registry/visualizer-registry';
+import { DahnImplementationResolutionError } from './runtime-errors';
+
+/** Resolves one Rust-selected implementation to a locally executable definition. */
+export interface VisualizerImplementationRuntime {
+  resolve(
+    resolution: VisualizerImplementationResolution,
+  ): Promise<VisualizerDefinition>;
+}
+
+export class DefaultVisualizerImplementationRuntime
+  implements VisualizerImplementationRuntime
+{
+  constructor(private readonly registry: VisualizerRegistry) {}
+
+  async resolve(
+    resolution: VisualizerImplementationResolution,
+  ): Promise<VisualizerDefinition> {
+    if (resolution.runtime !== 'TypeScript') {
+      throw new DahnImplementationResolutionError(
+        'unsupported-runtime',
+        resolution,
+      );
+    }
+
+    if (
+      resolution.implementationKey === undefined ||
+      resolution.implementationKey.trim() === ''
+    ) {
+      throw new DahnImplementationResolutionError(
+        'missing-implementation-key',
+        resolution,
+      );
+    }
+
+    try {
+      return await this.registry.ensureImplementationLoaded(
+        resolution.implementationKey,
+      );
+    } catch (error) {
+      const reason =
+        this.registry.getByImplementationKey(resolution.implementationKey) ===
+        undefined
+          ? 'unknown-implementation-key'
+          : 'load-failed';
+      throw new DahnImplementationResolutionError(reason, resolution, {
+        cause: error,
+      });
+    }
+  }
+}

--- a/host/ui/src/dahn/visualizers/builtins.test.ts
+++ b/host/ui/src/dahn/visualizers/builtins.test.ts
@@ -8,9 +8,17 @@ describe('registerBuiltInVisualizers', () => {
 
     registerBuiltInVisualizers(registry);
 
-    expect(registry.get('holon-node')).toBeDefined();
+    expect(
+      registry.getByImplementationKey('dahn.space-navigator'),
+    ).toMatchObject({ id: 'space-navigator' });
+    expect(
+      registry.getByImplementationKey('dahn.generic-holon-node'),
+    ).toMatchObject({ id: 'holon-node' });
+    expect(
+      registry.getByImplementationKey('dahn.table-collection'),
+    ).toMatchObject({ id: 'table-collection' });
     expect(registry.get('action-menu')).toBeDefined();
     expect(registry.get('debug')).toBeDefined();
-    expect(registry.list()).toHaveLength(3);
+    expect(registry.list()).toHaveLength(5);
   });
 });

--- a/host/ui/src/dahn/visualizers/builtins.ts
+++ b/host/ui/src/dahn/visualizers/builtins.ts
@@ -12,10 +12,33 @@ import {
   HOLON_NODE_VISUALIZER_TAG,
   HolonNodeVisualizerElement,
 } from './holon-node-visualizer.element';
+import {
+  SPACE_NAVIGATOR_VISUALIZER_TAG,
+  SpaceNavigatorVisualizerElement,
+} from './space-navigator-visualizer.element';
+import {
+  TABLE_COLLECTION_VISUALIZER_TAG,
+  TableCollectionVisualizerElement,
+} from './table-collection-visualizer.element';
 
 export const BUILTIN_VISUALIZER_DEFINITIONS: VisualizerDefinition[] = [
   {
+    id: 'space-navigator',
+    implementationKey: 'dahn.space-navigator',
+    displayName: 'Space Navigator',
+    version: '0.0.0',
+    componentTag: SPACE_NAVIGATOR_VISUALIZER_TAG,
+    supportedTargets: [{ kind: 'canvas' }],
+    load: async () => {
+      defineCustomElementOnce(
+        SPACE_NAVIGATOR_VISUALIZER_TAG,
+        SpaceNavigatorVisualizerElement,
+      );
+    },
+  },
+  {
     id: 'holon-node',
+    implementationKey: 'dahn.generic-holon-node',
     displayName: 'Holon Node',
     version: '0.0.0',
     componentTag: HOLON_NODE_VISUALIZER_TAG,
@@ -24,6 +47,20 @@ export const BUILTIN_VISUALIZER_DEFINITIONS: VisualizerDefinition[] = [
       defineCustomElementOnce(
         HOLON_NODE_VISUALIZER_TAG,
         HolonNodeVisualizerElement,
+      );
+    },
+  },
+  {
+    id: 'table-collection',
+    implementationKey: 'dahn.table-collection',
+    displayName: 'Table Collection',
+    version: '0.0.0',
+    componentTag: TABLE_COLLECTION_VISUALIZER_TAG,
+    supportedTargets: [{ kind: 'collection' }],
+    load: async () => {
+      defineCustomElementOnce(
+        TABLE_COLLECTION_VISUALIZER_TAG,
+        TableCollectionVisualizerElement,
       );
     },
   },

--- a/host/ui/src/dahn/visualizers/space-navigator-visualizer.element.ts
+++ b/host/ui/src/dahn/visualizers/space-navigator-visualizer.element.ts
@@ -1,0 +1,17 @@
+import type {
+  VisualizerContext,
+  VisualizerElement,
+} from '../contracts/visualizers';
+
+export const SPACE_NAVIGATOR_VISUALIZER_TAG =
+  'map-space-navigator-visualizer';
+
+/** Loadable Phase 0 Canvas Visualizer definition; mounting is a later slice. */
+export class SpaceNavigatorVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  setContext(_context: VisualizerContext): void {
+    this.dataset['visualizerId'] = 'space-navigator';
+  }
+}

--- a/host/ui/src/dahn/visualizers/table-collection-visualizer.element.ts
+++ b/host/ui/src/dahn/visualizers/table-collection-visualizer.element.ts
@@ -1,0 +1,17 @@
+import type {
+  VisualizerContext,
+  VisualizerElement,
+} from '../contracts/visualizers';
+
+export const TABLE_COLLECTION_VISUALIZER_TAG =
+  'map-table-collection-visualizer';
+
+/** Loadable Phase 0 Collection Visualizer definition; rendering is a later slice. */
+export class TableCollectionVisualizerElement
+  extends HTMLElement
+  implements VisualizerElement
+{
+  setContext(_context: VisualizerContext): void {
+    this.dataset['visualizerId'] = 'table-collection';
+  }
+}


### PR DESCRIPTION
# Summary

Implements Issue #673’s TypeScript Visualizer Implementation Runtime Resolution boundary.

Rust supplies the selected Visualizer Holon and one selected implementation identity. TypeScript resolves that implementation key to locally bundled executable code or returns a diagnostic resolution error; it does not traverse `ImplementedBy`, select candidates, or choose a generic fallback.

## Changes

- Added the public implementation-resolution contract:
  - selected Visualizer reference
  - selected implementation reference
  - runtime
  - implementation key
- Added `DefaultVisualizerImplementationRuntime` and `DahnImplementationResolutionError`.
- Added implementation-key indexing to `DefaultVisualizerRegistry`, separate from local executable definition IDs.
- Registered the three bootstrap TypeScript implementations:
  - `dahn.space-navigator`
  - `dahn.generic-holon-node`
  - `dahn.table-collection`
- Added loadable Space Navigator and Table Collection executable definitions without introducing Canvas mounting, composition, or rendering behavior.
- Preserved existing `action-menu` and `debug` definitions outside the MAP semantic Visualizer mapping.

## Testing

- `npm run web:test:dahn -w map-host`
  - 40 tests passed
- `npm run web:typecheck -w map-host`
- hApp and host builds completed successfully.
- `npm start` and `npm test` completed successfully.
- `git diff HEAD --check`

## Notes

- Resolution failures preserve selected Visualizer and implementation diagnostic context.
- An unavailable, missing, non-TypeScript, or failed-to-load implementation is reported explicitly; no TypeScript-side fallback occurs.
- Supporting authoritative documentation updates are prepared on the separate `map-dev-docs` branch `codex/673-schema-navigator-pr-2-runtime-resolution-docs`.